### PR TITLE
add context menus for auth, environment and solution panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,14 +133,46 @@
         "icon": "$(trash)"
       },
       {
+        "command": "pacCLI.authPanel.navigateToResource",
+        "title": "Navigate to Resource"
+      },
+      {
+        "command": "pacCLI.authPanel.copyUser",
+        "title": "Copy User"
+      },
+      {
         "command": "pacCLI.solutionPanel.refresh",
         "title": "Refresh",
         "icon": "$(refresh)"
       },
       {
+        "command": "pacCLI.solutionPanel.copyFriendlyName",
+        "title": "Copy Friendly Name"
+      },
+      {
+        "command": "pacCLI.solutionPanel.copyVersionNumber",
+        "title": "Copy Version Number"
+      },
+      {
         "command": "pacCLI.adminEnvironmentPanel.refresh",
         "title": "Refresh",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "pacCLI.adminEnvironmentPanel.copyDisplayName",
+        "title": "Copy Display Name"
+      },
+      {
+        "command": "pacCLI.adminEnvironmentPanel.copyEnvironmentId",
+        "title": "Copy Environment Id"
+      },
+      {
+        "command": "pacCLI.adminEnvironmentPanel.copyEnvironmentUrl",
+        "title": "Copy Environment Url"
+      },
+      {
+        "command": "pacCLI.adminEnvironmentPanel.copyOrganizationId",
+        "title": "Copy Organization Id"
       },
       {
         "command": "microsoft-powerapps-portals.preview-show",
@@ -250,6 +282,41 @@
           "command": "pacCLI.authPanel.selectAuthProfile",
           "when": "view == pacCLI.authPanel",
           "group": "inline"
+        },
+        {
+          "command": "pacCLI.authPanel.navigateToResource",
+          "when": "view == pacCLI.authPanel && viewItem == DATAVERSE"
+        },
+        {
+          "command": "pacCLI.authPanel.copyUser",
+          "when": "view == pacCLI.authPanel"
+        },
+        {
+          "command": "pacCLI.solutionPanel.copyFriendlyName",
+          "when": "view == pacCLI.solutionPanel"
+        },
+        {
+          "command": "pacCLI.solutionPanel.copyVersionNumber",
+          "when": "view == pacCLI.solutionPanel"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.copyDisplayName",
+          "when": "view == pacCLI.adminEnvironmentPanel",
+          "group": "displayName@0"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.copyEnvironmentId",
+          "when": "view == pacCLI.adminEnvironmentPanel",
+          "group": "environment"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.copyEnvironmentUrl",
+          "when": "view == pacCLI.adminEnvironmentPanel",
+          "group": "environment"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.copyOrganizationId",
+          "when": "view == pacCLI.adminEnvironmentPanel"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -238,7 +238,31 @@
           "when": "never"
         },
         {
+          "command": "pacCLI.solutionPanel.copyFriendlyName",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.solutionPanel.copyVersionNumber",
+          "when": "never"
+        },
+        {
           "command": "pacCLI.adminEnvironmentPanel.refresh",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.copyDisplayName",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.copyEnvironmentId",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.copyEnvironmentUrl",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.adminEnvironmentPanel.copyOrganizationId",
           "when": "never"
         },
         {
@@ -247,6 +271,14 @@
         },
         {
           "command": "pacCLI.authPanel.deleteAuthProfile",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.authPanel.navigateToResource",
+          "when": "never"
+        },
+        {
+          "command": "pacCLI.authPanel.copyUser",
           "when": "never"
         }
       ],

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -11,14 +11,32 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
     const solutionPanel = new PacFlatDataView(() => pacWrapper.solutionList(), item => new SolutionTreeItem(item));
     registrations.push(
         vscode.window.registerTreeDataProvider("pacCLI.solutionPanel", solutionPanel),
-        vscode.commands.registerCommand("pacCLI.solutionPanel.refresh", () => solutionPanel.refresh()));
+        vscode.commands.registerCommand("pacCLI.solutionPanel.refresh", () => solutionPanel.refresh()),
+        vscode.commands.registerCommand("pacCLI.solutionPanel.copyFriendlyName", (item: SolutionTreeItem) => {
+            vscode.env.clipboard.writeText(item.model.FriendlyName);
+        }),
+        vscode.commands.registerCommand("pacCLI.solutionPanel.copyVersionNumber", (item: SolutionTreeItem) => {
+            vscode.env.clipboard.writeText(item.model.VersionNumber);
+        }));
 
     const adminEnvironmentPanel = new PacFlatDataView(
         () => pacWrapper.adminEnvironmentList(),
         item => new AdminEnvironmentTreeItem(item));
     registrations.push(
         vscode.window.registerTreeDataProvider("pacCLI.adminEnvironmentPanel", adminEnvironmentPanel),
-        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.refresh", () => adminEnvironmentPanel.refresh()));
+        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.refresh", () => adminEnvironmentPanel.refresh()),
+        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.copyDisplayName", (item: AdminEnvironmentTreeItem) => {
+            vscode.env.clipboard.writeText(item.model.DisplayName);
+        }),
+        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.copyEnvironmentId", (item: AdminEnvironmentTreeItem) => {
+            vscode.env.clipboard.writeText(item.model.EnvironmentId);
+        }),
+        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.copyEnvironmentUrl", (item: AdminEnvironmentTreeItem) => {
+            vscode.env.clipboard.writeText(item.model.EnvironmentUrl);
+        }),
+        vscode.commands.registerCommand("pacCLI.adminEnvironmentPanel.copyOrganizationId", (item: AdminEnvironmentTreeItem) => {
+            vscode.env.clipboard.writeText(item.model.OrganizationId);
+        }));
 
     const authPanel = new PacFlatDataView(
         () => pacWrapper.authList(),
@@ -63,6 +81,12 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
                     adminEnvironmentPanel.refresh();
                 }
             }
+        }),
+        vscode.commands.registerCommand('pacCLI.authPanel.navigateToResource', (item: AuthProfileTreeItem) => {
+            vscode.env.openExternal(vscode.Uri.parse(item.model.Resource));
+        }),
+        vscode.commands.registerCommand('pacCLI.authPanel.copyUser', (item: AuthProfileTreeItem) => {
+            vscode.env.clipboard.writeText(item.model.User);
         }));
 
     return registrations;

--- a/src/client/lib/PanelComponents.ts
+++ b/src/client/lib/PanelComponents.ts
@@ -43,6 +43,7 @@ export class PacFlatDataView<PacResultType, TreeType extends vscode.TreeItem> im
 export class AuthProfileTreeItem extends vscode.TreeItem {
     public constructor(public readonly model: AuthProfileListing) {
         super(AuthProfileTreeItem.createLabel(model), vscode.TreeItemCollapsibleState.None);
+        this.contextValue = model.Kind;
         this.tooltip = AuthProfileTreeItem.createTooltip(model);
         if (model.IsActive){
             this.iconPath = new vscode.ThemeIcon("star-full")

--- a/src/client/lib/PanelComponents.ts
+++ b/src/client/lib/PanelComponents.ts
@@ -43,6 +43,7 @@ export class PacFlatDataView<PacResultType, TreeType extends vscode.TreeItem> im
 export class AuthProfileTreeItem extends vscode.TreeItem {
     public constructor(public readonly model: AuthProfileListing) {
         super(AuthProfileTreeItem.createLabel(model), vscode.TreeItemCollapsibleState.None);
+        this.tooltip = AuthProfileTreeItem.createTooltip(model);
         if (model.IsActive){
             this.iconPath = new vscode.ThemeIcon("star-full")
         }
@@ -53,8 +54,19 @@ export class AuthProfileTreeItem extends vscode.TreeItem {
         } else if (profile.Kind === "ADMIN") {
             return `${profile.Kind}: ${profile.User}`;
         } else {
-            return `${profile.Kind}: ${profile.User} - ${profile.Resource}`;
+            return `${profile.Kind}: ${profile.Resource}`;
         }
+    }
+    private static createTooltip(profile: AuthProfileListing): string {
+        let tooltip = `${profile.Kind}: `;
+        if (profile.Name) {
+            tooltip += `${profile.Name} `;
+        }
+        if (profile.Kind === "DATAVERSE") {
+            tooltip += `${profile.Resource} `;
+        }
+        tooltip += profile.User;
+        return tooltip;
     }
 }
 


### PR DESCRIPTION
Add context menus for auth, solution and environment panels.

Context menu for Auth Panel,
Dataverse auth profile: Navigate to Resource 
Both the auth profiles: Copy User

Context menu for Environment Panel,
Copy Display Name
Copy Environment Id
Copy Environment Url
Copy Organization Id

Context menu for Solution Panel,
Copy Friendly Name
Copy Version Number

[Work item: Context menu commands](https://dev.azure.com/dynamicscrm/ALM/_workitems/edit/2396563/)