### PR TITLE
added snippets for paportal liquid editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "publisher": "microsoft-IsvExpTools",
   "main": "./dist/extension.js",
   "categories": [
+    "Snippets",
     "Other"
   ],
   "icon": "assets/icon.png",
@@ -57,6 +58,12 @@
       {
         "command": "pacCLI.openDocumentation",
         "title": "pac PowerApps CLI: Documentation"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "html",
+        "path": "./snippets/paportal-liquid.code-snippets"
       }
     ]
   },

--- a/snippets/paportal-liquid.code-snippets
+++ b/snippets/paportal-liquid.code-snippets
@@ -1,0 +1,91 @@
+{
+	"EntityForm ID": {
+		"prefix": "entityform-id",
+		"body": [
+			"{% entityform id:\"$1\" %}"
+		],
+		"description": "Renders an entity forms by ID"
+	},
+	"EntityForm Name": {
+		"prefix": "entityform-name",
+		"body": [
+			"{% entityform name:\"$1\" %}"
+		],
+		"description": "Renders an entity forms by name"
+	},
+	"PowerBI AAD": {
+		"prefix": "powerbi-aad",
+		"body": [
+			"{% powerbi authentication_type:\"AAD\" path:\"$1\" %}"
+		],
+		"description": "Adds the Power BI dashboards and reports with AAD Auth"
+	},
+	"PowerBI Embedded": {
+		"prefix": "powerbi-embedded",
+		"body": [
+			"{% powerbi authentication_type:\"powerbiembedded\" path:\"$1\" %}"
+		],
+		"description": "Adds the Power BI Embedded dashboards and reports within pages"
+	},
+	"Chart": {
+		"prefix": "chart",
+		"body": ["{% chart id:\"$1\" viewid:\"$2\" %}"],
+		"description": "Adds a Power Apps chart to a web page"
+	},
+	"Editable Page": {
+		"prefix": "editable-page",
+		"body": [
+			"{% editable page 'adx_copy' type: 'html', title: 'Page Copy', escape: false, liquid: true %}"
+		],
+		"description": "Renders a given Power Apps portals page as editable on the portal"
+	},
+	"Editable Snippet": {
+		"prefix": "editable-snippet",
+		"body": [
+			"{% editable snippets '$1' type: 'html' liquid: true %}"
+		],
+		"description": "Renders a given Power Apps portals snippet as editable on the portal"
+	},
+	"EntityList Name": {
+		"prefix": "entitylist-name",
+		"body": [
+			"{% include 'entity_list' key: '$1' %}"
+		],
+		"description": "Loads a given entity list by name"
+	},
+	"EntityView Name": {
+		"prefix": "entityview-name",
+		"body": [
+			"{% entityview logical_name:\"$1\", name:\"$2\" %} {% endentityview %}"
+		],
+		"description": "Loads a given Power Apps view by name"
+	},
+	"EntityView Id": {
+		"prefix": "entityview-id",
+		"body": [
+			"{% entityview id:\"$1\" %} {% endentityview %}"
+		],
+		"description": "Loads a given Power Apps view by ID"
+	},
+	"SearchIndex": {
+		"prefix": "searchindex",
+		"body": [
+			"{% searchindex query:\"$1\", page:\"$2\" %} {% endsearchindex %}"
+		],
+		"description": "Performs a query against the portal search index"
+	},
+	"WebForm Name": {
+		"prefix": "webform-name",
+		"body": [
+			"{% webform name:\"$1\" %}"
+		],
+		"description": "Fully renders a web form by name"
+	},
+	"WebForm ID": {
+		"prefix": "webform",
+		"body": [
+			"{% webform id:\"$1\" %}"
+		],
+		"description": "Fully renders a web form by ID"
+	}
+}


### PR DESCRIPTION
Added snippets for liquid code editing. 
These snippets work on .html files and enable users to write liquid code (templating language for PowerApps Portals).

![image](https://user-images.githubusercontent.com/908570/108645613-6cfa4b80-74d9-11eb-9e7b-e9ccf686d55f.png)


Example followed: https://code.visualstudio.com/api/language-extensions/snippet-guide