### PR TITLE
Minor LOC cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@
 
 # Localization files
 # vscode-nls-dev regenerates these, writing lf endings; checking them out as lf prevents unnecessary diffs on Windows clients
-*.i18n.json text eol=lf
+*.l10n.*.json text eol=lf
 *.nls.*.json text eol=lf
 vscode-powerplatform.xlf text eol=lf
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -416,6 +416,7 @@ async function translationsImport() {
     // `@vscode/l10n-dev import-xlf` places both the package.nls.*.json and bundle.l10n.*.json files in the
     // same directory, but the package.nls.*.json need to reside at the repo root next to package.json
     gulp.src('./l10n/package.nls.*.json')
+        .pipe(replace("\\r\\n", "\\n"))
         .pipe(replace("\\\\n", "\\n"))
         .pipe(gulp.dest('./'));
 

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -90,6 +90,12 @@
       "The {3} represents Dataverse Environment's Organization ID (GUID)"
     ]
   },
+  "File might be referenced by name {0} here./{0} represents the name of the file": {
+    "message": "File might be referenced by name {0} here.",
+    "comment": [
+      "{0} represents the name of the file"
+    ]
+  },
   "Authorization Failed. Please run again to authorize it": "Authorization Failed. Please run again to authorize it",
   "There was a permissions problem with the server": "There was a permissions problem with the server",
   "There was a problem opening the workspace": "There was a problem opening the workspace",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -62,6 +62,10 @@ The {2} represents Solution's Version number</note>
     <trans-unit id="++CODE++2a8ddde521f14ecd4a8717f2bcf9a2b021fa38a578518066d2ae32271aa95237">
       <source xml:lang="en">Fetching your file ...</source>
     </trans-unit>
+    <trans-unit id="++CODE++7b351789f09522eb21ab2637f1b063ff2a41451a7130138b41f142a6fe5d249e">
+      <source xml:lang="en">File might be referenced by name {0} here.</source>
+      <note>{0} represents the name of the file</note>
+    </trans-unit>
     <trans-unit id="++CODE++25109e9c19daeeed3977b84ace83722ac8a4daafcfe4e3709082fcc5b228e7a8">
       <source xml:lang="en">Installing Power Pages generator(v{0})...</source>
       <note>{0} represents the version number</note>
@@ -283,24 +287,24 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.walkthrough.advancedCapabilities.description">
       <source xml:lang="en">Visual Studio Code for Web enables editing and publishing of web pages on your website.
-
- For a command line interface and more advanced capabilities, install the Power Platform Extension for VS Code, available in the VS Code Marketplace for desktop.
-
+ 
+ For a command line interface and more advanced capabilities, install the Power Platform Extension for VS Code, available in the VS Code Marketplace for desktop. 
+ 
  [Learn More](command:powerplatform-walkthrough.advancedCapabilities-learn-more) about the difference between Visual Studio Code for desktop and web.
-
+ 
 [Start coding](command:powerplatform-walkthrough.advancedCapabilities-start-coding)</source>
       <note>This is a Markdown formatted string, and the formatting must persist across translations.
 The fifth line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.advancedCapabilities-learn-more) TRANSLATION', keeping brackets and the text in the parentheses unmodified
 The seventh line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.advancedCapabilities-start-coding)', keeping brackets and the text in the parentheses unmodified</note>
     </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.walkthrough.fileSystem.description">
-      <source xml:lang="en">Your files are stored in nested folders under your site name.
-
- The individual page files can be found in the web-pages folder under your site name.
-
- All of your pages are arranged into HTML, CSS and JS files inside the folder with the respective page name.
-
- To learn more about the Power Pages file system in VS Code for Web, visit our [documentation](command:powerplatform-walkthrough.fileSystem-documentation).
+      <source xml:lang="en">Your files are stored in nested folders under your site name. 
+ 
+ The individual page files can be found in the web-pages folder under your site name. 
+ 
+ All of your pages are arranged into HTML, CSS and JS files inside the folder with the respective page name. 
+ 
+ To learn more about the Power Pages file system in VS Code for Web, visit our [documentation](command:powerplatform-walkthrough.fileSystem-documentation). 
 [Open site folder](command:powerplatform-walkthrough.fileSystem-open-folder)</source>
       <note>This is a Markdown formatted string, and the formatting must persist across translations.
 The seventh line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.fileSystem-documentation).', keeping brackets and the text in the parentheses unmodified


### PR DESCRIPTION
- ensure l10n only LF style endings for l10n files
- ensure generated l10n files use `\n` not `\r\n` literals
- commit exported strings missed by a previous PR
