### PR TITLE
Prepare for August refresh release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Installing this extension will also make the latest Power Platform CLI (aka pac)
 ![VSCode Terminal with pac CLI](https://github.com/microsoft/powerplatform-vscode/blob/main/src/client/assets/pac-CLI-in-terminal.png?raw=true)
 
 ## Release Notes
+
+0.2.21:
+  - pac CLI 1.9.8 (August refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
+  - added pac CLI Linux support in terminal: on Windows 10, remote connect to WSL terminal (<https://code.visualstudio.com/docs/remote/wsl>)
+
 0.2.19:
   - shortened the extension's friendly name
   - pac CLI 1.9.4 (July refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installing this extension will also make the latest Power Platform CLI (aka pac)
 
 ## Release Notes
 
-0.2.21:
+0.2.22:
   - pac CLI 1.9.8 (August refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
   - added pac CLI Linux support in terminal: on Windows 10, remote connect to WSL terminal (<https://code.visualstudio.com/docs/remote/wsl>)
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -214,7 +214,7 @@ async function snapshot() {
         process.chdir(orgDir);
     }
 }
-const cliVersion = '1.9.7';
+const cliVersion = '1.9.8';
 
 const recompile = gulp.series(
     clean,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerplatform-vscode",
-  "displayName": "Power Platform",
+  "displayName": "Power Platform Tools",
   "description": "Tooling to create Power Platform solutions & packages, manage Power Platform environments and edit Power Apps Portals",
   "version": "0.1.0-dev",
   "scripts": {

--- a/src/client/test/unit/CliAcquisition.test.ts
+++ b/src/client/test/unit/CliAcquisition.test.ts
@@ -82,7 +82,7 @@ describe('CliAcquisition', () => {
         expect(fs.existsSync(path.resolve(exePath, 'pac'))).to.be.true;
         expect(spy.infoMessages).to.be.not.empty;
         expect(spy.noErrors).to.be.true;
-    }).timeout(10000);
+    }).timeout(20000);
 
     it('updates older version to latest CLI nupkg', async () => {
         const trackerFile = path.resolve(spy.globalStorageLocalPath, 'installTracker.json');
@@ -96,5 +96,5 @@ describe('CliAcquisition', () => {
         expect(spy.noErrors).to.be.true;
         const versionInfo = fs.readJSONSync(trackerFile);
         expect(versionInfo.pac).to.be.equal('0.9.99');
-    }).timeout(10000);
+    }).timeout(20000);
 });


### PR DESCRIPTION
- update to latest pac CLI 1.9.8
- update release notes
- extend timeout for slower CLI acquisition tests