### PR TITLE
removed on language activation events and switched to a more specific event

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "onCommand:pacCLI.openDocumentation",
     "onCommand:microsoft-powerapps-portals.webExtension.init",
     "onStartupFinished",
-    "onLanguage:yaml",
-    "onLanguage:html",
+    "workspaceContains:**/**dynamics.com-manifest.yml",
     "onDebug"
   ],
   "capabilities": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "onCommand:pacCLI.openDocumentation",
     "onCommand:microsoft-powerapps-portals.webExtension.init",
     "onStartupFinished",
-    "workspaceContains:**/**dynamics.com-manifest.yml",
+    "workspaceContains:**/**.portalconfig",
     "onDebug"
   ],
   "capabilities": {


### PR DESCRIPTION
Reason for this change is captured in the GitHub Issue: [228](https://github.com/microsoft/powerplatform-vscode/issues/228)

Though at the moment the extension gets activated on a variety of events...but if we remove other activation events the extension will be activated when:
Workspace contains a file/folder ending with .portalconfig at any level of depth.

Tested with this change (and removing other activation events):

![image](https://user-images.githubusercontent.com/908570/185486606-3596aa13-4118-4150-98c6-1d94c7c28360.png)
