### PR TITLE
Fix webpacked localization for non-Windows environments

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,7 @@ function compile() {
     return gulp
         .src('src/**/*.ts')
         .pipe(gulpWebpack(webPackConfig, webpack))
+        .pipe(replace("src\\\\client\\\\lib\\\\", "src/client/lib/")) // Hacky fix: vscode-nls-dev/lib/webpack-loader uses Windows style paths when built on Windows, breaking localization on Linux & Mac
         .pipe(gulp.dest(distdir));
 }
 


### PR DESCRIPTION
[AB#2527929](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2527929): VS Code localizations not loading on WSL

When built on Windows, `vscode-nls-dev/lib/webpack-loader` uses Windows styled paths in `extension.js` and `dist/src/client/lib/*.nls.metadata.json`, breaking the loading of localization messages on Linux & Mac.

Builds on the other environments work fine, but for Windows builds (such as the official release process), we need to do the string replacement to fix up those paths.