### PR TITLE
add empty auth profiles content

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,12 @@
     "onLanguage:html"
   ],
   "contributes": {
+    "viewsWelcome": [
+      {
+        "view": "pacCLI.authPanel",
+        "contents": "No auth profiles found on this computer.\n[Add Admin Auth Profile](command:pacCLI.authPanel.newAdminAuthProfile)\n[Add Dataverse Auth Profile](command:pacCLI.authPanel.newDataverseAuthProfile)"
+      }
+    ],
     "commands": [
       {
         "command": "pacCLI.openDocumentation",


### PR DESCRIPTION
Add message for empty auth profiles panel and buttons to create Dataverse and Admin auth profiles.

[Work item: Add content for empty auth profiles panel](https://dev.azure.com/dynamicscrm/ALM/_workitems/edit/2224160)