### PR TITLE
Fixing installation issue on Win 11 insider builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0-dev",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "find-process": "^1.4.4",
+        "find-process": "^1.4.7",
         "glob": "^7.1.7",
         "n-readlines": "^1.0.1",
         "nearley": "^2.20.1",
@@ -3990,9 +3990,9 @@
       }
     },
     "node_modules/find-process": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.5.tgz",
-      "integrity": "sha512-v11rJYYISUWn+s8qZzgGnBvlzRKf3bOtlGFM8H0kw56lGQtOmLuLCzuclA5kehA2j7S5sioOWdI4woT3jDavAw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
       "dependencies": {
         "chalk": "^4.0.0",
         "commander": "^5.1.0",
@@ -15670,9 +15670,9 @@
       "dev": true
     },
     "find-process": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.5.tgz",
-      "integrity": "sha512-v11rJYYISUWn+s8qZzgGnBvlzRKf3bOtlGFM8H0kw56lGQtOmLuLCzuclA5kehA2j7S5sioOWdI4woT3jDavAw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
       "requires": {
         "chalk": "^4.0.0",
         "commander": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -453,7 +453,7 @@
     "yargs": "^16.2.0"
   },
   "dependencies": {
-    "find-process": "^1.4.4",
+    "find-process": "^1.4.7",
     "glob": "^7.1.7",
     "n-readlines": "^1.0.1",
     "nearley": "^2.20.1",


### PR DESCRIPTION
[AB#2590007](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2590007): VS Code fails to install on Win 11 insider rings - Update to `find-process` 1.4.7 for Win 11 deprecation of WMIC

Windows 11 insider builds have removed WMIC, which is used by the `find-process` v1.4.4 package as part of the upgrade/installation pathway.  Thus, installation of the VS Code extension fails on those insider builds.

The `find-process` package already [found and fixed this issue on v1.4.7](https://github.com/yibn2008/find-process/pull/52/files), thus updating here resolves the installation failure.