### PR TITLE
PR Build Updates - Include Ubuntu, and disable fail-fast

### DIFF
--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-latest, macos-latest ]
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, macos-latest ]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Including Ubuntu builds, as the extension is now being used more frequently in CodeSpaces and WSL scenarios.
Disabling `fail-fast`, so that any issues specific to one OS are clearer, instead of stopping the other OSs' build and test loops early.