### PR TITLE
Consume microsoft vscode-extension-telemetry

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "client",
-	"version": "2.1.14",
+	"name": "powerplatform-vscode-client",
+	"version": "0.0.1-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -24,6 +24,41 @@
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
 			"integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
 			"dev": true
+		},
+		"applicationinsights": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+			"integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
+			"requires": {
+				"cls-hooked": "^4.2.2",
+				"continuation-local-storage": "^3.2.1",
+				"diagnostic-channel": "0.2.0",
+				"diagnostic-channel-publishers": "^0.3.3"
+			}
+		},
+		"async-hook-jl": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+			"requires": {
+				"stack-chain": "^1.3.7"
+			}
+		},
+		"async-listener": {
+			"version": "0.6.10",
+			"resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+			"integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+			"requires": {
+				"semver": "^5.3.0",
+				"shimmer": "^1.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -61,10 +96,64 @@
 				"traverse": ">=0.3.0 <0.4"
 			}
 		},
+		"cls-hooked": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+			"integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+			"requires": {
+				"async-hook-jl": "^1.7.6",
+				"emitter-listener": "^1.0.1",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"continuation-local-storage": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+			"integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+			"requires": {
+				"async-listener": "^0.6.0",
+				"emitter-listener": "^1.1.1"
+			}
+		},
+		"diagnostic-channel": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
+			"integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+			"requires": {
+				"semver": "^5.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"diagnostic-channel-publishers": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.5.tgz",
+			"integrity": "sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ=="
+		},
+		"emitter-listener": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+			"integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+			"requires": {
+				"shimmer": "^1.2.0"
+			}
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -103,6 +192,16 @@
 				"lru-cache": "^6.0.0"
 			}
 		},
+		"shimmer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+		},
+		"stack-chain": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+			"integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+		},
 		"traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -115,6 +214,14 @@
 			"requires": {
 				"binary": "^0.3.0",
 				"mkdirp": "^0.5.1"
+			}
+		},
+		"vscode-extension-telemetry": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.7.tgz",
+			"integrity": "sha512-pZuZTHO9OpsrwlerOKotWBRLRYJ53DobYb7aWiRAXjlqkuqE+YJJaP+2WEy8GrLIF1EnitXTDMaTAKsmLQ5ORQ==",
+			"requires": {
+				"applicationinsights": "1.7.4"
 			}
 		},
 		"vscode-jsonrpc": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,32 +1,33 @@
 {
-  "name": "powerplatform-vscode-client",
-  "displayName": "Power Platform VS Code Extension Client",
-  "description": "Tooling to create Power Platform packages and manage Power Platform environments",
-  "version": "0.0.1-dev",
-	"private": true,
-  "author": "PowerApps-ISV-Tools",
-  "license": "SEE LICENSE IN LICENSE",
-  "homepage": "https://github.com/microsoft/powerplatform-vscode/blob/main/README.md",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/powerplatform-vscode"
-  },
-  "bugs": {
-    "url": "https://github.com/microsoft/powerplatform-vscode/issues",
-    "email": "PPTools@microsoft.com"
-  },
-	"engines": {
-		"vscode": "^1.52.0"
-	},
-	"devDependencies": {
-		"@types/unzip-stream": "^0.3.0",
-		"@types/vscode": "1.52.0"
-	},
-	"dependencies": {
-		"vscode-languageclient": "7.0.0",
-		"unzip-stream": "^0.3.1"
-	},
-	"scripts": {
-		"test": "node ../node_modules/mocha/bin/_mocha"
-	}
+ "name": "powerplatform-vscode-client",
+ "displayName": "Power Platform VS Code Extension Client",
+ "description": "Tooling to create Power Platform packages and manage Power Platform environments",
+ "version": "0.0.1-dev",
+ "private": true,
+ "author": "PowerApps-ISV-Tools",
+ "license": "SEE LICENSE IN LICENSE",
+ "homepage": "https://github.com/microsoft/powerplatform-vscode/blob/main/README.md",
+ "repository": {
+  "type": "git",
+  "url": "https://github.com/microsoft/powerplatform-vscode"
+ },
+ "bugs": {
+  "url": "https://github.com/microsoft/powerplatform-vscode/issues",
+  "email": "PPTools@microsoft.com"
+ },
+ "engines": {
+  "vscode": "^1.52.0"
+ },
+ "devDependencies": {
+  "@types/unzip-stream": "^0.3.0",
+  "@types/vscode": "1.52.0"
+ },
+ "dependencies": {
+  "unzip-stream": "^0.3.1",
+  "vscode-extension-telemetry": "^0.1.7",
+  "vscode-languageclient": "7.0.0"
+ },
+ "scripts": {
+  "test": "node ../node_modules/mocha/bin/_mocha"
+ }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -12,8 +12,13 @@ import {
 	ServerOptions,
 	TransportKind
 } from 'vscode-languageclient/node';
+import { TelemetryManager } from './telemetry/TelemetryManager';
 
 let client: LanguageClient;
+
+const extensionId = '';
+const extensionVersion = '';    // Should be updated via gulp taks
+const instrumentationKey = '';  // Should be updated via gulp taks
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     // The server is implemented in node
@@ -23,6 +28,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	// The debug options for the server
 	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
 	let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+
+    const telemetryManager = TelemetryManager.getInstance(extensionId, extensionVersion, instrumentationKey);
+    // ensure it gets property disposed
+    context.subscriptions.push(telemetryManager.getReporter());
 
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
@@ -66,5 +75,6 @@ export function deactivate(): Thenable<void> | undefined {
 	if (!client) {
 		return undefined;
 	}
+    TelemetryManager.getInstance().getReporter().dispose()
 	return client.stop();
 }

--- a/client/src/telemetry/TelemetryEvents.ts
+++ b/client/src/telemetry/TelemetryEvents.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export enum TelemetryEventName {
+    TestEvent = 'TestEvent'
+}

--- a/client/src/telemetry/TelemetryManager.ts
+++ b/client/src/telemetry/TelemetryManager.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import TelemetryReporter from "vscode-extension-telemetry";
+import { TelemetryEventName } from "./TelemetryEvents";
+
+export class TelemetryManager {
+    private static instance: TelemetryManager;
+    private reporter : TelemetryReporter;
+
+    private constructor(id: string, version: string, instrumentationKey: string) {
+        this.reporter = new TelemetryReporter(id, version, instrumentationKey);
+    }
+
+    public static getInstance(
+        id?: string,
+        version?: string,
+        key?: string
+    ): TelemetryManager {
+        if (!TelemetryManager.instance) {
+            TelemetryManager.instance = new TelemetryManager(id, version, key);
+        }
+
+        return TelemetryManager.instance;
+    }
+
+    public getReporter(): TelemetryReporter {
+        return this.reporter;
+    }
+
+    public report(event: TelemetryEventName): void {
+        this.reporter.sendTelemetryEvent(event);
+    }
+
+    public reportErrorEvent(event: TelemetryEventName, error: Error): void {
+        this.reporter.sendTelemetryErrorEvent(event, {
+            error: error.message,
+        });
+    }
+    public reportException(error: Error): void {
+        this.reporter.sendTelemetryException(error);
+    }
+}
+


### PR DESCRIPTION
Consime vscode-extension-telemetry package to log event telemetry from the vscode plugin