### PR TITLE
don't include AzDO pipeline

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,7 @@
 .github/
 .vscode/
 node_modules/
+azure-pipelines.yml
 dist/**/*.map
 out/
 package/


### PR DESCRIPTION
TEST only: validating triggers for both GH and AzDO work correctly for patching the release/stable branch