### PR TITLE
update to ESRP@2 to fix build break due to missing .net runtime

### DIFF
--- a/.azure-pipelines/OfficialBuild.yml
+++ b/.azure-pipelines/OfficialBuild.yml
@@ -76,7 +76,7 @@ steps:
 
 # https://microsoft.sharepoint.com/teams/prss/esrp/info/ESRP%20Onboarding%20Wiki/Generating%20Signing%20JSON.aspx
 # https://microsoft.sharepoint.com/teams/prss/esrp/info/ESRP%20Onboarding%20Wiki/Selecting%20CodeSign%20Certificates.aspx
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   displayName: 'ESRP sign vsix packages'
   inputs:
     ConnectedServiceName: ESRPCodeSigningConnection


### PR DESCRIPTION
The latest build agent update in AzDevOps no longer contains .netcore2 which was the required runtime for ESRP@1
A recent ESRP v2 release added support for .net6
https://aka.ms/esrp.signtask

validated in rel/stable for 1.1.9
https://dev.azure.com/dynamicscrm/OneCRM/_build/results?buildId=10820039&view=results

cherry pick of commit bfdd9cd in rel/stable