### PR TITLE
Initial Auth, Solution, and Admin Environments panels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,4 +17,7 @@ module.exports = {
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
     ],
+    rules: {
+        '@typescript-eslint/no-unused-vars': [ 'error', { "argsIgnorePattern": "^_$" } ],
+    }
 };

--- a/package.json
+++ b/package.json
@@ -108,6 +108,36 @@
         "title": "Enable PAC telemetry"
       },
       {
+        "command": "pacCLI.dataverseAuthPanel.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "pacCLI.dataverseAuthPanel.newAuthProfile",
+        "title": "New Auth Profile",
+        "icon": "$(add)"
+      },
+      {
+        "command": "pacCLI.solutionPanel.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "pacCLI.adminAuthPanel.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "pacCLI.adminEnvironmentPanel.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "pacCLI.adminAuthPanel.newAuthProfile",
+        "title": "New Auth Profile",
+        "icon": "$(add)"
+      },
+      {
         "command": "microsoft-powerapps-portals.preview-show",
         "title": "PowerApps Portal -> Show preview",
         "icon": {
@@ -123,6 +153,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "EXPERIMENTAL: Enable the PowerPlatform Auth Profile activity bar panel"
+        },
+        "powerplatform.experimental.solutionPanel": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "EXPERIMENTAL: Enable the PowerPlatform Solution panel"
         },
         "powerplatform.experimental.pacLab": {
           "type": "boolean",
@@ -161,6 +196,71 @@
         {
           "command": "pacCLI.openPacLab",
           "when": "config.powerplatform.experimental.pacLab"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "pacCLI.dataverseAuthPanel.refresh",
+          "when": "view == pacCLI.dataverseAuthPanel",
+          "group": "navigation"
+        },
+        {
+          "command": "pacCLI.dataverseAuthPanel.newAuthProfile",
+          "when": "view == pacCLI.dataverseAuthPanel",
+          "group": "navigation"
+        },
+        {
+          "command": "pacCLI.solutionPanel.refresh",
+          "when": "view == pacCLI.solutionPanel",
+          "group": "navigation"
+        },
+        {
+          "command": "pacCLI.adminAuthPanel.refresh",
+          "when": "view == pacCLI.adminAuthPanel",
+          "group": "navigation"
+        },
+        {
+          "command": "pacCLI.adminAuthPanel.newAuthProfile",
+          "when": "view == pacCLI.adminAuthPanel",
+          "group": "navigation"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.refresh",
+          "when": "view == pacCLI.adminEnvironmentPanel",
+          "group": "navigation"
+        }
+      ]
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "power-platform-activitybar",
+          "title": "Power Platform",
+          "icon": "resources/powerplatform-activitybar-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "power-platform-activitybar": [
+        {
+          "id": "pacCLI.dataverseAuthPanel",
+          "name": "Dataverse Auth Profiles",
+          "when": "config.powerplatform.experimental.authProfilePanel"
+        },
+        {
+          "id": "pacCLI.solutionPanel",
+          "name": "Solutions",
+          "when": "config.powerplatform.experimental.authProfilePanel"
+        },
+        {
+          "id": "pacCLI.adminAuthPanel",
+          "name": "Admin Auth Profiles",
+          "when": "config.powerplatform.experimental.authProfilePanel"
+        },
+        {
+          "id": "pacCLI.adminEnvironmentPanel",
+          "name": "Admin Environments",
+          "when": "config.powerplatform.experimental.authProfilePanel"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
           "when": "view == pacCLI.adminAuthPanel"
         },
         {
-          "command": "pacCLI.dataverseAuthPanel.deleteAuthProfile",
+          "command": "pacCLI.adminAuthPanel.deleteAuthProfile",
           "when": "view == pacCLI.adminAuthPanel"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -154,15 +154,10 @@
     "configuration": {
       "tile": "PowerPlatform",
       "properties": {
-        "powerplatform.experimental.authProfilePanel": {
+        "powerplatform.experimental.activityBarPanels": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "EXPERIMENTAL: Enable the PowerPlatform Auth Profile activity bar panel"
-        },
-        "powerplatform.experimental.solutionPanel": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "EXPERIMENTAL: Enable the PowerPlatform Solution panel"
         },
         "powerplatform.experimental.pacLab": {
           "type": "boolean",
@@ -272,17 +267,17 @@
         {
           "id": "pacCLI.authPanel",
           "name": "Dataverse Auth Profiles",
-          "when": "config.powerplatform.experimental.authProfilePanel"
+          "when": "config.powerplatform.experimental.activityBarPanels"
         },
         {
           "id": "pacCLI.solutionPanel",
           "name": "Solutions",
-          "when": "config.powerplatform.experimental.authProfilePanel"
+          "when": "config.powerplatform.experimental.activityBarPanels"
         },
         {
           "id": "pacCLI.adminEnvironmentPanel",
           "name": "Admin Environments",
-          "when": "config.powerplatform.experimental.authProfilePanel"
+          "when": "config.powerplatform.experimental.activityBarPanels"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
       },
       {
         "command": "pacCLI.authPanel.selectAuthProfile",
-        "title": "Select Auth Profile"
+        "title": "Select Auth Profile",
+        "icon": "$(star-empty)"
       },
       {
         "command": "pacCLI.authPanel.deleteAuthProfile",
@@ -247,6 +248,11 @@
       "view/item/context": [
         {
           "command": "pacCLI.authPanel.deleteAuthProfile",
+          "when": "view == pacCLI.authPanel",
+          "group": "inline"
+        },
+        {
+          "command": "pacCLI.authPanel.selectAuthProfile",
           "when": "view == pacCLI.authPanel",
           "group": "inline"
         }

--- a/package.json
+++ b/package.json
@@ -108,21 +108,26 @@
         "title": "Enable PAC telemetry"
       },
       {
-        "command": "pacCLI.dataverseAuthPanel.refresh",
+        "command": "pacCLI.authPanel.refresh",
         "title": "Refresh",
         "icon": "$(refresh)"
       },
       {
-        "command": "pacCLI.dataverseAuthPanel.newAuthProfile",
-        "title": "New Auth Profile",
+        "command": "pacCLI.authPanel.newDataverseAuthProfile",
+        "title": "New Dataverse Auth Profile",
         "icon": "$(add)"
       },
       {
-        "command": "pacCLI.dataverseAuthPanel.selectAuthProfile",
+        "command": "pacCLI.authPanel.newAdminAuthProfile",
+        "title": "New Admin Auth Profile",
+        "icon": "$(add)"
+      },
+      {
+        "command": "pacCLI.authPanel.selectAuthProfile",
         "title": "Select Auth Profile"
       },
       {
-        "command": "pacCLI.dataverseAuthPanel.deleteAuthProfile",
+        "command": "pacCLI.authPanel.deleteAuthProfile",
         "title": "Delete Auth Profile",
         "icon": "$(trash)"
       },
@@ -132,28 +137,9 @@
         "icon": "$(refresh)"
       },
       {
-        "command": "pacCLI.adminAuthPanel.refresh",
-        "title": "Refresh",
-        "icon": "$(refresh)"
-      },
-      {
         "command": "pacCLI.adminEnvironmentPanel.refresh",
         "title": "Refresh",
         "icon": "$(refresh)"
-      },
-      {
-        "command": "pacCLI.adminAuthPanel.newAuthProfile",
-        "title": "New Auth Profile",
-        "icon": "$(add)"
-      },
-      {
-        "command": "pacCLI.adminAuthPanel.selectAuthProfile",
-        "title": "Select Auth Profile"
-      },
-      {
-        "command": "pacCLI.adminAuthPanel.deleteAuthProfile",
-        "title": "Delete Auth Profile",
-        "icon": "$(trash)"
       },
       {
         "command": "microsoft-powerapps-portals.preview-show",
@@ -216,7 +202,7 @@
           "when": "config.powerplatform.experimental.pacLab"
         },
         {
-          "command": "pacCLI.dataverseAuthPanel.refresh",
+          "command": "pacCLI.authPanel.refresh",
           "when": "never"
         },
         {
@@ -224,78 +210,45 @@
           "when": "never"
         },
         {
-          "command": "pacCLI.adminAuthPanel.refresh",
-          "when": "never"
-        },
-        {
           "command": "pacCLI.adminEnvironmentPanel.refresh",
           "when": "never"
         },
         {
-          "command": "pacCLI.dataverseAuthPanel.selectAuthProfile",
+          "command": "pacCLI.authPanel.selectAuthProfile",
           "when": "never"
         },
         {
-          "command": "pacCLI.adminAuthPanel.selectAuthProfile",
-          "when": "never"
-        },
-        {
-          "command": "pacCLI.dataverseAuthPanel.deleteAuthProfile",
-          "when": "never"
-        },
-        {
-          "command": "pacCLI.adminAuthPanel.deleteAuthProfile",
+          "command": "pacCLI.authPanel.deleteAuthProfile",
           "when": "never"
         }
       ],
       "view/title": [
         {
-          "command": "pacCLI.dataverseAuthPanel.refresh",
-          "when": "view == pacCLI.dataverseAuthPanel",
+          "command": "pacCLI.authPanel.refresh",
+          "when": "view == pacCLI.authPanel",
           "group": "navigation"
         },
         {
-          "command": "pacCLI.dataverseAuthPanel.newAuthProfile",
-          "when": "view == pacCLI.dataverseAuthPanel",
+          "command": "pacCLI.authPanel.newDataverseAuthProfile",
+          "when": "view == pacCLI.authPanel",
+          "group": "navigation"
+        },
+        {
+          "command": "pacCLI.authPanel.newAdminAuthProfile",
+          "when": "view == pacCLI.authPanel",
           "group": "navigation"
         },
         {
           "command": "pacCLI.solutionPanel.refresh",
           "when": "view == pacCLI.solutionPanel",
           "group": "navigation"
-        },
-        {
-          "command": "pacCLI.adminAuthPanel.refresh",
-          "when": "view == pacCLI.adminAuthPanel",
-          "group": "navigation"
-        },
-        {
-          "command": "pacCLI.adminAuthPanel.newAuthProfile",
-          "when": "view == pacCLI.adminAuthPanel",
-          "group": "navigation"
-        },
-        {
-          "command": "pacCLI.adminEnvironmentPanel.refresh",
-          "when": "view == pacCLI.adminEnvironmentPanel",
-          "group": "navigation"
         }
       ],
       "view/item/context": [
         {
-          "command": "pacCLI.dataverseAuthPanel.selectAuthProfile",
-          "when": "view == pacCLI.dataverseAuthPanel"
-        },
-        {
-          "command": "pacCLI.dataverseAuthPanel.deleteAuthProfile",
-          "when": "view == pacCLI.dataverseAuthPanel"
-        },
-        {
-          "command": "pacCLI.adminAuthPanel.selectAuthProfile",
-          "when": "view == pacCLI.adminAuthPanel"
-        },
-        {
-          "command": "pacCLI.adminAuthPanel.deleteAuthProfile",
-          "when": "view == pacCLI.adminAuthPanel"
+          "command": "pacCLI.authPanel.deleteAuthProfile",
+          "when": "view == pacCLI.authPanel",
+          "group": "inline"
         }
       ]
     },
@@ -311,18 +264,13 @@
     "views": {
       "power-platform-activitybar": [
         {
-          "id": "pacCLI.dataverseAuthPanel",
+          "id": "pacCLI.authPanel",
           "name": "Dataverse Auth Profiles",
           "when": "config.powerplatform.experimental.authProfilePanel"
         },
         {
           "id": "pacCLI.solutionPanel",
           "name": "Solutions",
-          "when": "config.powerplatform.experimental.authProfilePanel"
-        },
-        {
-          "id": "pacCLI.adminAuthPanel",
-          "name": "Admin Auth Profiles",
           "when": "config.powerplatform.experimental.authProfilePanel"
         },
         {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,15 @@
         "icon": "$(add)"
       },
       {
+        "command": "pacCLI.dataverseAuthPanel.selectAuthProfile",
+        "title": "Select Auth Profile"
+      },
+      {
+        "command": "pacCLI.dataverseAuthPanel.deleteAuthProfile",
+        "title": "Delete Auth Profile",
+        "icon": "$(trash)"
+      },
+      {
         "command": "pacCLI.solutionPanel.refresh",
         "title": "Refresh",
         "icon": "$(refresh)"
@@ -136,6 +145,15 @@
         "command": "pacCLI.adminAuthPanel.newAuthProfile",
         "title": "New Auth Profile",
         "icon": "$(add)"
+      },
+      {
+        "command": "pacCLI.adminAuthPanel.selectAuthProfile",
+        "title": "Select Auth Profile"
+      },
+      {
+        "command": "pacCLI.adminAuthPanel.deleteAuthProfile",
+        "title": "Delete Auth Profile",
+        "icon": "$(trash)"
       },
       {
         "command": "microsoft-powerapps-portals.preview-show",
@@ -196,6 +214,38 @@
         {
           "command": "pacCLI.openPacLab",
           "when": "config.powerplatform.experimental.pacLab"
+        },
+        {
+          "command": "pacCLI.dataverseAuthPanel.refresh",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.solutionPanel.refresh",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.adminAuthPanel.refresh",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.refresh",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.dataverseAuthPanel.selectAuthProfile",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.adminAuthPanel.selectAuthProfile",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.dataverseAuthPanel.deleteAuthProfile",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.adminAuthPanel.deleteAuthProfile",
+          "when": "never"
         }
       ],
       "view/title": [
@@ -228,6 +278,24 @@
           "command": "pacCLI.adminEnvironmentPanel.refresh",
           "when": "view == pacCLI.adminEnvironmentPanel",
           "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "pacCLI.dataverseAuthPanel.selectAuthProfile",
+          "when": "view == pacCLI.dataverseAuthPanel"
+        },
+        {
+          "command": "pacCLI.dataverseAuthPanel.deleteAuthProfile",
+          "when": "view == pacCLI.dataverseAuthPanel"
+        },
+        {
+          "command": "pacCLI.adminAuthPanel.selectAuthProfile",
+          "when": "view == pacCLI.adminAuthPanel"
+        },
+        {
+          "command": "pacCLI.dataverseAuthPanel.deleteAuthProfile",
+          "when": "view == pacCLI.adminAuthPanel"
         }
       ]
     },

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -27,7 +27,11 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
         item => item.Kind === "ADMIN");
     registrations.push(
         vscode.window.registerTreeDataProvider("pacCLI.adminAuthPanel",adminAuthPanel),
-        vscode.commands.registerCommand("pacCLI.adminAuthPanel.refresh", () => adminAuthPanel.refresh()));
+        vscode.commands.registerCommand("pacCLI.adminAuthPanel.refresh", () => adminAuthPanel.refresh(),
+        vscode.commands.registerCommand("pacCLI.adminAuthPanel.newAuthProfile", async () => {
+            await pacWrapper.authCreateNewAdminProfile();
+            adminAuthPanel.refresh();
+        })));
 
     const adminEnvironmentPanel = new PacFlatDataView(
         () => pacWrapper.adminEnvironmentList(),

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -14,7 +14,18 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
         item => item.Kind === "CDS" || item.Kind === "DATAVERSE");
     registrations.push(
         vscode.window.registerTreeDataProvider("pacCLI.dataverseAuthPanel", dataverseAuthPanel),
-        vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.refresh", () => dataverseAuthPanel.refresh()));
+        vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.refresh", () => dataverseAuthPanel.refresh(),
+        vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.newAuthProfile", async () => {
+            const environmentUrl = await vscode.window.showInputBox({
+                title: "Create new Dataverse Auth Profile",
+                prompt: "Enter Environment URL",
+                placeHolder: "https://example.crm.dynamics.com/"
+            });
+            if (environmentUrl) {
+                await pacWrapper.authCreateNewDataverseProfile(environmentUrl);
+                dataverseAuthPanel.refresh();
+            }
+        })));
 
     const solutionPanel = new PacFlatDataView(() => pacWrapper.solutionList(), item => new SolutionTreeItem(item));
     registrations.push(

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -8,6 +8,11 @@ import { PacWrapper } from '../pac/PacWrapper';
 export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
     const registrations: vscode.Disposable[] = [];
 
+    const solutionPanel = new PacFlatDataView(() => pacWrapper.solutionList(), item => new SolutionTreeItem(item));
+    registrations.push(
+        vscode.window.registerTreeDataProvider("pacCLI.solutionPanel", solutionPanel),
+        vscode.commands.registerCommand("pacCLI.solutionPanel.refresh", () => solutionPanel.refresh()));
+
     const dataverseAuthPanel = new PacFlatDataView(
         () => pacWrapper.authList(),
         item => new AuthProfileTreeItem(item),
@@ -24,22 +29,26 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
             if (environmentUrl) {
                 await pacWrapper.authCreateNewDataverseProfile(environmentUrl);
                 dataverseAuthPanel.refresh();
+                solutionPanel.refresh()
             }
         }),
         vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.selectAuthProfile", async (item: AuthProfileTreeItem) => {
             await pacWrapper.authSelectByIndex(item.model.Index);
             dataverseAuthPanel.refresh();
+            solutionPanel.refresh()
         }),
         vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.deleteAuthProfile", async (item: AuthProfileTreeItem) => {
             await pacWrapper.authDeleteByIndex(item.model.Index);
             dataverseAuthPanel.refresh();
+            solutionPanel.refresh()
         }));
 
-    const solutionPanel = new PacFlatDataView(() => pacWrapper.solutionList(), item => new SolutionTreeItem(item));
-    registrations.push(
-        vscode.window.registerTreeDataProvider("pacCLI.solutionPanel", solutionPanel),
-        vscode.commands.registerCommand("pacCLI.solutionPanel.refresh", () => solutionPanel.refresh()));
-
+        const adminEnvironmentPanel = new PacFlatDataView(
+            () => pacWrapper.adminEnvironmentList(),
+            item => new AdminEnvironmentTreeItem(item));
+        registrations.push(
+            vscode.window.registerTreeDataProvider("pacCLI.adminEnvironmentPanel", adminEnvironmentPanel),
+            vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.refresh", () => adminEnvironmentPanel.refresh()));
     const adminAuthPanel = new PacFlatDataView(
         () => pacWrapper.authList(),
         item => new AuthProfileTreeItem(item),
@@ -50,22 +59,18 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
         vscode.commands.registerCommand("pacCLI.adminAuthPanel.newAuthProfile", async () => {
             await pacWrapper.authCreateNewAdminProfile();
             adminAuthPanel.refresh();
+            adminEnvironmentPanel.refresh();
         }),
         vscode.commands.registerCommand("pacCLI.adminAuthPanel.selectAuthProfile", async (item: AuthProfileTreeItem) => {
             await pacWrapper.authSelectByIndex(item.model.Index);
             adminAuthPanel.refresh();
+            adminEnvironmentPanel.refresh();
         }),
         vscode.commands.registerCommand("pacCLI.adminAuthPanel.deleteAuthProfile", async (item: AuthProfileTreeItem) => {
             await pacWrapper.authDeleteByIndex(item.model.Index);
             adminAuthPanel.refresh();
+            adminEnvironmentPanel.refresh();
         }));
-
-    const adminEnvironmentPanel = new PacFlatDataView(
-        () => pacWrapper.adminEnvironmentList(),
-        item => new AdminEnvironmentTreeItem(item));
-    registrations.push(
-        vscode.window.registerTreeDataProvider("pacCLI.adminEnvironmentPanel", adminEnvironmentPanel),
-        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.refresh", () => adminEnvironmentPanel.refresh()));
 
     return registrations;
 }

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+import { AdminEnvironmentListing, AuthProfileListing, SolutionListing, PacOutputWithResultList } from '../pac/PacTypes';
+import { PacWrapper } from '../pac/PacWrapper';
+
+export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
+    const registrations: vscode.Disposable[] = [];
+
+    const dataverseAuthPanel = new PacFlatDataView(
+        () => pacWrapper.authList(),
+        item => new AuthProfileTreeItem(item),
+        item => item.Kind === "CDS" || item.Kind === "DATAVERSE");
+    registrations.push(
+        vscode.window.registerTreeDataProvider("pacCLI.dataverseAuthPanel", dataverseAuthPanel),
+        vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.refresh", () => dataverseAuthPanel.refresh()));
+
+    const solutionPanel = new PacFlatDataView(() => pacWrapper.solutionList(), item => new SolutionTreeItem(item));
+    registrations.push(
+        vscode.window.registerTreeDataProvider("pacCLI.solutionPanel", solutionPanel),
+        vscode.commands.registerCommand("pacCLI.solutionPanel.refresh", () => solutionPanel.refresh()));
+
+    const adminAuthPanel = new PacFlatDataView(
+        () => pacWrapper.authList(),
+        item => new AuthProfileTreeItem(item),
+        item => item.Kind === "ADMIN");
+    registrations.push(
+        vscode.window.registerTreeDataProvider("pacCLI.adminAuthPanel",adminAuthPanel),
+        vscode.commands.registerCommand("pacCLI.adminAuthPanel.refresh", () => adminAuthPanel.refresh()));
+
+    const adminEnvironmentPanel = new PacFlatDataView(
+        () => pacWrapper.adminEnvironmentList(),
+        item => new AdminEnvironmentTreeItem(item));
+    registrations.push(
+        vscode.window.registerTreeDataProvider("pacCLI.adminEnvironmentPanel", adminEnvironmentPanel),
+        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.refresh", () => adminEnvironmentPanel.refresh()));
+
+    return registrations;
+}
+
+class PacFlatDataView<PacResultType, TreeType extends vscode.TreeItem> implements vscode.TreeDataProvider<TreeType> {
+    private _onDidChangeTreeData: vscode.EventEmitter<TreeType | undefined | void> = new vscode.EventEmitter<TreeType | undefined | void>();
+    readonly onDidChangeTreeData: vscode.Event<TreeType | undefined | void> = this._onDidChangeTreeData.event;
+
+    constructor(
+        public readonly dataSource: () => Promise<PacOutputWithResultList<PacResultType>>,
+        private readonly mapToTreeItem: (item: PacResultType) => TreeType,
+        private readonly itemFilter?: (item:PacResultType) => boolean) {
+    }
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    public getTreeItem(element: TreeType): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+
+    public async getChildren(element?: TreeType): Promise<TreeType[]> {
+        if (element) {
+            // If we are not at the root, then there are no child items
+            return [];
+        } else {
+            const pacOutput = await this.dataSource();
+            if (pacOutput && pacOutput.Status === "Success") {
+                const items = pacOutput.Results
+                    .filter(this.itemFilter || (_ => true))
+                    .map(this.mapToTreeItem);
+                return items;
+            } else {
+                return [];
+            }
+        }
+    }
+}
+
+class AuthProfileTreeItem extends vscode.TreeItem {
+    public constructor(private readonly model: AuthProfileListing) {
+        super(`${model.Resource} - ${model.User}`, vscode.TreeItemCollapsibleState.None);
+        if (model.IsActive){
+            this.iconPath = new vscode.ThemeIcon("star-full")
+        }
+    }
+}
+class SolutionTreeItem extends vscode.TreeItem {
+    public constructor(private readonly model: SolutionListing) {
+        super(`${model.FriendlyName}-${model.VersionNumber}`);
+    }
+}
+
+class AdminEnvironmentTreeItem extends vscode.TreeItem {
+    public constructor(private readonly model: AdminEnvironmentListing) {
+        super(`${model.DisplayName} ${model.EnvironmentUrl}`);
+    }
+}

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -67,7 +67,7 @@ class PacFlatDataView<PacResultType, TreeType extends vscode.TreeItem> implement
             return [];
         } else {
             const pacOutput = await this.dataSource();
-            if (pacOutput && pacOutput.Status === "Success") {
+            if (pacOutput && pacOutput.Status === "Success" && pacOutput.Results) {
                 const items = pacOutput.Results
                     .filter(this.itemFilter || (_ => true))
                     .map(this.mapToTreeItem);

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -106,11 +106,18 @@ class PacFlatDataView<PacResultType, TreeType extends vscode.TreeItem> implement
 
 class AuthProfileTreeItem extends vscode.TreeItem {
     public constructor(public readonly model: AuthProfileListing) {
-        super(`${model.Kind} ${model.User} - ${model.Resource}`, vscode.TreeItemCollapsibleState.None);
+        super(AuthProfileTreeItem.createLabel(model), vscode.TreeItemCollapsibleState.None);
         if (model.IsActive){
             this.iconPath = new vscode.ThemeIcon("star-full")
+        }
+    }
+    private static createLabel(profile: AuthProfileListing): string {
+        if (profile.Name) {
+            return `${profile.Kind}: ${profile.Name}`;
+        } else if (profile.Kind === "ADMIN") {
+            return `${profile.Kind}: ${profile.User}`;
         } else {
-            this.command = {title: "Select", command: "pacCLI.authPanel.selectAuthProfile", arguments:[this]};
+            return `${profile.Kind}: ${profile.User} - ${profile.Resource}`;
         }
     }
 }

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -14,7 +14,7 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
         item => item.Kind === "CDS" || item.Kind === "DATAVERSE");
     registrations.push(
         vscode.window.registerTreeDataProvider("pacCLI.dataverseAuthPanel", dataverseAuthPanel),
-        vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.refresh", () => dataverseAuthPanel.refresh(),
+        vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.refresh", () => dataverseAuthPanel.refresh()),
         vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.newAuthProfile", async () => {
             const environmentUrl = await vscode.window.showInputBox({
                 title: "Create new Dataverse Auth Profile",
@@ -25,7 +25,15 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
                 await pacWrapper.authCreateNewDataverseProfile(environmentUrl);
                 dataverseAuthPanel.refresh();
             }
-        })));
+        }),
+        vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.selectAuthProfile", async (item: AuthProfileTreeItem) => {
+            await pacWrapper.authSelectByIndex(item.model.Index);
+            dataverseAuthPanel.refresh();
+        }),
+        vscode.commands.registerCommand("pacCLI.dataverseAuthPanel.deleteAuthProfile", async (item: AuthProfileTreeItem) => {
+            await pacWrapper.authDeleteByIndex(item.model.Index);
+            dataverseAuthPanel.refresh();
+        }));
 
     const solutionPanel = new PacFlatDataView(() => pacWrapper.solutionList(), item => new SolutionTreeItem(item));
     registrations.push(
@@ -37,12 +45,20 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
         item => new AuthProfileTreeItem(item),
         item => item.Kind === "ADMIN");
     registrations.push(
-        vscode.window.registerTreeDataProvider("pacCLI.adminAuthPanel",adminAuthPanel),
-        vscode.commands.registerCommand("pacCLI.adminAuthPanel.refresh", () => adminAuthPanel.refresh(),
+        vscode.window.registerTreeDataProvider("pacCLI.adminAuthPanel", adminAuthPanel),
+        vscode.commands.registerCommand("pacCLI.adminAuthPanel.refresh", () => adminAuthPanel.refresh()),
         vscode.commands.registerCommand("pacCLI.adminAuthPanel.newAuthProfile", async () => {
             await pacWrapper.authCreateNewAdminProfile();
             adminAuthPanel.refresh();
-        })));
+        }),
+        vscode.commands.registerCommand("pacCLI.adminAuthPanel.selectAuthProfile", async (item: AuthProfileTreeItem) => {
+            await pacWrapper.authSelectByIndex(item.model.Index);
+            adminAuthPanel.refresh();
+        }),
+        vscode.commands.registerCommand("pacCLI.adminAuthPanel.deleteAuthProfile", async (item: AuthProfileTreeItem) => {
+            await pacWrapper.authDeleteByIndex(item.model.Index);
+            adminAuthPanel.refresh();
+        }));
 
     const adminEnvironmentPanel = new PacFlatDataView(
         () => pacWrapper.adminEnvironmentList(),
@@ -91,7 +107,7 @@ class PacFlatDataView<PacResultType, TreeType extends vscode.TreeItem> implement
 }
 
 class AuthProfileTreeItem extends vscode.TreeItem {
-    public constructor(private readonly model: AuthProfileListing) {
+    public constructor(public readonly model: AuthProfileListing) {
         super(`${model.Resource} - ${model.User}`, vscode.TreeItemCollapsibleState.None);
         if (model.IsActive){
             this.iconPath = new vscode.ThemeIcon("star-full")
@@ -99,13 +115,13 @@ class AuthProfileTreeItem extends vscode.TreeItem {
     }
 }
 class SolutionTreeItem extends vscode.TreeItem {
-    public constructor(private readonly model: SolutionListing) {
+    public constructor(public readonly model: SolutionListing) {
         super(`${model.FriendlyName}-${model.VersionNumber}`);
     }
 }
 
 class AdminEnvironmentTreeItem extends vscode.TreeItem {
-    public constructor(private readonly model: AdminEnvironmentListing) {
+    public constructor(public readonly model: AdminEnvironmentListing) {
         super(`${model.DisplayName} ${model.EnvironmentUrl}`);
     }
 }

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -43,12 +43,13 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
             solutionPanel.refresh()
         }));
 
-        const adminEnvironmentPanel = new PacFlatDataView(
-            () => pacWrapper.adminEnvironmentList(),
-            item => new AdminEnvironmentTreeItem(item));
-        registrations.push(
-            vscode.window.registerTreeDataProvider("pacCLI.adminEnvironmentPanel", adminEnvironmentPanel),
-            vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.refresh", () => adminEnvironmentPanel.refresh()));
+    const adminEnvironmentPanel = new PacFlatDataView(
+        () => pacWrapper.adminEnvironmentList(),
+        item => new AdminEnvironmentTreeItem(item));
+    registrations.push(
+        vscode.window.registerTreeDataProvider("pacCLI.adminEnvironmentPanel", adminEnvironmentPanel),
+        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.refresh", () => adminEnvironmentPanel.refresh()));
+
     const adminAuthPanel = new PacFlatDataView(
         () => pacWrapper.authList(),
         item => new AuthProfileTreeItem(item),

--- a/src/client/lib/PacTerminal.ts
+++ b/src/client/lib/PacTerminal.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { PacInterop, PacWrapper, PacWrapperContext } from '../pac/PacWrapper';
 import { ITelemetry } from '../telemetry/ITelemetry';
+import { RegisterPanels } from './PacActivityBarUI';
 
 export class PacTerminal implements vscode.Disposable {
     private readonly _context: vscode.ExtensionContext;
@@ -31,18 +32,16 @@ export class PacTerminal implements vscode.Disposable {
         // https://code.visualstudio.com/api/references/vscode-api#EnvironmentVariableCollection
         this._context.environmentVariableCollection.prepend('PATH', cliPath + path.delimiter);
 
-        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.openDocumentation', this.openDocumentation));
-        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.openPacLab', this.openPacLab));
-        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacHelp',
-            () => PacTerminal.getTerminal().sendText("pac help")));
-        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacAuthHelp',
-            () => PacTerminal.getTerminal().sendText("pac auth help")));
-        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacPackageHelp',
-            () => PacTerminal.getTerminal().sendText("pac package help")));
-        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacPcfHelp',
-            () => PacTerminal.getTerminal().sendText("pac pcf help")));
-        this._cmdDisposables.push(vscode.commands.registerCommand('pacCLI.pacSolutionHelp',
-            () => PacTerminal.getTerminal().sendText("pac solution help")));
+        this._cmdDisposables.push(
+            vscode.commands.registerCommand('pacCLI.openDocumentation', this.openDocumentation),
+            vscode.commands.registerCommand('pacCLI.openPacLab', this.openPacLab));
+
+        this._cmdDisposables.push(
+            vscode.commands.registerCommand('pacCLI.pacHelp', () => PacTerminal.getTerminal().sendText("pac help")),
+            vscode.commands.registerCommand('pacCLI.pacAuthHelp', () => PacTerminal.getTerminal().sendText("pac auth help")),
+            vscode.commands.registerCommand('pacCLI.pacPackageHelp', () => PacTerminal.getTerminal().sendText("pac package help")),
+            vscode.commands.registerCommand('pacCLI.pacPcfHelp', () => PacTerminal.getTerminal().sendText("pac pcf help")),
+            vscode.commands.registerCommand('pacCLI.pacSolutionHelp', () => PacTerminal.getTerminal().sendText("pac solution help")));
 
         this._cmdDisposables.push(vscode.commands.registerCommand(`pacCLI.enableTelemetry`, async () => {
             const result = await this._pacWrapper.enableTelemetry();
@@ -61,6 +60,8 @@ export class PacTerminal implements vscode.Disposable {
                 vscode.window.showErrorMessage("Failed to disable PAC telemetry.")
             }
         }));
+
+        this._cmdDisposables.push(...RegisterPanels(this._pacWrapper));
     }
 
     public openDocumentation(): void {

--- a/src/client/pac/PacTypes.ts
+++ b/src/client/pac/PacTypes.ts
@@ -17,6 +17,10 @@ export type AuthProfileListing = {
     CloudInstance: string;
 }
 
+export type PacOutputWithResultList<T> = PacOutput & {
+    Results: T[]
+}
+
 export type PacAuthListOutput = PacOutput & {
     Results: AuthProfileListing[];
 }

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -113,6 +113,14 @@ export class PacWrapper {
         return this.executeCommandAndParseResults<PacAuthListOutput>(new PacArguments("auth", "create", "--kind", "ADMIN"));
     }
 
+    public async authSelectByIndex(index: number): Promise<PacOutput>{
+        return this.executeCommandAndParseResults<PacOutput>(new PacArguments("auth", "select", "--index", index.toString()))
+    }
+
+    public async authDeleteByIndex(index: number): Promise<PacOutput>{
+        return this.executeCommandAndParseResults<PacOutput>(new PacArguments("auth", "delete", "--index", index.toString()))
+    }
+
     public async adminEnvironmentList(): Promise<PacAdminListOutput> {
         return this.executeCommandAndParseResults<PacAdminListOutput>(new PacArguments("admin", "list"));
     }

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -103,6 +103,16 @@ export class PacWrapper {
         return this.executeCommandAndParseResults<PacAuthListOutput>(new PacArguments("auth", "list"));
     }
 
+    public async authCreateNewDataverseProfile(): Promise<PacAuthListOutput> {
+        // TODO: Update to Dataverse once those changes are in
+        // TODO: Take URL argument
+        return this.executeCommandAndParseResults<PacAuthListOutput>(new PacArguments("auth", "create", "--kind", "CDS", "--url", "https://ppdevtools.crm.dynamics.com"));
+    }
+
+    public async authCreateNewAdminProfile(): Promise<PacAuthListOutput> {
+        return this.executeCommandAndParseResults<PacAuthListOutput>(new PacArguments("auth", "create", "--kind", "ADMIN"));
+    }
+
     public async adminEnvironmentList(): Promise<PacAdminListOutput> {
         return this.executeCommandAndParseResults<PacAdminListOutput>(new PacArguments("admin", "list"));
     }

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -106,7 +106,7 @@ export class PacWrapper {
 
     public async authCreateNewDataverseProfile(environmentUrl: string): Promise<PacAuthListOutput> {
         return this.executeCommandAndParseResults<PacAuthListOutput>(
-            new PacArguments("auth", "create", "--kind", "CDS", "--url", environmentUrl));
+            new PacArguments("auth", "create", "--kind", "DATAVERSE", "--url", environmentUrl));
     }
 
     public async authCreateNewAdminProfile(): Promise<PacAuthListOutput> {

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -104,10 +104,9 @@ export class PacWrapper {
         return this.executeCommandAndParseResults<PacAuthListOutput>(new PacArguments("auth", "list"));
     }
 
-    public async authCreateNewDataverseProfile(): Promise<PacAuthListOutput> {
-        // TODO: Update to Dataverse once those changes are in
-        // TODO: Take URL argument
-        return this.executeCommandAndParseResults<PacAuthListOutput>(new PacArguments("auth", "create", "--kind", "CDS", "--url", "https://ppdevtools.crm.dynamics.com"));
+    public async authCreateNewDataverseProfile(environmentUrl: string): Promise<PacAuthListOutput> {
+        return this.executeCommandAndParseResults<PacAuthListOutput>(
+            new PacArguments("auth", "create", "--kind", "CDS", "--url", environmentUrl));
     }
 
     public async authCreateNewAdminProfile(): Promise<PacAuthListOutput> {


### PR DESCRIPTION
Initial work on the Auth, Solution, and Admin Environments panels.
As this is still under flux and not ready for release yet, the panels are all behind a `powerplatform.experimental.activityBarPanels` "feature flag" implemented with the Configuration schema through the VS Code settings.

[AB#2335295](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2335295) : UI - initial Auth Profiles panel
[Task 2336580: UI - Add new Auth Profile button/command](https://dev.azure.com/dynamicscrm/ALM/_workitems/edit/2336580)
[Task 2335322: UI - Admin Environments](https://dev.azure.com/dynamicscrm/ALM/_workitems/edit/2335322)
[Task 2335311: UI - Solutions display](https://dev.azure.com/dynamicscrm/ALM/_workitems/edit/2335311)