### PR TITLE
POC - New localization API - supports localization in Web extension

### DIFF
--- a/l10n-sample.xlf
+++ b/l10n-sample.xlf
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="bundle" source-language="en" datatype="plaintext"><body>
+    <trans-unit id="++CODE++bf27ec2e917b9f2578f8e6372f8656370d24cffe2c5a7b900d0b3280f8ec69fb">
+      <source xml:lang="en">Be careful making changes. Anyone can see the changes you make immediately. Choose Edit the site to make edits, or close the editor tab to cancel without editing.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++ac72407b10d30bf47faf11da09b605a85fc649bd3f2e33acb281655cb9021d9d">
+      <source xml:lang="en">Edit the site</source>
+    </trans-unit>
+    <trans-unit id="++CODE++3c65297a1fc0860c6993f5c8beb4341dd13b71d7f3957daba611adf04a6c971b">
+      <source xml:lang="en">You are editing a live, public site </source>
+    </trans-unit>
+  </body></file>
+  <file original="package" source-language="en" datatype="plaintext"><body>
+    <trans-unit id="microsoft-powerapps-portals.walkthrough.advancedCapabilities.title">
+      <source xml:lang="en">Advanced capabilities</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.title">
+      <source xml:lang="en">Auth Profiles</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.clearAuthProfile.title">
+      <source xml:lang="en">Clear Auth Profiles</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.copyDisplayName.title">
+      <source xml:lang="en">Copy Display Name</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.copyEnvironmentId.title">
+      <source xml:lang="en">Copy Environment Id</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.copyEnvironmentUrl.title">
+      <source xml:lang="en">Copy Environment Url</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.copyFriendlyName.title">
+      <source xml:lang="en">Copy Friendly Name</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.copyOrganizationId.title">
+      <source xml:lang="en">Copy Organization Id</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.copyUniqueName.title">
+      <source xml:lang="en">Copy Unique Name</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.copyUser.title">
+      <source xml:lang="en">Copy User</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.copyVersionNumber.title">
+      <source xml:lang="en">Copy Version Number</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.deleteAuthProfile.title">
+      <source xml:lang="en">Delete Auth Profile</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.disableTelemetry.title">
+      <source xml:lang="en">Disable PAC Telemetry</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.walkthrough.description">
+      <source xml:lang="en">Discover how you can make complete, modern websites right in VS Code</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.openDocumentation.title">
+      <source xml:lang="en">Documentation</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.walkthrough.title">
+      <source xml:lang="en">Edit Power Pages code</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.enableTelemetry.title">
+      <source xml:lang="en">Enable PAC telemetry</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.title">
+      <source xml:lang="en">Environments &amp; Solutions</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.walkthrough.fileSystem.title">
+      <source xml:lang="en">File system</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.webExtension.init.title">
+      <source xml:lang="en">Initialize Web Extension</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.nameAuthProfile.title">
+      <source xml:lang="en">Name/Rename Auth Profile</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.navigateToResource.title">
+      <source xml:lang="en">Navigate to Resource</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.newDataverseAuthProfile.title">
+      <source xml:lang="en">New Auth Profile</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.welcome.whenInteractiveNotSupported">
+      <source xml:lang="en">No auth profiles found on this computer.
+Interactive Authentication is not availalbe for remote scenarios; auth profiles must be created by the command line.  The `--deviceCode` flow must be used for users with MFA requirements, or whose tenants use ADFS.
+[View Auth Profile Help](command:pacCLI.pacAuthHelp)</source>
+      <note>This is a Markdown formatted string, and the formatting must persist across translations.
+The second line should not translate the argument `--deviceCode`
+The third line should be &apos;[TRANSLATION HERE](command:pacCLI.pacAuthHelp)&apos;, keeping brackets and the text in the parentheses unmodified</note>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.welcome.whenInteractiveSupported">
+      <source xml:lang="en">No auth profiles found on this computer.
+[Add Auth Profile](command:pacCLI.authPanel.newAuthProfile)</source>
+      <note>This is a Markdown formatted string, and the formatting must persist across translations.
+The second line should be &apos;[TRANSLATION HERE](command:pacCLI.authPanel.newAuthProfile)&apos;, keeping brackets and the text in the parentheses unmodified</note>
+    </trans-unit>
+    <trans-unit id="pacCLI.openPacLab.title">
+      <source xml:lang="en">Open PAC Lab</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.walkthrough.overview.title">
+      <source xml:lang="en">Overview</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.webExtension.limitation">
+      <source xml:lang="en">PAC CLI is not supported in VS Code for the Web</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.walkthrough.overview.description">
+      <source xml:lang="en">Power Pages extension enables a customized file system which is synced with the project structure of the Power Pages studio.
+[Learn More](command:powerplatform-walkthrough.overview-learn-more)</source>
+      <note>This is a Markdown formatted string, and the formatting must persist across translations.
+The second line should be &apos;[TRANSLATION HERE](command:powerplatform-walkthrough.overview-learn-more)&apos;, keeping brackets and the text in the parentheses unmodified</note>
+    </trans-unit>
+    <trans-unit id="power-platform-activitybar.title">
+      <source xml:lang="en">Power Platform</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.preview-show.title">
+      <source xml:lang="en">PowerApps Portal -&gt; Show preview</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.envAndSolutionsPanel.refresh.title">
+      <source xml:lang="en">Refresh</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.refresh.title">
+      <source xml:lang="en">Refresh</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.authPanel.selectAuthProfile.title">
+      <source xml:lang="en">Select Auth Profile</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.pacAuthHelp.title">
+      <source xml:lang="en">Show PAC Authentication Help</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.pacHelp.title">
+      <source xml:lang="en">Show PAC Help</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.pacPcfHelp.title">
+      <source xml:lang="en">Show PAC PCF Help</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.pacPackageHelp.title">
+      <source xml:lang="en">Show PAC Package Help</source>
+    </trans-unit>
+    <trans-unit id="pacCLI.pacSolutionHelp.title">
+      <source xml:lang="en">Show PAC Solution Help</source>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.walkthrough.advancedCapabilities.description">
+      <source xml:lang="en">Visual Studio Code for Web enables editing and publishing of web pages on your website.
+ 
+ For a command line interface and more advanced capabilities, install the Power Platform Extension for VS Code, available in the VS Code Marketplace for desktop. 
+ 
+ [Learn More](command:powerplatform-walkthrough.advancedCapabilities-learn-more) about the difference between Visual Studio Code for desktop and web.
+ 
+[Start coding](command:powerplatform-walkthrough.advancedCapabilities-start-coding)</source>
+      <note>This is a Markdown formatted string, and the formatting must persist across translations.
+The fifth line should be &apos;[TRANSLATION HERE](command:powerplatform-walkthrough.advancedCapabilities-learn-more) TRANSLATION&apos;, keeping brackets and the text in the parentheses unmodified
+The seventh line should be &apos;[TRANSLATION HERE](command:powerplatform-walkthrough.advancedCapabilities-start-coding)&apos;, keeping brackets and the text in the parentheses unmodified</note>
+    </trans-unit>
+    <trans-unit id="microsoft-powerapps-portals.walkthrough.fileSystem.description">
+      <source xml:lang="en">Your files are stored in nested folders under your site name. 
+ 
+ The individual page files can be found in the web-pages folder under your site name. 
+ 
+ All of your pages are arranged into HTML, CSS and JS files inside the folder with the respective page name. 
+ 
+ To learn more about the Power Pages file system in VS Code for Web, visit our [documentation](command:powerplatform-walkthrough.fileSystem-documentation). 
+[Open site folder](command:powerplatform-walkthrough.fileSystem-open-folder)</source>
+      <note>This is a Markdown formatted string, and the formatting must persist across translations.
+The seventh line should be &apos;[TRANSLATION HERE](command:powerplatform-walkthrough.fileSystem-documentation).&apos;, keeping brackets and the text in the parentheses unmodified
+The eighth line should be &apos;[TRANSLATION HERE](command:powerplatform-walkthrough.fileSystem-open-folder)&apos;, keeping brackets and the text in the parentheses unmodified</note>
+    </trans-unit>
+  </body></file>
+</xliff>

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -1,0 +1,5 @@
+{
+  "Edit the site": "Edit the site - jp",
+  "Be careful making changes. Anyone can see the changes you make immediately. Choose Edit the site to make edits, or close the editor tab to cancel without editing.": "JP - Be careful making changes. Anyone can see the changes you make immediately. Choose Edit the site to make edits, or close the editor tab to cancel without editing.",
+  "You are editing a live, public site ": "JP - You are editing a live, public site "
+}

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -1,0 +1,5 @@
+{
+  "Edit the site": "Edit the site",
+  "Be careful making changes. Anyone can see the changes you make immediately. Choose Edit the site to make edits, or close the editor tab to cancel without editing.": "Be careful making changes. Anyone can see the changes you make immediately. Choose Edit the site to make edits, or close the editor tab to cancel without editing.",
+  "You are editing a live, public site ": "You are editing a live, public site "
+}

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -244,15 +244,6 @@ The {2} represents Solution's Version number</note>
     </trans-unit>
   </body></file>
   <file original="./web/client/extension" source-language="en" datatype="plaintext"><body>
-    <trans-unit id="microsoft-powerapps-portals.webExtension.init.sitevisibility.edit">
-      <source xml:lang="en">Edit the site</source>
-    </trans-unit>
-    <trans-unit id="microsoft-powerapps-portals.webExtension.init.sitevisibility.edit.desc">
-      <source xml:lang="en">Be careful making changes. Anyone can see the changes you make immediately. Choose Edit the site to make edits, or close the editor tab to cancel without editing.</source>
-    </trans-unit>
-    <trans-unit id="microsoft-powerapps-portals.webExtension.init.sitevisibility.edit.title">
-      <source xml:lang="en">You are editing a live, public site </source>
-    </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.webExtension.init.app-not-found">
       <source xml:lang="en">Unable to find that app</source>
     </trans-unit>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/sinon": "^10.0.12",
         "@types/unzip-stream": "^0.3.0",
         "@types/uuid": "^8.3.0",
-        "@types/vscode": "^1.72.0",
+        "@types/vscode": "^1.73.0",
         "@types/webpack": "^5.28.0",
         "@types/webpack-env": "^1.17.0",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
@@ -72,7 +72,7 @@
         "yargs": "^16.2.0"
       },
       "engines": {
-        "vscode": "^1.72.0"
+        "vscode": "^1.73.0"
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.6",
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
-      "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==",
+      "version": "1.73.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
+      "integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
       "dev": true
     },
     "node_modules/@types/webpack": {
@@ -13141,9 +13141,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
-      "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==",
+      "version": "1.73.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
+      "integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
       "dev": true
     },
     "@types/webpack": {
@@ -21026,9 +21026,9 @@
       }
     },
     "terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
+      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "email": "PPTools@microsoft.com"
   },
   "engines": {
-    "vscode": "^1.72.0"
+    "vscode": "^1.73.0"
   },
   "extensionKind": [
     "workspace"
@@ -41,6 +41,7 @@
   "publisher": "microsoft-IsvExpTools",
   "main": "./dist/extension",
   "browser": "./dist/web/extension.js",
+  "l10n": "./l10n",
   "categories": [
     "Snippets",
     "Other"
@@ -723,7 +724,7 @@
     "@types/sinon": "^10.0.12",
     "@types/unzip-stream": "^0.3.0",
     "@types/uuid": "^8.3.0",
-    "@types/vscode": "^1.72.0",
+    "@types/vscode": "^1.73.0",
     "@types/webpack": "^5.28.0",
     "@types/webpack-env": "^1.17.0",
     "@typescript-eslint/eslint-plugin": "^5.15.0",

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -50,10 +50,10 @@ export function activate(context: vscode.ExtensionContext): void {
                 sendExtensionInitPathParametersTelemetry(appName, entity, entityId);
 
                 if (queryParamsMap.get(SITE_VISIBILITY) === PUBLIC) {
-                    const edit: vscode.MessageItem = { isCloseAffordance: true, title: localize("microsoft-powerapps-portals.webExtension.init.sitevisibility.edit", "Edit the site") };
-                    const siteMessage = localize("microsoft-powerapps-portals.webExtension.init.sitevisibility.edit.desc", "Be careful making changes. Anyone can see the changes you make immediately. Choose Edit the site to make edits, or close the editor tab to cancel without editing.");
+                    const edit: vscode.MessageItem = { isCloseAffordance: true, title: vscode.l10n.t("Edit the site") };
+                    const siteMessage = vscode.l10n.t("Be careful making changes. Anyone can see the changes you make immediately. Choose Edit the site to make edits, or close the editor tab to cancel without editing.");
                     const options = { detail: siteMessage, modal: true };
-                    await vscode.window.showWarningMessage(localize("microsoft-powerapps-portals.webExtension.init.sitevisibility.edit.title", "You are editing a live, public site "), options, edit);
+                    await vscode.window.showWarningMessage(vscode.l10n.t("You are editing a live, public site "), options, edit);
                 }
 
                 if (appName) {


### PR DESCRIPTION
This PR is a PoC done using new localization API l10n (shipped as part of latest vscode package)  that supports localization for web extension. Below is a screenshot capturing it working on Webextension.  

![image](https://user-images.githubusercontent.com/6157891/202668862-c0d00234-d94c-49ed-b17a-90e7b5b9d7d4.png)

Useful link for this PoC are here: 
https://code.visualstudio.com/updates/v1_72#_localization-as-part-of-the-api
https://github.com/microsoft/vscode-extension-samples/tree/main/l10n-sample

NOTE: One gap that exist in the new localization file is that there was no way to introduce a key:string mapping for better readability. This is something we can investigate further, and follow up with VSCode team if needed. See comment below on bundle.l10n.json file.
