### PR TITLE
Handle in-use PAC processes for debugging / upgrade scenarios

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "lib": [ "es6" ],
     "noImplicitAny": true,
     "strictPropertyInitialization": true,
-		"strict": true
+		"strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true
   },
   "include": [
     "src"


### PR DESCRIPTION
[AB#2400076](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2400076) - Handle PAC process conflicts on upgrade / debug

When debugging the extension using a different version of PAC than the current one (as well as some extension upgrade scenarios), the debugger instance of VS Code may have the PAC assemblies in use and locked, preventing the debuggee instance of VS Code from overwriting them with the new version.