### PR TITLE
Adding Help commands to Command Pallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,23 @@
         "title": "pac PowerApps CLI: Documentation"
       },
       {
+        "command": "pacCLI.pacAuthHelp",
+        "title": "pac PowerApps CLI: Show Authentication Help"
+      },
+
+      {
+        "command": "pacCLI.pacPackageHelp",
+        "title": "pac PowerApps CLI: Show Package Help"
+      },
+      {
+        "command": "pacCLI.pacPcfHelp",
+        "title": "pac PowerApps CLI: Show PCF Help"
+      },
+      {
+        "command": "pacCLI.pacSolutionHelp",
+        "title": "pac PowerApps CLI: Show Solution Help"
+      },
+      {
         "command": "microsoft-powerapps-portals.preview-show",
         "title": "PowerApps Portal -> Show preview",
         "icon": {

--- a/package.json
+++ b/package.json
@@ -64,10 +64,13 @@
         "title": "pac PowerApps CLI: Documentation"
       },
       {
+        "command": "pacCLI.pacHelp",
+        "title": "pac PowerApps CLI: Show General Command Line Help"
+      },
+      {
         "command": "pacCLI.pacAuthHelp",
         "title": "pac PowerApps CLI: Show Authentication Help"
       },
-
       {
         "command": "pacCLI.pacPackageHelp",
         "title": "pac PowerApps CLI: Show Package Help"

--- a/src/client/lib/PacTerminal.ts
+++ b/src/client/lib/PacTerminal.ts
@@ -20,9 +20,25 @@ export class PacTerminal implements vscode.Disposable {
         this._context.environmentVariableCollection.prepend('PATH', cliPath + path.delimiter);
 
         this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.openDocumentation', this.openDocumentation));
+        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacAuthHelp',
+            () => PacTerminal.getTerminal().sendText("pac auth help")));
+        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacPackageHelp',
+            () => PacTerminal.getTerminal().sendText("pac package help")));
+        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacPcfHelp',
+            () => PacTerminal.getTerminal().sendText("pac pcf help")));
+        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacSolutionHelp',
+            () => PacTerminal.getTerminal().sendText("pac solution help")));
     }
 
     public openDocumentation(): void {
         vscode.env.openExternal(vscode.Uri.parse('https://aka.ms/pacvscodedocs'));
+    }
+
+    private static getTerminal(): vscode.Terminal {
+        const terminal = vscode.window.activeTerminal ?
+            vscode.window.activeTerminal as vscode.Terminal :
+            vscode.window.createTerminal();
+        terminal.show();
+        return terminal;
     }
 }

--- a/src/client/lib/PacTerminal.ts
+++ b/src/client/lib/PacTerminal.ts
@@ -20,6 +20,8 @@ export class PacTerminal implements vscode.Disposable {
         this._context.environmentVariableCollection.prepend('PATH', cliPath + path.delimiter);
 
         this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.openDocumentation', this.openDocumentation));
+        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacHelp',
+            () => PacTerminal.getTerminal().sendText("pac help")));
         this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacAuthHelp',
             () => PacTerminal.getTerminal().sendText("pac auth help")));
         this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacPackageHelp',


### PR DESCRIPTION
[Task 2362548: PAC Help via Command Pallet](https://dev.azure.com/dynamicscrm/ALM/_workitems/edit/2362548)

This adds various PAC Help commands to the command pallet, which will run those commands in the current active terminal or create a new one if no terminal exists.