### PR TITLE
Remove unneeded Admin profiles from the Auth Profile panel

### DIFF
--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -36,11 +36,9 @@
     </trans-unit>
     <trans-unit id="pacCLI.authPanel.welcome.whenInteractiveSupported">
       <source xml:lang="en">No auth profiles found on this computer.
-[Add Admin Auth Profile](command:pacCLI.authPanel.newAdminAuthProfile)
 [Add Dataverse Auth Profile](command:pacCLI.authPanel.newDataverseAuthProfile)</source>
       <note>This is a Markdown formatted string, and the formatting must persist across translations.
-The second line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newAdminAuthProfile)', keeping brackets and the text in the parentheses unmodified
-The third line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newDataverseAuthProfile)', keeping brackets and the text in the parentheses unmodified</note>
+The second line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newDataverseAuthProfile)', keeping brackets and the text in the parentheses unmodified</note>
     </trans-unit>
     <trans-unit id="pacCLI.authPanel.welcome.whenInteractiveNotSupported">
       <source xml:lang="en">No auth profiles found on this computer.
@@ -56,9 +54,6 @@ The second line should be '[TRANSLATION HERE](command:pacCLI.pacAuthHelp)', keep
     </trans-unit>
     <trans-unit id="pacCLI.authPanel.newDataverseAuthProfile.title">
       <source xml:lang="en">New Dataverse Auth Profile</source>
-    </trans-unit>
-    <trans-unit id="pacCLI.authPanel.newAdminAuthProfile.title">
-      <source xml:lang="en">New Admin Auth Profile</source>
     </trans-unit>
     <trans-unit id="pacCLI.authPanel.selectAuthProfile.title">
       <source xml:lang="en">Select Auth Profile</source>

--- a/package.json
+++ b/package.json
@@ -140,12 +140,6 @@
         "icon": "$(add)"
       },
       {
-        "command": "pacCLI.authPanel.newAdminAuthProfile",
-        "category": "Power Platform CLI",
-        "title": "%pacCLI.authPanel.newAdminAuthProfile.title%",
-        "icon": "$(add)"
-      },
-      {
         "command": "pacCLI.authPanel.selectAuthProfile",
         "title": "%pacCLI.authPanel.selectAuthProfile.title%",
         "icon": "$(star-empty)"
@@ -256,10 +250,6 @@
           "when": "never"
         },
         {
-          "command": "pacCLI.authPanel.newAdminAuthProfile",
-          "when": "pacCLI.authPanel.interactiveLoginSupported"
-        },
-        {
           "command": "pacCLI.authPanel.newDataverseAuthProfile",
           "when": "pacCLI.authPanel.interactiveLoginSupported"
         },
@@ -314,24 +304,19 @@
       ],
       "view/title": [
         {
-          "command": "pacCLI.authPanel.newAdminAuthProfile",
+          "command": "pacCLI.authPanel.newDataverseAuthProfile",
           "when": "view == pacCLI.authPanel && pacCLI.authPanel.interactiveLoginSupported",
           "group": "navigation@0"
         },
         {
-          "command": "pacCLI.authPanel.newDataverseAuthProfile",
-          "when": "view == pacCLI.authPanel && pacCLI.authPanel.interactiveLoginSupported",
-          "group": "navigation@1"
-        },
-        {
           "command": "pacCLI.authPanel.refresh",
           "when": "view == pacCLI.authPanel",
-          "group": "navigation@2"
+          "group": "navigation@1"
         },
         {
           "command": "pacCLI.authPanel.clearAuthProfile",
           "when": "view == pacCLI.authPanel",
-          "group": "navigation@3"
+          "group": "navigation@2"
         },
         {
           "command": "pacCLI.envAndSolutionsPanel.refresh",

--- a/package.nls.cs.json
+++ b/package.nls.cs.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "Vymazat ověřovací profily",
 	"pacCLI.authPanel.refresh.title": "Aktualizovat",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "Nový ověřovací profil Dataverse",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "Nový ověřovací profil správce",
 	"pacCLI.authPanel.selectAuthProfile.title": "Vybrat ověřovací profil",
 	"pacCLI.authPanel.deleteAuthProfile.title": "Odstranit ověřovací profil",
 	"pacCLI.authPanel.nameAuthProfile.title": "Pojmenovat nebo přejmenovat ověřovací profil",

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "Authentifizierungsprofile löschen",
 	"pacCLI.authPanel.refresh.title": "Aktualisieren",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "Neues Dataverse-Authentifizierungsprofil",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "Neues Administrator-Authentifizierungsprofil",
 	"pacCLI.authPanel.selectAuthProfile.title": "Authentifizierungsprofil auswählen",
 	"pacCLI.authPanel.deleteAuthProfile.title": "Authentifizierungsprofil löschen",
 	"pacCLI.authPanel.nameAuthProfile.title": "Authentifizierungsprofil benennen/umbenennen",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "Borrar perfiles de autenticación",
 	"pacCLI.authPanel.refresh.title": "Actualizar",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "Nuevo perfil de autenticación de Dataverse",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "Nuevo perfil de autenticación de administrador",
 	"pacCLI.authPanel.selectAuthProfile.title": "Seleccionar perfil de autenticación",
 	"pacCLI.authPanel.deleteAuthProfile.title": "Eliminar perfil de autenticación",
 	"pacCLI.authPanel.nameAuthProfile.title": "Asignar nombre/Cambiar nombre del perfil de autenticación",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "Effacer les profils d’authentification",
 	"pacCLI.authPanel.refresh.title": "Actualiser",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "Nouveau profil d’authentification Dataverse",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "Nouveau profil d’authentification de l’administrateur",
 	"pacCLI.authPanel.selectAuthProfile.title": "Sélectionner un profil d’authentification",
 	"pacCLI.authPanel.deleteAuthProfile.title": "Supprimer le profil d’authentification",
 	"pacCLI.authPanel.nameAuthProfile.title": "Nommer/Renommer le profil d’authentification",

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "Cancella profili di autenticazione",
 	"pacCLI.authPanel.refresh.title": "Aggiorna",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "Nuovo profilo di autenticazione Dataverse",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "Nuovo profilo di autenticazione amministratore",
 	"pacCLI.authPanel.selectAuthProfile.title": "Seleziona profilo autenticazione",
 	"pacCLI.authPanel.deleteAuthProfile.title": "Elimina profilo di autenticazione",
 	"pacCLI.authPanel.nameAuthProfile.title": "Assegna un nome/rinomina profilo di autorizzazione",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "認証プロファイルのクリア",
 	"pacCLI.authPanel.refresh.title": "最新の情報に更新",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "新しい Dataverse 認証プロファイル",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "新しい管理者認証プロファイル",
 	"pacCLI.authPanel.selectAuthProfile.title": "認証プロファイルの選択",
 	"pacCLI.authPanel.deleteAuthProfile.title": "認証プロファイルの削除",
 	"pacCLI.authPanel.nameAuthProfile.title": "認証プロファイルの名前の指定/変更",

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,11 +13,10 @@
 
   "pacCLI.authPanel.title": "Auth Profiles",
   "pacCLI.authPanel.welcome.whenInteractiveSupported": {
-     "message": "No auth profiles found on this computer.\n[Add Admin Auth Profile](command:pacCLI.authPanel.newAdminAuthProfile)\n[Add Dataverse Auth Profile](command:pacCLI.authPanel.newDataverseAuthProfile)",
+     "message": "No auth profiles found on this computer.\n[Add Dataverse Auth Profile](command:pacCLI.authPanel.newDataverseAuthProfile)",
      "comment": [
        "This is a Markdown formatted string, and the formatting must persist across translations.",
-       "The second line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newAdminAuthProfile)', keeping brackets and the text in the parentheses unmodified",
-       "The third line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newDataverseAuthProfile)', keeping brackets and the text in the parentheses unmodified"
+       "The second line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newDataverseAuthProfile)', keeping brackets and the text in the parentheses unmodified"
     ]
   },
   "pacCLI.authPanel.welcome.whenInteractiveNotSupported": {
@@ -30,7 +29,6 @@
   "pacCLI.authPanel.clearAuthProfile.title": "Clear Auth Profiles",
   "pacCLI.authPanel.refresh.title": "Refresh",
   "pacCLI.authPanel.newDataverseAuthProfile.title": "New Dataverse Auth Profile",
-  "pacCLI.authPanel.newAdminAuthProfile.title": "New Admin Auth Profile",
   "pacCLI.authPanel.selectAuthProfile.title": "Select Auth Profile",
   "pacCLI.authPanel.deleteAuthProfile.title": "Delete Auth Profile",
   "pacCLI.authPanel.nameAuthProfile.title": "Name/Rename Auth Profile",

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "인증 프로필 지우기",
 	"pacCLI.authPanel.refresh.title": "새로 고침",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "새 Dataverse 인증 프로필",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "새 관리자 인증 프로필",
 	"pacCLI.authPanel.selectAuthProfile.title": "인증 프로필 선택",
 	"pacCLI.authPanel.deleteAuthProfile.title": "인증 프로필 삭제",
 	"pacCLI.authPanel.nameAuthProfile.title": "인증 프로필 이름 지정/이름 변경",

--- a/package.nls.pt-BR.json
+++ b/package.nls.pt-BR.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "Limpar Perfis de Autenticação",
 	"pacCLI.authPanel.refresh.title": "Atualizar",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "Novo Perfil de Autenticação do Dataverse",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "Novo Administrador do Perfil de Autenticação",
 	"pacCLI.authPanel.selectAuthProfile.title": "Selecionar Perfil de Autenticação",
 	"pacCLI.authPanel.deleteAuthProfile.title": "Excluir Perfil de Autenticação",
 	"pacCLI.authPanel.nameAuthProfile.title": "Nomear/Renomear Perfil de Autenticação",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "Удаление профилей проверки подлинности",
 	"pacCLI.authPanel.refresh.title": "Обновить",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "Новый профиль проверки подлинности Dataverse",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "Новый профиль проверки подлинности администратора",
 	"pacCLI.authPanel.selectAuthProfile.title": "Выбор профиля проверки подлинности",
 	"pacCLI.authPanel.deleteAuthProfile.title": "Удаление профиля проверки подлинности",
 	"pacCLI.authPanel.nameAuthProfile.title": "Установка/изменение имени профиля проверки подлинности",

--- a/package.nls.tr.json
+++ b/package.nls.tr.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "Kimlik Doğrulama Profillerini Temizle",
 	"pacCLI.authPanel.refresh.title": "Yenile",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "Yeni Dataverse Kimlik Doğrulama Profili",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "Yeni Yönetici Kimlik Doğrulama Profili",
 	"pacCLI.authPanel.selectAuthProfile.title": "Kimlik Doğrulama Profili Seçin",
 	"pacCLI.authPanel.deleteAuthProfile.title": "Kimlik Doğrulama Profilini Sil",
 	"pacCLI.authPanel.nameAuthProfile.title": "Kimlik Doğrulama Profilini Adlandır/Yeniden Adlandır",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "清除身份验证配置文件",
 	"pacCLI.authPanel.refresh.title": "刷新",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "新建 Dataverse 身份验证配置文件",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "新建管理员身份验证配置文件",
 	"pacCLI.authPanel.selectAuthProfile.title": "选择身份验证配置文件",
 	"pacCLI.authPanel.deleteAuthProfile.title": "删除身份验证配置文件",
 	"pacCLI.authPanel.nameAuthProfile.title": "命名/重命名身份验证配置文件",

--- a/package.nls.zh-TW.json
+++ b/package.nls.zh-TW.json
@@ -15,7 +15,6 @@
 	"pacCLI.authPanel.clearAuthProfile.title": "清除驗證設定檔",
 	"pacCLI.authPanel.refresh.title": "重新整理​",
 	"pacCLI.authPanel.newDataverseAuthProfile.title": "新增 Dataverse 驗證設定檔",
-	"pacCLI.authPanel.newAdminAuthProfile.title": "新增系統管理驗證設定檔",
 	"pacCLI.authPanel.selectAuthProfile.title": "選取驗證設定檔",
 	"pacCLI.authPanel.deleteAuthProfile.title": "刪除驗證設定檔",
 	"pacCLI.authPanel.nameAuthProfile.title": "命名/重新命名驗證設定檔",

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -15,7 +15,8 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
 
     const authPanel = new PacFlatDataView(
         () => pacWrapper.authList(),
-        item => new AuthProfileTreeItem(item));
+        item => new AuthProfileTreeItem(item),
+        item => item.Kind !== "ADMIN");
     registrations.push(
         vscode.window.registerTreeDataProvider("pacCLI.authPanel", authPanel),
         vscode.commands.registerCommand("pacCLI.authPanel.refresh", () => authPanel.refresh()),
@@ -42,11 +43,6 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
                 authPanel.refresh();
                 envAndSolutionPanel.refresh();
             }
-        }),
-        vscode.commands.registerCommand("pacCLI.authPanel.newAdminAuthProfile", async () => {
-            await pacWrapper.authCreateNewAdminProfile();
-            authPanel.refresh();
-            envAndSolutionPanel.refresh();
         }),
         vscode.commands.registerCommand("pacCLI.authPanel.selectAuthProfile", async (item: AuthProfileTreeItem) => {
             await pacWrapper.authSelectByIndex(item.model.Index);


### PR DESCRIPTION
[AB#2553702](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2553702): Auth Panel Updates - Remove Admin profiles from display and commands

As all actions done by the UI layer will be using Dataverse auth profiles with Token Exchange occurring in the background, the Admin auth profiles are not needed and can cause confusion by their presence. 