### PR TITLE
Blocking Queue to permit consumption of async/event returned items

### DIFF
--- a/src/client/test/unit/BlockingQueue.test.ts
+++ b/src/client/test/unit/BlockingQueue.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { expect } from "chai";
+import { BlockingQueue } from "../../../common/utilities/BlockingQueue";
+
+describe('BlockingQueue', () => {
+
+    it('items enqueued prior to dequeue are resolved in correct order', async () => {
+        const queue = new BlockingQueue<number>();
+        queue.enqueue(1);
+        queue.enqueue(2);
+        queue.enqueue(3);
+        queue.enqueue(4);
+        queue.enqueue(5);
+        expect(await queue.dequeue()).to.be.equal(1);
+        expect(await queue.dequeue()).to.be.equal(2);
+        expect(await queue.dequeue()).to.be.equal(3);
+        expect(await queue.dequeue()).to.be.equal(4);
+        expect(await queue.dequeue()).to.be.equal(5);
+    });
+
+    it('items dequeued prior to enqueue resolve when items are added', async () => {
+        const queue = new BlockingQueue<number>();
+        const prom1 = queue.dequeue();
+        const prom2 = queue.dequeue();
+        const prom3 = queue.dequeue();
+        const prom4 = queue.dequeue();
+        const prom5 = queue.dequeue();
+        queue.enqueue(1);
+        queue.enqueue(2);
+        queue.enqueue(3);
+        queue.enqueue(4);
+        queue.enqueue(5);
+        expect(await prom1).to.be.equal(1);
+        expect(await prom2).to.be.equal(2);
+        expect(await prom3).to.be.equal(3);
+        expect(await prom4).to.be.equal(4);
+        expect(await prom5).to.be.equal(5);
+    });
+
+    it('items enqueued by "another thread" dequeued in correct order', async () => {
+        const sleep = (ms : number) => new Promise(resolve => setTimeout(resolve, ms));
+        const queue = new BlockingQueue<number>();
+
+        setTimeout(async () => {
+            queue.enqueue(1);
+            await sleep(1);
+            queue.enqueue(2);
+            await sleep(1);
+            queue.enqueue(3);
+        }, 5);
+
+        expect(await queue.dequeue()).to.be.equal(1);
+        expect(await queue.dequeue()).to.be.equal(2);
+        expect(await queue.dequeue()).to.be.equal(3);
+    });
+});

--- a/src/common/utilities/BlockingQueue.ts
+++ b/src/common/utilities/BlockingQueue.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Queue that returns Promises on dequeue, either already resolved if the item
+// has already been enqueued, or still waiting if the item has not yet arrived.
+export class BlockingQueue<T> {
+    private readonly promiseQueue: Promise<T>[] = [];
+    private readonly resolverQueue: ((t: T) => void)[] = [];
+
+    private addPromiseResolverPair() {
+        this.promiseQueue.push(
+            new Promise(resolve => {this.resolverQueue.push(resolve); })
+        );
+    }
+
+    enqueue(t: T) : void {
+        // ensure that either a resolver is already queued, or generate a new pair
+        if (!this.resolverQueue.length) {
+            this.addPromiseResolverPair();
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const resolve = this.resolverQueue.shift()!;
+        resolve(t);
+    }
+
+    dequeue() : Promise<T> {
+        // ensure that either a promise is already queued, or generate a new pair
+        if (!this.promiseQueue.length) {
+            this.addPromiseResolverPair();
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const promise = this.promiseQueue.shift()!;
+        return promise;
+    }
+}


### PR DESCRIPTION
Event generated items, such as output "returned" by a child process on its stdout stream can only be processed once we are off the thread, so we'll need to throw them into this blocking queue to wait for and resume after receiving the event.