### PR TITLE
handle un-necessary Diff view render on  Entity Etag changes

### DIFF
--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -79,7 +79,8 @@ export class PortalsFS implements vscode.FileSystemProvider {
             if (isVersionControlEnabled()) {
                 const latestContent =
                     await EtagHandlerService.getLatestAndUpdateMetadata(
-                        uri.fsPath
+                        uri.fsPath,
+                        this
                     );
                 const entityEtagValue = getEntityEtag(
                     getFileEntityId(uri.fsPath)


### PR DESCRIPTION
handles corner case where a diff view shows up even when there has been no change in file's content. Etag value can be updated on any change  being made in the entity and is not restricted to file content updates