### PR TITLE
Web pages delete file scenario - single and multi file delete

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -23,6 +23,7 @@ import {
 import { readUserSettings } from "./telemetry/localfileusersettings";
 import { activateDebugger, deactivateDebugger, shouldEnableDebugger } from "../debugger";
 import { PORTAL_CRUD_OPERATION_SETTING_NAME, SETTINGS_EXPERIMENTAL_STORE_NAME } from "./constants";
+import { handleFileSystemCallbacks } from "./power-pages/fileSystemCallbacks";
 
 let client: LanguageClient;
 let _context: vscode.ExtensionContext;
@@ -110,6 +111,7 @@ export async function activate(
     const areCRUDoperationEnabled = vscode.workspace.getConfiguration(SETTINGS_EXPERIMENTAL_STORE_NAME).get(PORTAL_CRUD_OPERATION_SETTING_NAME);
     if (areCRUDoperationEnabled) {
         // Add CRUD related callback subscription here
+        await handleFileSystemCallbacks(_context);
     }
 
     const cli = new CliAcquisition(new CliAcquisitionContext(_context, _telemetry));

--- a/src/client/power-pages/commonUtility.ts
+++ b/src/client/power-pages/commonUtility.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from "vscode";
-import { EntityFolderMap, EntityFolderName, PowerPagesEntityType } from "./constants";
+import { ContentPages, EntityFolderMap, EntityFolderName, PowerPagesEntityType } from "./constants";
 
 export interface IFileProperties {
     fileCompleteName?: string,
@@ -51,7 +51,10 @@ export function getDeletePathUris(fsPath: string,
 ): vscode.Uri[] {
     const pathUris: vscode.Uri[] = [];
     const deletePathUri = vscode.Uri.file(fsPath.substring(0, fileProperties.fileNameIndex));
-    if (fileEntityType === PowerPagesEntityType.WEBPAGES && isValidUri(deletePathUri.fsPath)) {
+    if (fileEntityType === PowerPagesEntityType.WEBPAGES
+        && isValidUri(deletePathUri.fsPath)
+        && ContentPages !== fileProperties.fileName?.toLowerCase()
+    ) {
         pathUris.push(vscode.Uri.file(fsPath.substring(0, fileProperties.fileNameIndex)));
     }
 

--- a/src/client/power-pages/commonUtility.ts
+++ b/src/client/power-pages/commonUtility.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { EntityFolderMap, EntityFolderName, PowerPagesEntityType } from "./constants";
+
+export interface IFileProperties {
+    fileCompleteName?: string,
+    fileNameIndex?: number,
+    fileName?: string,
+    fileExtension?: string
+}
+
+export function getFileProperties(fsPath: string): IFileProperties {
+    const filePathTokens = fsPath.split("\\");
+    const fileCompleteName = filePathTokens.pop();
+    let fileNameIndex, fileName;
+
+    if (fileCompleteName) {
+        fileNameIndex = fsPath.indexOf(fileCompleteName);
+        fileName = fileCompleteName?.split('.').shift();
+    }
+
+    return {
+        fileCompleteName: fileCompleteName,
+        fileName: fileName,
+        fileExtension: '',
+        fileNameIndex: fileNameIndex
+    }
+}
+
+export function isValidDocument(fsPath: string): PowerPagesEntityType {
+    let pagesEntityType = PowerPagesEntityType.UNKNOWN;
+
+    EntityFolderName.forEach(folderName => {
+        folderName = folderName.toLowerCase();
+
+        if (fsPath.includes(`\\${folderName}\\`)) {
+            pagesEntityType = EntityFolderMap.get(folderName) ?? PowerPagesEntityType.UNKNOWN;
+        }
+    });
+
+    return pagesEntityType;
+}
+
+export function getDeletePathUris(fsPath: string,
+    fileEntityType: PowerPagesEntityType,
+    fileProperties: IFileProperties
+): vscode.Uri[] {
+    const pathUris: vscode.Uri[] = [];
+    if (fileEntityType === PowerPagesEntityType.WEBPAGES) {
+        pathUris.push(vscode.Uri.file(fsPath.substring(0, fileProperties.fileNameIndex)));
+    }
+
+    return pathUris;
+}
+
+
+

--- a/src/client/power-pages/commonUtility.ts
+++ b/src/client/power-pages/commonUtility.ts
@@ -72,5 +72,12 @@ export function isValidUri(fsPath: string): boolean {
     return validUri;
 }
 
+export function getCurrentWorkspaceURI(): vscode.Uri | undefined {
+    // TODO - This will not cover multi-WorkspaceFolderScenario
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders && workspaceFolders.length > 0) {
+        return workspaceFolders[0].uri;
+    }
 
-
+    return undefined;
+}

--- a/src/client/power-pages/commonUtility.ts
+++ b/src/client/power-pages/commonUtility.ts
@@ -50,11 +50,26 @@ export function getDeletePathUris(fsPath: string,
     fileProperties: IFileProperties
 ): vscode.Uri[] {
     const pathUris: vscode.Uri[] = [];
-    if (fileEntityType === PowerPagesEntityType.WEBPAGES) {
+    const deletePathUri = vscode.Uri.file(fsPath.substring(0, fileProperties.fileNameIndex));
+    if (fileEntityType === PowerPagesEntityType.WEBPAGES && isValidUri(deletePathUri.fsPath)) {
         pathUris.push(vscode.Uri.file(fsPath.substring(0, fileProperties.fileNameIndex)));
     }
 
     return pathUris;
+}
+
+export function isValidUri(fsPath: string): boolean {
+    let validUri = true;
+
+    EntityFolderName.forEach(folderName => {
+        folderName = folderName.toLowerCase();
+
+        if (fsPath.endsWith(`\\${folderName}\\`)) {
+            validUri = false;
+        }
+    });
+
+    return validUri;
 }
 
 

--- a/src/client/power-pages/constants.ts
+++ b/src/client/power-pages/constants.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+export const EntityFolderName = [
+    "web-pages"
+];
+
+export enum PowerPagesEntityType { // EntityType to foldername mapping
+    WEBPAGES,
+    WEBFILES,
+    WEBTEMPLATE,
+    CONTENT_SNIPPET,
+    UNKNOWN
+}
+
+export const EntityFolderMap: Map<string, PowerPagesEntityType> = new Map<string, PowerPagesEntityType>([
+    ["web-pages", PowerPagesEntityType.WEBPAGES],
+    ["web-files", PowerPagesEntityType.WEBFILES],
+    ["web-template", PowerPagesEntityType.WEBTEMPLATE],
+    ["content - snippet", PowerPagesEntityType.CONTENT_SNIPPET]
+]);
+

--- a/src/client/power-pages/constants.ts
+++ b/src/client/power-pages/constants.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
+export const ContentPages = "content-pages"
+
 export const EntityFolderName = [
     "web-pages"
 ];
@@ -19,6 +21,6 @@ export const EntityFolderMap: Map<string, PowerPagesEntityType> = new Map<string
     ["web-pages", PowerPagesEntityType.WEBPAGES],
     ["web-files", PowerPagesEntityType.WEBFILES],
     ["web-template", PowerPagesEntityType.WEBTEMPLATE],
-    ["content - snippet", PowerPagesEntityType.CONTENT_SNIPPET]
+    ["content-snippet", PowerPagesEntityType.CONTENT_SNIPPET]
 ]);
 

--- a/src/client/power-pages/fileSystemCallbacks.ts
+++ b/src/client/power-pages/fileSystemCallbacks.ts
@@ -16,7 +16,7 @@ export async function handleFileSystemCallbacks(context: vscode.ExtensionContext
 async function processOnDidDeleteFiles(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.workspace.onDidDeleteFiles(async (e) => {
-            let deleteInfoMessage = `Are you sure you want to delete these files`;
+            let deleteInfoMessage = `Are you sure you want to delete these files?`;
             const deleteInfoMessageDetail = "Places where this file has been used might be affected.";
             const messageOptions = { detail: deleteInfoMessageDetail, modal: true };
             const edit: vscode.MessageItem = {
@@ -26,19 +26,18 @@ async function processOnDidDeleteFiles(context: vscode.ExtensionContext) {
             if (e.files.length === 1) {
                 const fileProperties = getFileProperties(e.files[0].fsPath);
                 if (fileProperties.fileName) {
-                    deleteInfoMessage = `Are you sure you want to delete ${fileProperties.fileName}`;
+                    deleteInfoMessage = `Are you sure you want to delete "${fileProperties.fileName}"?`;
                 }
             }
 
             await vscode.window.showInformationMessage(deleteInfoMessage, messageOptions, edit).then(selection => {
-                if (selection) {   //PoC for searching files
+                if (selection) {
                     e.files.forEach(async f => {
                         const fileEntityType = isValidDocument(f.fsPath)
                         if (fileEntityType !== PowerPagesEntityType.UNKNOWN) {
                             const fileProperties = getFileProperties(f.fsPath);
 
                             if (fileProperties.fileCompleteName) {
-                                //Delete all files
                                 const pathUris = getDeletePathUris(f.fsPath, fileEntityType, fileProperties);
                                 pathUris.forEach(pathUri => {
                                     console.log(fileProperties.fileCompleteName, fileProperties.fileName, pathUri);

--- a/src/client/power-pages/fileSystemCallbacks.ts
+++ b/src/client/power-pages/fileSystemCallbacks.ts
@@ -40,7 +40,6 @@ async function processOnDidDeleteFiles(context: vscode.ExtensionContext) {
                             if (fileProperties.fileCompleteName) {
                                 const pathUris = getDeletePathUris(f.fsPath, fileEntityType, fileProperties);
                                 pathUris.forEach(pathUri => {
-                                    console.log(fileProperties.fileCompleteName, fileProperties.fileName, pathUri);
                                     vscode.workspace.fs.delete(pathUri, { recursive: true, useTrash: true });
                                 });
 

--- a/src/client/power-pages/fileSystemCallbacks.ts
+++ b/src/client/power-pages/fileSystemCallbacks.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { getDeletePathUris, getFileProperties, isValidDocument } from "./commonUtility";
+import { PowerPagesEntityType } from "./constants";
+import { validateTextDocument } from "./validationDiagnostics";
+
+export async function handleFileSystemCallbacks(context: vscode.ExtensionContext) {
+    // Add file system callback flows here - for rename and delete file actions
+    await processOnDidDeleteFiles(context);
+}
+
+async function processOnDidDeleteFiles(context: vscode.ExtensionContext) {
+    context.subscriptions.push(
+        vscode.workspace.onDidDeleteFiles(async (e) => {
+            let deleteInfoMessage = `Are you sure you want to delete these files`;
+            const deleteInfoMessageDetail = "Places where this file has been used might be affected.";
+            const messageOptions = { detail: deleteInfoMessageDetail, modal: true };
+            const edit: vscode.MessageItem = {
+                title: "Delete"
+            };
+
+            if (e.files.length === 1) {
+                const fileProperties = getFileProperties(e.files[0].fsPath);
+                if (fileProperties.fileName) {
+                    deleteInfoMessage = `Are you sure you want to delete ${fileProperties.fileName}`;
+                }
+            }
+
+            await vscode.window.showInformationMessage(deleteInfoMessage, messageOptions, edit).then(selection => {
+                if (selection) {   //PoC for searching files
+                    e.files.forEach(async f => {
+                        const fileEntityType = isValidDocument(f.fsPath)
+                        if (fileEntityType !== PowerPagesEntityType.UNKNOWN) {
+                            const fileProperties = getFileProperties(f.fsPath);
+
+                            if (fileProperties.fileCompleteName) {
+                                //Delete all files
+                                const pathUris = getDeletePathUris(f.fsPath, fileEntityType, fileProperties);
+                                pathUris.forEach(pathUri => {
+                                    console.log(fileProperties.fileCompleteName, fileProperties.fileName, pathUri);
+                                    vscode.workspace.fs.delete(pathUri, { recursive: true, useTrash: true });
+                                });
+
+                                // TODO - Add search validation for entity guid
+                                vscode.workspace.textDocuments.forEach(document => validateTextDocument(document, [RegExp(`${fileProperties.fileName}`, "g")]));
+                            }
+                        }
+                    });
+                }
+            });
+        })
+    );
+}

--- a/src/client/power-pages/validationDiagnostics.ts
+++ b/src/client/power-pages/validationDiagnostics.ts
@@ -4,12 +4,13 @@
  */
 
 import * as vscode from "vscode";
+//import * as nls from 'vscode-nls';
+//const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
-// Create a connection for the server, using Node's IPC as a transport.
-// Also include all preview / proposed LSP features.
+// Create a diagnostics connection to output warning/error messages to "Problems" tab
 const connection = vscode.languages.createDiagnosticCollection("FileDeleteEvent");
 
-export async function validateTextDocument(uri: vscode.Uri, patterns: RegExp[], message: string): Promise<void> {
+export async function validateTextDocument(uri: vscode.Uri, patterns: RegExp[], searchByName: boolean): Promise<void> {
     const textDocument = await vscode.workspace.openTextDocument(uri);
     const text = textDocument.getText();
     let m: RegExpExecArray | null;
@@ -21,7 +22,8 @@ export async function validateTextDocument(uri: vscode.Uri, patterns: RegExp[], 
             const diagnostic: vscode.Diagnostic = {
                 severity: vscode.DiagnosticSeverity.Warning,
                 range: new vscode.Range(textDocument.positionAt(m.index), textDocument.positionAt(m.index + m[0].length)),
-                message: `${m[0]}: ` + message,
+                // localize("powerPages.searchByNameReferenceMessage", `Deleted file might be referenced by name here.`)
+                message: `${m[0]}: ` + (searchByName ? `Deleted file might be referenced by name here.` : ""),
                 source: 'ex',
                 // relatedInformation: [
                 //     new vscode.DiagnosticRelatedInformation(new vscode.Location(textDocument.uri, new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 9))), 'first assignment to `x`')

--- a/src/client/power-pages/validationDiagnostics.ts
+++ b/src/client/power-pages/validationDiagnostics.ts
@@ -9,7 +9,8 @@ import * as vscode from "vscode";
 // Also include all preview / proposed LSP features.
 const connection = vscode.languages.createDiagnosticCollection("FileDeleteEvent");
 
-export async function validateTextDocument(textDocument: vscode.TextDocument, patterns: RegExp[]): Promise<void> {
+export async function validateTextDocument(uri: vscode.Uri, patterns: RegExp[], message: string): Promise<void> {
+    const textDocument = await vscode.workspace.openTextDocument(uri);
     const text = textDocument.getText();
     let m: RegExpExecArray | null;
 
@@ -20,7 +21,7 @@ export async function validateTextDocument(textDocument: vscode.TextDocument, pa
             const diagnostic: vscode.Diagnostic = {
                 severity: vscode.DiagnosticSeverity.Warning,
                 range: new vscode.Range(textDocument.positionAt(m.index), textDocument.positionAt(m.index + m[0].length)),
-                message: `${m[0]} here might be referencing deleted file by name.`,
+                message: `${m[0]}: ` + message,
                 source: 'ex',
                 // relatedInformation: [
                 //     new vscode.DiagnosticRelatedInformation(new vscode.Location(textDocument.uri, new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 9))), 'first assignment to `x`')
@@ -31,5 +32,5 @@ export async function validateTextDocument(textDocument: vscode.TextDocument, pa
     });
 
     // Send the computed diagnostics to VSCode.
-    connection.set(textDocument.uri, diagnostics);
+    connection.set(uri, diagnostics);
 }

--- a/src/client/power-pages/validationDiagnostics.ts
+++ b/src/client/power-pages/validationDiagnostics.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+
+// Create a connection for the server, using Node's IPC as a transport.
+// Also include all preview / proposed LSP features.
+const connection = vscode.languages.createDiagnosticCollection("FileDeleteEvent");
+
+export async function validateTextDocument(textDocument: vscode.TextDocument, patterns: RegExp[]): Promise<void> {
+    const text = textDocument.getText();
+    let m: RegExpExecArray | null;
+
+    const diagnostics: vscode.Diagnostic[] = [];
+    patterns.forEach(pattern => {
+        m = pattern.exec(text);
+        while ((m = pattern.exec(text))) {
+            const diagnostic: vscode.Diagnostic = {
+                severity: vscode.DiagnosticSeverity.Warning,
+                range: new vscode.Range(textDocument.positionAt(m.index), textDocument.positionAt(m.index + m[0].length)),
+                message: `${m[0]} here might be referencing deleted file by name.`,
+                source: 'ex',
+                // relatedInformation: [
+                //     new vscode.DiagnosticRelatedInformation(new vscode.Location(textDocument.uri, new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 9))), 'first assignment to `x`')
+                // ]
+            };
+            diagnostics.push(diagnostic);
+        }
+    });
+
+    // Send the computed diagnostics to VSCode.
+    connection.set(textDocument.uri, diagnostics);
+}


### PR DESCRIPTION
![DeleteSingleAndMultiFile](https://user-images.githubusercontent.com/6157891/215423346-551dfa28-1930-4311-9702-0177951432d5.gif)

- Covered single and multifile delete scenario for desktop extension - including output to diagnostics window for name references
- Code is behind the Configuration setting for CRUD operations on desktop extension

TODO:
- Check localization once the new localization API related changes are in
- Telemetry will be added in a separate task

