### PR TITLE
Fixing formatting of release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Installing this extension will also make the latest Power Platform CLI (aka pac)
 0.2.31:
  - pac CLI 1.11.6 (Dec/Jan refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
  - fixed installation issue for Windows 11 Insider builds due to deprecation of WMIC
+
 0.2.27:
  - pac CLI 1.10.4 (November refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
   - .NET 6 on Apple M1: pac CLI is targeting dotnetCore 5 for intel, but the .NET6 amd64 installer removes the net5 and x64 support.  Users who have installed .NET 6 will need to uninstall all existing .NET bits and then install **both** the amd64 (Apple M1) and the x64 .NET 6 SDKs side by side.


### PR DESCRIPTION
Missing newline in the release notes causes MD to cause the lines to run together 