### PR TITLE
Use node 16.x in official builds, as our Contributing.md already requires

### DIFF
--- a/.azure-pipelines/OfficialBuild.yml
+++ b/.azure-pipelines/OfficialBuild.yml
@@ -34,9 +34,9 @@ steps:
   displayName: Capture build version in package/version.csv
 
 - task: NodeTool@0
-  displayName: 'Use nodejs 14.x'
+  displayName: 'Use nodejs 16.x'
   inputs:
-    versionSpec: '14.x'
+    versionSpec: '16.x'
 
 - task: Npm@1
   displayName: 'Restore (npm install)'


### PR DESCRIPTION
Contributing.md mentions the Node 16.x requirement, but the official build was using 14.
16+ is required for the `npm pkg set` commands in the `packageVSIX` gulp task.

[AB#3010171](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/3010171)