### PR TITLE
Update to latest PAC

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -216,7 +216,7 @@ async function snapshot() {
         process.chdir(orgDir);
     }
 }
-const cliVersion = '1.9.8';
+const cliVersion = '1.9.9';
 
 const recompile = gulp.series(
     clean,


### PR DESCRIPTION
Update to PAC v1.9.9, fixing the `pac canvas unpack` issue
[AB#2479539](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2479539): Canvas Pack/Unpack fails due to System.Text.Json assembly mismatch