### PR TITLE
Auto-refresh Auth panel on changes made via CLI

### DIFF
--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
+import path from 'path';
 import * as vscode from 'vscode';
 import { OrgListOutput, SolutionListing } from '../pac/PacTypes';
 import { PacWrapper } from '../pac/PacWrapper';
@@ -11,10 +12,15 @@ import { AuthProfileTreeItem, EnvAndSolutionTreeView, EnvOrSolutionTreeItem, Pac
 export function RegisterPanels(pacWrapper: PacWrapper): vscode.Disposable[] {
     const registrations: vscode.Disposable[] = [];
 
+    const authProfilePath = process.env.LOCALAPPDATA
+        ? new vscode.RelativePattern(path.join(process.env.LOCALAPPDATA, "Microsoft", "PowerAppsCli"), "authprofiles*.json")
+        : undefined;
+
     const authPanel = new PacFlatDataView(
         () => pacWrapper.authList(),
         item => new AuthProfileTreeItem(item),
-        item => item.Kind !== "ADMIN");
+        item => item.Kind !== "ADMIN",
+        authProfilePath);
     registrations.push(
         vscode.window.registerTreeDataProvider("pacCLI.authPanel", authPanel),
         vscode.commands.registerCommand("pacCLI.authPanel.refresh", () => authPanel.refresh()),

--- a/src/client/lib/PanelComponents.ts
+++ b/src/client/lib/PanelComponents.ts
@@ -13,7 +13,15 @@ export class PacFlatDataView<PacResultType, TreeType extends vscode.TreeItem> im
     constructor(
         public readonly dataSource: () => Promise<PacOutputWithResultList<PacResultType>>,
         private readonly mapToTreeItem: (item: PacResultType) => TreeType,
-        private readonly itemFilter?: (item:PacResultType) => boolean) {
+        private readonly itemFilter?: (item:PacResultType) => boolean,
+        private readonly watchPath?: vscode.RelativePattern) {
+
+        if (this.watchPath) {
+            const watcher = vscode.workspace.createFileSystemWatcher(this.watchPath);
+            watcher.onDidChange(() => this.refresh());
+            watcher.onDidCreate(() => this.refresh());
+            watcher.onDidDelete(() => this.refresh());
+        }
     }
 
     refresh(): void {


### PR DESCRIPTION
Set a FileWatch on the auth profiles to auto-refresh the Auth panel when changes are made via CLI

[AB#2336573](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2336573) 