### PR TITLE
Switch Interactive Auth to DeviceCode in CodeSpaces and non-WSL Remote scenarios

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -41,6 +41,9 @@ export async function activate(
         // as the extension (i.e. NOT remote), or the remote is WSL
         vscode.commands.executeCommand('setContext', 'pacCLI.authPanel.interactiveLoginSupported', true);
     }
+    else {
+        _context.environmentVariableCollection.replace('PAC_CLI_INTERACTIVE_AUTH_NOT_AVAILABLE','true');
+    }
 
     vscode.workspace.onDidOpenTextDocument(didOpenTextDocument);
     vscode.workspace.textDocuments.forEach(didOpenTextDocument);


### PR DESCRIPTION
AB#2694410

When the user is running PAC in a remote scenario such as CodeSpaces or SSH (but _not_ WSL remoting), we cannot use Interactive Auth, as the `localhost` of the machine running PAC is not the same `localhost` as the machine running the browser.

For these scenarios, the user can just use `--deviceCode`.  If they don't supply that arg however, they end in a state that can never return control back to the user, as PAC is waiting for redirect that will never come.

This change sets an Environment Variable in those cases, which PAC uses to default in the device code flow instead of Interactive.