### PR TITLE
diff view - handle etag update after save

### DIFF
--- a/src/web/client/WebExtensionContext.ts
+++ b/src/web/client/WebExtensionContext.ts
@@ -46,7 +46,7 @@ export interface IWebExtensionContext {
 
     // VScode specific details
     rootDirectory: vscode.Uri;
-    fileDataMap: FileDataMap; // VFS file URI to file detail map - TODO - convert to class
+    fileDataMap: FileDataMap; // VFS file URI to file detail map
     defaultEntityId: string;
     defaultEntityType: string;
     defaultFileUri: vscode.Uri; // This will default to home page or current page in multifile scenario

--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -24,6 +24,7 @@ import {
     getEntityEtag,
     getFileEntityEtag,
     getFileEntityId,
+    getFileEntityType,
     updateEntityEtag,
     updateFileDirtyChanges,
 } from "../utilities/fileAndEntityUtil";
@@ -74,18 +75,26 @@ export class PortalsFS implements vscode.FileSystemProvider {
     // --- manage file metadata
 
     async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
-        const isVersionControlEnabled = vscode.workspace
-            .getConfiguration(SETTINGS_EXPERIMENTAL_STORE_NAME)
-            .get(VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME);
-
-        if (isVersionControlEnabled && fileHasDirtyChanges(uri.fsPath)) {
-            const latestContent =
-                await EtagHandlerService.getLatestAndUpdateMetadata(uri.fsPath);
-            const entityEtagValue = getEntityEtag(getFileEntityId(uri.fsPath));
-
+        if (fileHasDirtyChanges(uri.fsPath)) {
             WebExtensionContext.telemetry.sendInfoTelemetry(
                 telemetryEventNames.WEB_EXTENSION_FILE_HAS_DIRTY_CHANGES
             );
+
+            const isVersionControlEnabled = vscode.workspace
+                .getConfiguration(SETTINGS_EXPERIMENTAL_STORE_NAME)
+                .get(VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME);
+
+            if (!isVersionControlEnabled) {
+                WebExtensionContext.telemetry.sendInfoTelemetry(
+                    telemetryEventNames.WEB_EXTENSION_DIFF_VIEW_FEATURE_FLAG_DISABLED
+                );
+
+                return await this._lookup(uri, false);
+            }
+
+            const latestContent =
+                await EtagHandlerService.getLatestAndUpdateMetadata(uri.fsPath);
+            const entityEtagValue = getEntityEtag(getFileEntityId(uri.fsPath));
 
             // Triggers diff view logic in web extension using file system provider in-built flows
             if (
@@ -397,13 +406,14 @@ export class PortalsFS implements vscode.FileSystemProvider {
                     vscode.Uri.parse(filePathInPortalFS, true)
                 );
             } catch {
-                // TODO - add telemetry
+                WebExtensionContext.telemetry.sendInfoTelemetry(
+                    telemetryEventNames.WEB_EXTENSION_CREATE_ENTITY_FOLDER_FAILED
+                );
             }
         });
     }
 
     // --- Dataverse calls
-
     private async _loadFromDataverseToVFS() {
         await WebExtensionContext.authenticateAndUpdateDataverseProperties();
         await this.createFileSystem(
@@ -421,7 +431,11 @@ export class PortalsFS implements vscode.FileSystemProvider {
         // Update fileDataMap with the latest changes
         updateFileDirtyChanges(uri.fsPath, false);
 
-        // TODO - Update the etag of the file after saving - this is used to check if the file has been modified in Dataverse
-        // Co-related with the TODO in readFile
+        // Update the etag of the file after saving
+        await fetchDataFromDataverseAndUpdateVFS(
+            this,
+            getFileEntityId(uri.fsPath),
+            getFileEntityType(uri.fsPath)
+        );
     }
 }

--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -27,8 +27,12 @@ import { folderExportType, schemaEntityKey } from "../schema/constants";
 import { getRequestUrlForEntities } from "../utilities/folderHelperUtility";
 import { IAttributePath } from "../common/interfaces";
 
-export async function fetchDataFromDataverseAndUpdateVFS(portalFs: PortalsFS) {
-    const entityRequestURLs = getRequestUrlForEntities();
+export async function fetchDataFromDataverseAndUpdateVFS(
+    portalFs: PortalsFS,
+    entityId = "",
+    entityType = ""
+) {
+    const entityRequestURLs = getRequestUrlForEntities(entityId, entityType);
 
     entityRequestURLs.forEach(async (entity) => {
         let requestSentAtTime = new Date().getTime();

--- a/src/web/client/services/etagHandlerService.ts
+++ b/src/web/client/services/etagHandlerService.ts
@@ -10,7 +10,7 @@ import { telemetryEventNames } from "../telemetry/constants";
 import { GetFileContent } from "../utilities/commonUtil";
 import {
     getFileEntityId,
-    getFileEntityName,
+    getFileEntityType,
 } from "../utilities/fileAndEntityUtil";
 import { getRequestURL } from "../utilities/urlBuilderUtil";
 import WebExtensionContext from "../WebExtensionContext";
@@ -19,7 +19,7 @@ export class EtagHandlerService {
     public static async getLatestAndUpdateMetadata(
         fileFsPath: string
     ): Promise<string> {
-        const entityName = getFileEntityName(fileFsPath);
+        const entityName = getFileEntityType(fileFsPath);
         const entityId = getFileEntityId(fileFsPath);
 
         const requestSentAtTime = new Date().getTime();

--- a/src/web/client/telemetry/constants.ts
+++ b/src/web/client/telemetry/constants.ts
@@ -39,4 +39,6 @@ export enum telemetryEventNames {
     WEB_EXTENSION_CREATE_ENTITY_FOLDER = "WebExtensionCreateEntityFolder",
     WEB_EXTENSION_FILE_HAS_DIRTY_CHANGES = "WebExtensionFileHasDirtyChanges",
     WEB_EXTENSION_DIFF_VIEW_TRIGGERED = "WebExtensionDiffViewTriggered",
+    WEB_EXTENSION_DIFF_VIEW_FEATURE_FLAG_DISABLED = "WebExtensionDiffViewFeatureFlagDisabled",
+    WEB_EXTENSION_CREATE_ENTITY_FOLDER_FAILED = "webExtensionCreateEntityFolderFailed",
 }

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -3,9 +3,16 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-import { NO_CONTENT } from "../common/constants";
+import * as vscode from "vscode";
+import {
+    NO_CONTENT,
+    VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME,
+} from "../common/constants";
 import { IAttributePath } from "../common/interfaces";
 import { schemaEntityName } from "../schema/constants";
+import { telemetryEventNames } from "../telemetry/constants";
+import WebExtensionContext from "../WebExtensionContext";
+import { SETTINGS_EXPERIMENTAL_STORE_NAME } from "../../../client/constants";
 
 // decodes base64 to text
 export function convertfromBase64ToString(data: string) {
@@ -47,4 +54,18 @@ export function GetFileContent(result: any, attributePath: IAttributePath) {
     }
 
     return fileContent;
+}
+
+export function isVersionControlEnabled() {
+    const isVersionControlEnabled = vscode.workspace
+        .getConfiguration(SETTINGS_EXPERIMENTAL_STORE_NAME)
+        .get(VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME);
+
+    if (!isVersionControlEnabled) {
+        WebExtensionContext.telemetry.sendInfoTelemetry(
+            telemetryEventNames.WEB_EXTENSION_DIFF_VIEW_FEATURE_FLAG_DISABLED
+        );
+    }
+
+    return isVersionControlEnabled;
 }

--- a/src/web/client/utilities/fileAndEntityUtil.ts
+++ b/src/web/client/utilities/fileAndEntityUtil.ts
@@ -17,7 +17,7 @@ export function getFileEntityId(fileFsPath: string) {
         ?.entityId as string;
 }
 
-export function getFileEntityName(fileFsPath: string) {
+export function getFileEntityType(fileFsPath: string) {
     return WebExtensionContext.fileDataMap.getFileMap.get(fileFsPath)
         ?.entityName as string;
 }

--- a/src/web/client/utilities/folderHelperUtility.ts
+++ b/src/web/client/utilities/folderHelperUtility.ts
@@ -34,17 +34,27 @@ export function getFolderSubUris(): string[] {
     return subUris;
 }
 
-export function getRequestUrlForEntities(): IEntityRequestUrl[] {
+export function getRequestUrlForEntities(
+    entityId: string,
+    entityType: string
+): IEntityRequestUrl[] {
     const entityRequestURLs: IEntityRequestUrl[] = [];
     const dataverseOrgUrl = WebExtensionContext.urlParametersMap.get(
         queryParameters.ORG_URL
     ) as string;
 
-    if (!ENABLE_MULTI_FILE_FEATURE) {
+    if (
+        !ENABLE_MULTI_FILE_FEATURE ||
+        (entityId.length > 0 && entityType.length > 0)
+    ) {
         const requestURL = getRequestURL(
             dataverseOrgUrl,
-            WebExtensionContext.defaultEntityType,
-            WebExtensionContext.defaultEntityId,
+            entityType.length > 0
+                ? entityType
+                : WebExtensionContext.defaultEntityType,
+            entityId.length > 0
+                ? entityId
+                : WebExtensionContext.defaultEntityId,
             httpMethod.GET,
             false
         );


### PR DESCRIPTION
This addresses corner scenario where difference in etag of a recently saved entity triggers un-necessary diff view