### PR TITLE
truncate dataverse auth profile description and add tooltip

### DIFF
--- a/src/client/lib/PanelComponents.ts
+++ b/src/client/lib/PanelComponents.ts
@@ -43,6 +43,7 @@ export class PacFlatDataView<PacResultType, TreeType extends vscode.TreeItem> im
 export class AuthProfileTreeItem extends vscode.TreeItem {
     public constructor(public readonly model: AuthProfileListing) {
         super(AuthProfileTreeItem.createLabel(model), vscode.TreeItemCollapsibleState.None);
+        this.tooltip = AuthProfileTreeItem.createTooltip(model);
         if (model.IsActive){
             this.iconPath = new vscode.ThemeIcon("star-full")
         }
@@ -53,8 +54,19 @@ export class AuthProfileTreeItem extends vscode.TreeItem {
         } else if (profile.Kind === "ADMIN") {
             return `${profile.Kind}: ${profile.User}`;
         } else {
-            return `${profile.Kind}: ${profile.User} - ${profile.Resource}`;
+            return `${profile.Kind}: ${profile.Resource}`;
         }
+    }
+    private static createTooltip(profile: AuthProfileListing): string {
+        let tooltip = `${profile.Kind}: `;
+        if (profile.Name) {
+            tooltip += `${profile.Name} `;
+        }
+        if (profile.Kind === "DATAVERSE") {
+            tooltip += `${profile.Resource} `;
+        }
+        tooltip += profile.User;
+        return tooltip;
     }
 }
 


### PR DESCRIPTION
Truncate Dataverse auth profile description for better readability
Add tooltip which shows all the details for auth profile.
Example:
Tooltip for Dataverse auth profile would look like, DATAVERSE: {profileName} {orgUrl} {user}
Tooltip for Admin auth profile, ADMIN: {profileName} {user}

[Truncate Dataverse auth profile description and add tooltip](https://dev.azure.com/dynamicscrm/ALM/_workitems/edit/2399914/)