### PR TITLE
Categorize commands exposed to the Command Palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
       },
       {
         "command": "pacCLI.authPanel.clearAuthProfile",
+        "category": "Power Platform CLI",
         "title": "Clear Auth Profiles",
         "icon": "$(clear-all)"
       },
@@ -125,11 +126,13 @@
       },
       {
         "command": "pacCLI.authPanel.newDataverseAuthProfile",
+        "category": "Power Platform CLI",
         "title": "New Dataverse Auth Profile",
         "icon": "$(add)"
       },
       {
         "command": "pacCLI.authPanel.newAdminAuthProfile",
+        "category": "Power Platform CLI",
         "title": "New Admin Auth Profile",
         "icon": "$(add)"
       },


### PR DESCRIPTION
Most of the panel related commands are context specific (eg "Copy Environment Id" for Environments), and thus prevented from displaying in the Command Palette.  
Three however - new dataverse auth profile, new admin auth profile, and clear auth profiles - do not need that context, and as such can be used from the command palette.   
This change adds those three to our `Power Platform CLI` category