### PR TITLE
Update Auth Name validation to match PAC

### DIFF
--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -149,7 +149,7 @@ The third line should be '[TRANSLATION HERE](command:pacCLI.pacAuthHelp)', keepi
       <source xml:lang="en">The name you want to give to this authentication profile</source>
     </trans-unit>
     <trans-unit id="pacCLI.authPanel.nameAuthProfile.validation">
-      <source xml:lang="en">Maximum 12 characters allowed</source>
+      <source xml:lang="en">Maximum 30 characters allowed</source>
     </trans-unit>
   </body></file>
   <file original="./client/lib/PacTerminal" source-language="en" datatype="plaintext"><body>

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -69,7 +69,7 @@ export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
             const authProfileName = await vscode.window.showInputBox({
                 title: localize("pacCLI.authPanel.nameAuthProfile.title", "Name/Rename Auth Profile"),
                 prompt: localize("pacCLI.authPanel.nameAuthProfile.prompt", "The name you want to give to this authentication profile"),
-                validateInput: value => value.length <= 12 ? null : localize("pacCLI.authPanel.nameAuthProfile.validation", 'Maximum 12 characters allowed')
+                validateInput: value => value.length <= 30 ? null : localize("pacCLI.authPanel.nameAuthProfile.validation", 'Maximum 30 characters allowed')
             });
             if (authProfileName) {
                 await pacWrapper.authNameByIndex(item.model.Index, authProfileName);


### PR DESCRIPTION
PAC side validation allows for 30 character max, though its error message also claims it to be 12 characters.  
Fix for that side in ADO side PR.

[AB#2724005](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2724005) and #198 -  AuthProfile name argument validation differs in PAC and VS Code