### PR TITLE
Update PAC and release notes for Feb release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Installing this extension will also make the latest Power Platform CLI (aka pac)
 ![VSCode Terminal with pac CLI](https://github.com/microsoft/powerplatform-vscode/blob/main/src/client/assets/pac-CLI-in-terminal.png?raw=true)
 
 ## Release Notes
+0.2.33:
+ - pac CLI 1.12.1 (February refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
+
 0.2.32:
  - pac CLI 1.11.8 (Fixes a regression in `pac solution check`)
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -218,7 +218,7 @@ async function snapshot() {
         process.chdir(orgDir);
     }
 }
-const cliVersion = '1.11.8';
+const cliVersion = '1.12.1';
 
 const recompile = gulp.series(
     clean,

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -42,9 +42,11 @@ The second line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newDatave
     </trans-unit>
     <trans-unit id="pacCLI.authPanel.welcome.whenInteractiveNotSupported">
       <source xml:lang="en">No auth profiles found on this computer.
+Interactive Authentication is not availalbe for remote scenarios; auth profiles must be created by the command line.  The `--deviceCode` flow must be used for users with MFA requirements, or whose tenants use ADFS.
 [View Auth Profile Help](command:pacCLI.pacAuthHelp)</source>
       <note>This is a Markdown formatted string, and the formatting must persist across translations.
-The second line should be '[TRANSLATION HERE](command:pacCLI.pacAuthHelp)', keeping brackets and the text in the parentheses unmodified</note>
+The second line should not translate the argument `--deviceCode`
+The third line should be '[TRANSLATION HERE](command:pacCLI.pacAuthHelp)', keeping brackets and the text in the parentheses unmodified</note>
     </trans-unit>
     <trans-unit id="pacCLI.authPanel.clearAuthProfile.title">
       <source xml:lang="en">Clear Auth Profiles</source>

--- a/package.nls.json
+++ b/package.nls.json
@@ -20,10 +20,12 @@
     ]
   },
   "pacCLI.authPanel.welcome.whenInteractiveNotSupported": {
-    "message": "No auth profiles found on this computer.\n[View Auth Profile Help](command:pacCLI.pacAuthHelp)",
+    "message": "No auth profiles found on this computer.\nInteractive Authentication is not availalbe for remote scenarios; auth profiles must be created by the command line.  The `--deviceCode` flow must be used for users with MFA requirements, or whose tenants use ADFS.\n[View Auth Profile Help](command:pacCLI.pacAuthHelp)",
     "comment": [
       "This is a Markdown formatted string, and the formatting must persist across translations.",
-      "The second line should be '[TRANSLATION HERE](command:pacCLI.pacAuthHelp)', keeping brackets and the text in the parentheses unmodified"
+      "The second line should not translate the argument `--deviceCode`",
+      "The third line should be '[TRANSLATION HERE](command:pacCLI.pacAuthHelp)', keeping brackets and the text in the parentheses unmodified"
+      
    ]
   },
   "pacCLI.authPanel.clearAuthProfile.title": "Clear Auth Profiles",


### PR DESCRIPTION
Update PAC and release notes for Feb release, and inform non-WSL remote users to use the `--deviceCode` auth flow when necessary

[AB#2588409](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2588409): Inform CodeSpaces/Remote users to use Device Code flow