### PR TITLE
Roll forward to .NET 6.0 for M1 mac users when 6.0 uninstalls the 5.0 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Installing this extension will also make the latest Power Platform CLI (aka pac)
 ## Release Notes
 
 0.2.24:
-  - Known issues with .NET 6.0 on arm64 MacOS (aka M1 and Apple Silicone)
-    - Installing .NET 6.0 on M1 machiens breaks previous installations of .NET 5.0 prior to the November 2021 release of .NET 5.0, which breaks the prerequisites of this extension.  Users who are planing to or who have already installed .NET 6.0 are recommended to uninstall .NET from the machine, then install **both** the arm64 and x64 versions of .NET 6.0
+  - .NET 6 on Apple M1: pac CLI is targeting dotnetCore 5 for intel, but the .NET6 amd64 installer removes the net5 and x64 support.  Users who have installed .NET 6 will need to uninstall all existing .NET bits and then install **both** the amd64 (Apple M1) and the x64 .NET 6 SDKs side by side.
     - Documentation on this .NET issue can be found at [.NET Support for macOS 11 and Windows 11 for Arm64 and x64](https://github.com/dotnet/sdk/issues/22380)
     - Users who only have .NET 5.0 installed do not need to take any action.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Installing this extension will also make the latest Power Platform CLI (aka pac)
 
 ## Release Notes
 
+0.2.24:
+  - Known issues with .NET 6.0 on arm64 MacOS (aka M1 and Apple Silicone)
+    - Installing .NET 6.0 on M1 machiens breaks previous installations of .NET 5.0 prior to the November 2021 release of .NET 5.0, which breaks the prerequisites of this extension.  Users who are planing to or who have already installed .NET 6.0 are recommended to uninstall .NET from the machine, then install **both** the arm64 and x64 versions of .NET 6.0
+    - Documentation on this .NET issue can be found at [.NET Support for macOS 11 and Windows 11 for Arm64 and x64](https://github.com/dotnet/sdk/issues/22380)
+    - Users who only have .NET 5.0 installed do not need to take any action.
+
 0.2.22:
   - pac CLI 1.9.8 (August refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
   - added pac CLI Linux support in terminal: on Windows 10, remote connect to WSL terminal (<https://code.visualstudio.com/docs/remote/wsl>)

--- a/src/client/lib/PacTerminal.ts
+++ b/src/client/lib/PacTerminal.ts
@@ -7,6 +7,7 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as os from 'os'
 import { PacInterop, PacWrapper, PacWrapperContext } from '../pac/PacWrapper';
 import { ITelemetry } from '../telemetry/ITelemetry';
 import { RegisterPanels } from './PacActivityBarUI';
@@ -28,6 +29,12 @@ export class PacTerminal implements vscode.Disposable {
 
         // https://code.visualstudio.com/api/references/vscode-api#EnvironmentVariableCollection
         this._context.environmentVariableCollection.prepend('PATH', cliPath + path.delimiter);
+
+        // Compatability for users on M1 Macs with .NET 6.0 installed - permit pac and pacTelemetryUpload
+        // to roll up to 6.0 if 5.0 is not found on the system.
+        if (os.platform() === 'darwin' && os.version().includes('ARM64')) {
+            this._context.environmentVariableCollection.replace('DOTNET_ROLL_FORWARD','Major');
+        }
 
         this._cmdDisposables.push(
             vscode.commands.registerCommand('pacCLI.openDocumentation', this.openDocumentation),


### PR DESCRIPTION
Roll forward to .NET 6.0 for M1 mac users when 6.0 uninstalls the 5.0 runtime