### PR TITLE
setup-node v1.x' usage of add-path is now disabled in GH

### DIFF
--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -24,7 +24,7 @@ jobs:
         lfs: true
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v1.4.1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: 12.x
 


### PR DESCRIPTION
setup-node v1.x' usage of add-path is now disabled in GH -> updating to v2-beta
