### PR TITLE
Env & Solution panel should use the URL version of `pac solution list`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -218,13 +218,13 @@ async function snapshot() {
         process.chdir(orgDir);
     }
 }
-const cliVersion = '1.10.4';
+const cliVersion = '1.10.5-daily-22011218';
 
 const recompile = gulp.series(
     clean,
-    async () => nugetInstall('CAP_ISVExp_Tools_Stable', 'Microsoft.PowerApps.CLI',cliVersion, path.resolve(distdir, 'pac')),
-    async () => nugetInstall('CAP_ISVExp_Tools_Stable', 'Microsoft.PowerApps.CLI.Core.osx-x64', cliVersion, path.resolve(distdir, 'pac')),
-    async () => nugetInstall('CAP_ISVExp_Tools_Stable', 'Microsoft.PowerApps.CLI.Core.linux-x64', cliVersion, path.resolve(distdir, 'pac')),
+    async () => nugetInstall('CAP_ISVExp_Tools_Daily', 'Microsoft.PowerApps.CLI',cliVersion, path.resolve(distdir, 'pac')),
+    async () => nugetInstall('CAP_ISVExp_Tools_Daily', 'Microsoft.PowerApps.CLI.Core.osx-x64', cliVersion, path.resolve(distdir, 'pac')),
+    async () => nugetInstall('CAP_ISVExp_Tools_Daily', 'Microsoft.PowerApps.CLI.Core.linux-x64', cliVersion, path.resolve(distdir, 'pac')),
     translationsExport,
     translationsImport,
     translationsGenerate,

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -89,7 +89,7 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
 
     const envAndSolutionPanel = new EnvAndSolutionTreeView(
         () => pacWrapper.orgList(),
-        (envId) => pacWrapper.solutionListFromEnvironment(envId));
+        (environmentUrl) => pacWrapper.solutionListFromEnvironment(environmentUrl));
     registrations.push(
         vscode.window.registerTreeDataProvider("pacCLI.envAndSolutionsPanel", envAndSolutionPanel),
         vscode.commands.registerCommand("pacCLI.envAndSolutionsPanel.refresh", () => envAndSolutionPanel.refresh()),

--- a/src/client/lib/PanelComponents.ts
+++ b/src/client/lib/PanelComponents.ts
@@ -157,7 +157,7 @@ export class EnvAndSolutionTreeView implements vscode.TreeDataProvider<EnvOrSolu
 
     constructor(
         public readonly envDataSource: () => Promise<PacOrgListOutput>,
-        public readonly solutionDataSource: (envId: string) => Promise<PacSolutionListOutput>,
+        public readonly solutionDataSource: (environmentUrl: string) => Promise<PacSolutionListOutput>,
     ){
     }
 
@@ -183,7 +183,7 @@ export class EnvAndSolutionTreeView implements vscode.TreeDataProvider<EnvOrSolu
             return [];
         } else {
             // element is environment
-            const solutionOutput = await this.solutionDataSource(element.model.EnvironmentId);
+            const solutionOutput = await this.solutionDataSource(element.model.EnvironmentUrl);
             if (solutionOutput && solutionOutput.Status === "Success" && solutionOutput.Results) {
                 return solutionOutput.Results.map(item => new EnvOrSolutionTreeItem(item))
             } else {

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -139,8 +139,8 @@ export class PacWrapper {
         return this.executeCommandAndParseResults<PacSolutionListOutput>(new PacArguments("solution", "list"));
     }
 
-    public async solutionListFromEnvironment(environmentId: string): Promise<PacSolutionListOutput> {
-        return this.executeCommandAndParseResults<PacSolutionListOutput>(new PacArguments("solution", "list", "--environment-id", environmentId));
+    public async solutionListFromEnvironment(environmentUrl: string): Promise<PacSolutionListOutput> {
+        return this.executeCommandAndParseResults<PacSolutionListOutput>(new PacArguments("solution", "list", "--environment", environmentUrl));
     }
 
     public async orgList(): Promise<PacOrgListOutput> {


### PR DESCRIPTION
[AB#2569818](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2569818): Solution List optimization - use URL instead of ID

Switching the call to use the URL for `pac solution list -env [url]` prevents the need to call the Global Discovery Service to map the Environment ID to the URL necessary for the Dataverse connection