### PR TITLE
Include DOM.Iterable to support .entries

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "sourceMap": true,
     "outDir": "out",
     "rootDir": "src",
-    "lib": [ "es2019", "WebWorker" ],
+    "lib": [ "es2019", "WebWorker", "DOM.Iterable" ],
     "noImplicitAny": true,
     "strictPropertyInitialization": true,
 		"strict": true,


### PR DESCRIPTION
Fixes a build issue caused by missing `.entries` method for lists used in /web/client/extension

> [09:27:06] Error in plugin "webpack-stream"
Message:
    [tsl] ERROR in D:\a\powerplatform-vscode\powerplatform-vscode\src\web\client\extension.ts(43,56)
      TS2339: Property 'entries' does not exist on type 'URLSearchParams'.

<img width="671" alt="image" src="https://user-images.githubusercontent.com/10966969/178246523-2f796ea7-d251-4575-aa9b-f66b6419a6ce.png">
