### PR TITLE
CSS mimetype update - studio runtime fix

### DIFF
--- a/src/web/client/common/constants.ts
+++ b/src/web/client/common/constants.ts
@@ -30,6 +30,7 @@ export const SCOPE_OPTION = "//.default";
 export const BAD_REQUEST = 'BAD_REQUEST';
 export const PUBLIC = 'public';
 export const SITE_VISIBILITY = 'siteVisibility';
+export const MIMETYPE = 'mimetype';
 
 export enum httpMethod {
     PATCH = 'PATCH',
@@ -76,6 +77,7 @@ export enum exportType {
     SingleFile = "SingleFile"
 }
 
+// Entity attributes that need to be saved in base64 encoding - example documentBody
 export enum entityAttributesWithBase64Encoding {
     documentbody = "documentbody"
 }

--- a/src/web/client/common/constants.ts
+++ b/src/web/client/common/constants.ts
@@ -76,6 +76,10 @@ export enum exportType {
     SingleFile = "SingleFile"
 }
 
+export enum entityAttributesWithBase64Encoding {
+    documentbody = "documentbody"
+}
+
 export const columnExtension = new Map([
     ["customcss.css", "adx_customcss"],
     ["customjs.js", "adx_customjavascript"],

--- a/src/web/client/common/portalSchema.ts
+++ b/src/web/client/common/portalSchema.ts
@@ -771,8 +771,8 @@ export const portal_schema_data = {
                 "_foldername": "web-files",
                 "_propextension": "webfile",
                 "_exporttype": "SingleFolder",
-                "_fetchQueryParameters": "?$filter=_objectid_value%20eq%20{entityId}%20&$select=documentbody,filename,annotationid",
-                "_attributes": "documentbody",
+                "_fetchQueryParameters": "?$filter=_objectid_value%20eq%20{entityId}%20&$select=mimetype,documentbody,filename,annotationid",
+                "_attributes": "mimetype,documentbody",
                 "_mappingEntityId": "annotationid" // Webfile in old schema are maintained with two dataverse entity adx_webfile and annotations. This Id acts as foreign key for that mapping
             },
             {

--- a/src/web/client/common/portalSchema.ts
+++ b/src/web/client/common/portalSchema.ts
@@ -772,7 +772,7 @@ export const portal_schema_data = {
                 "_propextension": "webfile",
                 "_exporttype": "SingleFolder",
                 "_fetchQueryParameters": "?$filter=_objectid_value%20eq%20{entityId}%20&$select=mimetype,documentbody,filename,annotationid",
-                "_attributes": "mimetype,documentbody",
+                "_attributes": "documentbody",
                 "_mappingEntityId": "annotationid" // Webfile in old schema are maintained with two dataverse entity adx_webfile and annotations. This Id acts as foreign key for that mapping
             },
             {

--- a/src/web/client/common/portalSchemaInterface.ts
+++ b/src/web/client/common/portalSchemaInterface.ts
@@ -37,22 +37,26 @@ export interface ISaveEntityDetails {
     readonly entityName: string,
     readonly entityId: string,
     readonly saveAttribute: string,
-    readonly useBase64Encoding: boolean;
+    readonly useBase64Encoding?: boolean;
+    readonly mimeType?: string;
 }
 
 export class SaveEntityDetails implements ISaveEntityDetails {
     entityName!: string;
     entityId!: string;
     saveAttribute!: string;
-    useBase64Encoding!: boolean;
+    useBase64Encoding: boolean | undefined;
+    mimeType: string | undefined;
     public get getEntityName(): string { return this.entityName; }
     public get getEntityId(): string { return this.entityId; }
     public get getSaveAttribute(): string { return this.saveAttribute }
-    public get getUseBase64Encoding(): boolean { return this.useBase64Encoding }
-    constructor(entityId: string, entityName: string, saveAttribute: string, useBase64Encoding: boolean) {
+    public get getUseBase64Encoding(): boolean | undefined { return this.useBase64Encoding }
+    public get getMimeType(): string | undefined { return this.mimeType }
+    constructor(entityId: string, entityName: string, saveAttribute: string, useBase64Encoding?: boolean, mimeType?: string) {
         this.entityId = entityId;
         this.entityName = entityName;
         this.saveAttribute = saveAttribute;
         this.useBase64Encoding = useBase64Encoding;
+        this.mimeType = mimeType;
     }
 }

--- a/src/web/client/common/portalSchemaInterface.ts
+++ b/src/web/client/common/portalSchemaInterface.ts
@@ -36,19 +36,23 @@ export interface WebsiteDetails {
 export interface ISaveEntityDetails {
     readonly entityName: string,
     readonly entityId: string,
-    readonly saveAttribute: string
+    readonly saveAttribute: string,
+    readonly useBase64Encoding: boolean;
 }
 
 export class SaveEntityDetails implements ISaveEntityDetails {
     entityName!: string;
     entityId!: string;
     saveAttribute!: string;
+    useBase64Encoding!: boolean;
     public get getEntityName(): string { return this.entityName; }
     public get getEntityId(): string { return this.entityId; }
     public get getSaveAttribute(): string { return this.saveAttribute }
-    constructor(entityId: string, entityName: string, saveAttribute: string) {
+    public get getUseBase64Encoding(): boolean { return this.useBase64Encoding }
+    constructor(entityId: string, entityName: string, saveAttribute: string, useBase64Encoding: boolean) {
         this.entityId = entityId;
         this.entityName = entityName;
         this.saveAttribute = saveAttribute;
+        this.useBase64Encoding = useBase64Encoding;
     }
 }

--- a/src/web/client/common/remoteFetchProvider.ts
+++ b/src/web/client/common/remoteFetchProvider.ts
@@ -101,7 +101,6 @@ function createContentFiles(
     const exportType = entityEntry?.get('_exporttype');
     const portalFolderName = queryParamsMap.get(Constants.WEBSITE_NAME) as string;
     const subUri = Constants.entityFolder.get(entity) as string;
-    const useBase64Encoding = useBase64(entity);
     let languageCode: string = Constants.DEFAULT_LANGUAGE_CODE;
 
     if (languageIdCodeMap?.size && lcid) {
@@ -140,6 +139,7 @@ function createContentFiles(
 
         let fileUri = '';
         for (counter; counter < attributeArray.length; counter++) {
+            const useBase64Encoding = useBase64(entity, attributeArray[counter]);
             const value = result[attributeArray[counter]] ? result[attributeArray[counter]] : Constants.NO_CONTENT;
             const fileNameWithExtension = GetFileNameWithExtension(entity,
                 fileName,
@@ -153,13 +153,14 @@ function createContentFiles(
                 useBase64Encoding ? fromBase64(value) : value,
                 updateEntityId(entity, entityId, entitiesSchemaMap, result),
                 attributeArray[counter] as string,
+                useBase64Encoding,
                 entity);
         }
 
         // Display only the last file
         vscode.window.showTextDocument(vscode.Uri.parse(fileUri));
     }
-    registerSaveProvider(accessToken, portalsFS, dataverseOrgUrl, saveDataMap, useBase64Encoding);
+    registerSaveProvider(accessToken, portalsFS, dataverseOrgUrl, saveDataMap);
 }
 
 function createVirtualFile(
@@ -168,9 +169,10 @@ function createVirtualFile(
     data: string | undefined,
     entityId: string,
     saveDataAtribute: string,
+    useBase64Encoding: boolean,
     entity: string
 ) {
-    const saveEntityDetails = new SaveEntityDetails(entityId, entity, saveDataAtribute);
+    const saveEntityDetails = new SaveEntityDetails(entityId, entity, saveDataAtribute, useBase64Encoding);
 
     portalsFS.writeFile(vscode.Uri.parse(fileUri), new TextEncoder().encode(data), { create: true, overwrite: true });
     saveDataMap.set(vscode.Uri.parse(fileUri).fsPath, saveEntityDetails);

--- a/src/web/client/common/remoteFetchProvider.ts
+++ b/src/web/client/common/remoteFetchProvider.ts
@@ -154,7 +154,8 @@ function createContentFiles(
                 updateEntityId(entity, entityId, entitiesSchemaMap, result),
                 attributeArray[counter] as string,
                 useBase64Encoding,
-                entity);
+                entity,
+                result[Constants.MIMETYPE]);
         }
 
         // Display only the last file
@@ -168,11 +169,12 @@ function createVirtualFile(
     fileUri: string,
     data: string | undefined,
     entityId: string,
-    saveDataAtribute: string,
+    saveDataAttribute: string,
     useBase64Encoding: boolean,
-    entity: string
+    entity: string,
+    mimeType?: string
 ) {
-    const saveEntityDetails = new SaveEntityDetails(entityId, entity, saveDataAtribute, useBase64Encoding);
+    const saveEntityDetails = new SaveEntityDetails(entityId, entity, saveDataAttribute, useBase64Encoding, mimeType);
 
     portalsFS.writeFile(vscode.Uri.parse(fileUri), new TextEncoder().encode(data), { create: true, overwrite: true });
     saveDataMap.set(vscode.Uri.parse(fileUri).fsPath, saveEntityDetails);

--- a/src/web/client/common/remoteSaveProvider.ts
+++ b/src/web/client/common/remoteSaveProvider.ts
@@ -8,7 +8,7 @@ import { sendAPIFailureTelemetry, sendAPITelemetry } from '../telemetry/webExten
 import { toBase64 } from '../utility/CommonUtility';
 import { getRequestURL } from '../utility/UrlBuilder';
 import { getHeader } from './authenticationProvider';
-import { BAD_REQUEST, CHARSET, httpMethod } from './constants';
+import { BAD_REQUEST, CHARSET, httpMethod, MIMETYPE } from './constants';
 import { showErrorDialog } from './errorHandler';
 import { PortalsFS } from './fileSystemProvider';
 import { entitiesSchemaMap } from './localStore';
@@ -52,14 +52,17 @@ export async function saveData(
     saveDataMap: Map<string, SaveEntityDetails>,
     value: string
 ) {
-    console.log(saveDataMap);
     let requestBody = '';
     const column = saveDataMap.get(fileUri.fsPath)?.getSaveAttribute;
 
     if (column) {
         const data: { [k: string]: string } = {};
         data[column] = value;
-        data['filename'] = 'customname.css';
+
+        const mimeType = saveDataMap.get(fileUri.fsPath)?.getMimeType;
+        if (mimeType) {
+            data[MIMETYPE] = mimeType
+        }
         requestBody = JSON.stringify(data);
     } else {
         sendAPIFailureTelemetry(requestUrl, 0, BAD_REQUEST); // no API request is made in this case since we do not know in which column should we save the value

--- a/src/web/client/common/remoteSaveProvider.ts
+++ b/src/web/client/common/remoteSaveProvider.ts
@@ -21,8 +21,7 @@ export function registerSaveProvider(
     accessToken: string,
     portalsFS: PortalsFS,
     dataVerseOrgUrl: string,
-    saveDataMap: Map<string, SaveEntityDetails>,
-    useBase64Encoding: boolean
+    saveDataMap: Map<string, SaveEntityDetails>
 ) {
     vscode.workspace.onDidSaveTextDocument(async (document) => {
         if (document?.uri?.fsPath) {
@@ -31,7 +30,7 @@ export function registerSaveProvider(
             const newFileData = portalsFS.readFile(document.uri);
             let stringDecodedValue = new TextDecoder(CHARSET).decode(newFileData);
 
-            if (useBase64Encoding) {
+            if (saveDataMap.get(document.uri.fsPath)?.getUseBase64Encoding as boolean) {
                 stringDecodedValue = toBase64(stringDecodedValue);
             }
 
@@ -53,12 +52,14 @@ export async function saveData(
     saveDataMap: Map<string, SaveEntityDetails>,
     value: string
 ) {
+    console.log(saveDataMap);
     let requestBody = '';
     const column = saveDataMap.get(fileUri.fsPath)?.getSaveAttribute;
 
     if (column) {
         const data: { [k: string]: string } = {};
         data[column] = value;
+        data['filename'] = 'customname.css';
         requestBody = JSON.stringify(data);
     } else {
         sendAPIFailureTelemetry(requestUrl, 0, BAD_REQUEST); // no API request is made in this case since we do not know in which column should we save the value

--- a/src/web/client/utility/CommonUtility.ts
+++ b/src/web/client/utility/CommonUtility.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-import { dataverseUrlPathEntityName } from "../common/constants";
+import { dataverseUrlPathEntityName, entityAttributesWithBase64Encoding } from "../common/constants";
 
 // decodes base64 to text
 export function fromBase64(data: string) {
@@ -15,8 +15,8 @@ export function toBase64(data: string) {
     return btoa(unescape(encodeURIComponent(data)));
 }
 
-export function useBase64(entity: string): boolean {
-    return entity === dataverseUrlPathEntityName.WEBFILES;
+export function useBase64(entity: string, attributeType: string): boolean {
+    return entity === dataverseUrlPathEntityName.WEBFILES && attributeType === entityAttributesWithBase64Encoding.documentbody;
 }
 
 export function GetFileNameWithExtension(


### PR DESCRIPTION
We need to write mimetype for css files as they are base64 encoded and dataverse overwirtes mimetype in these cases. This will fix css load in portals runtime.