### PR TITLE
Localization fix for web extension

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,13 +85,6 @@ const webConfig = {
 			test: /\.ts$/,
 			exclude: /node_modules/,
 			use: [{
-                // vscode-nls-dev loader:
-                // * rewrite nls-calls
-                loader: 'vscode-nls-dev/lib/webpack-loader',
-                options: {
-                    base: __dirname
-                }
-            },{
 				loader: 'ts-loader'
 			}]
 		}]


### PR DESCRIPTION
Due to the current limitation of vscode.dev - localization of external string does not work in the web extension. 

More details here: https://github.com/microsoft/vscode/issues/82595

This feature is expected to be available in September 2022

Temporary fix is to avoid the web extension from breaking is to offload nls loader from webconfig

Requirements: https://github.com/microsoft/vscode-dev/issues/477

Testing: 

![image](https://user-images.githubusercontent.com/5424608/186052864-cfdf90a3-e6e4-4f50-9816-c890d7d64fda.png)
