### PR TITLE
Disable Remote/Codespaces installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "engines": {
     "vscode": "^1.51.0"
   },
+  "extensionKind": [
+    "ui"
+  ],
   "publisher": "microsoft-IsvExpTools",
   "main": "./dist/extension",
   "categories": [
@@ -114,14 +117,14 @@
       }
     ],
     "configuration": {
-      "tile" : "PowerPlatform",
+      "tile": "PowerPlatform",
       "properties": {
-        "powerplatform.experimental.authProfilePanel" : {
+        "powerplatform.experimental.authProfilePanel": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "EXPERIMENTAL: Enable the PowerPlatform Auth Profile activity bar panel"
         },
-        "powerplatform.experimental.pacLab" : {
+        "powerplatform.experimental.pacLab": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "EXPERIMENTAL: Enable the PAC Lab link command"

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -31,6 +31,17 @@ export async function activate(
 ): Promise<void> {
     _context = context;
 
+    // Extension only supports Desktop UI installs currently
+    const extension = vscode.extensions.getExtension('microsoft-IsvExpTools.powerplatform-vscode');
+    if (extension && extension.extensionKind !== vscode.ExtensionKind.UI) {
+        vscode.window.showErrorMessage("The PowerPlatform Extension does not currently support remote installations.");
+        return;
+    }
+    if (vscode.env.uiKind !== vscode.UIKind.Desktop) {
+        vscode.window.showErrorMessage("The PowerPlatform Extension does not currently support Web UI.");
+        return;
+    }    
+    
     // setup telemetry
     const sessionId = v4();
     _telemetry = createTelemetryReporter('powerplatform-vscode', context, AI_KEY, sessionId);


### PR DESCRIPTION
Disable the extension from running remotely / in Codespaces, as work to support such has not yet been done.

[AB#2373053](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2373053) Power Platform VS Code extension gets installed in codespaces even when it is not supported