### PR TITLE
Introduce continuation token to fetch files for large sites

### DIFF
--- a/src/web/client/WebExtensionContext.ts
+++ b/src/web/client/WebExtensionContext.ts
@@ -7,7 +7,7 @@ import fetch from "node-fetch";
 import * as vscode from "vscode";
 import {
     dataverseAuthentication,
-    getHeader,
+    getCommonHeaders,
 } from "./common/authenticationProvider";
 import * as Constants from "./common/constants";
 import {
@@ -346,7 +346,7 @@ class WebExtensionContext implements IWebExtensionContext {
 
             requestSentAtTime = new Date().getTime();
             const response = await fetch(requestUrl, {
-                headers: getHeader(accessToken),
+                headers: getCommonHeaders(accessToken),
             });
             if (!response?.ok) {
                 this.telemetry.sendAPIFailureTelemetry(
@@ -404,7 +404,7 @@ class WebExtensionContext implements IWebExtensionContext {
 
             requestSentAtTime = new Date().getTime();
             const response = await fetch(requestUrl, {
-                headers: getHeader(accessToken),
+                headers: getCommonHeaders(accessToken),
             });
             if (!response?.ok) {
                 this.telemetry.sendAPIFailureTelemetry(
@@ -458,7 +458,7 @@ class WebExtensionContext implements IWebExtensionContext {
 
             requestSentAtTime = new Date().getTime();
             const response = await fetch(requestUrl, {
-                headers: getHeader(accessToken),
+                headers: getCommonHeaders(accessToken),
             });
 
             if (!response?.ok) {

--- a/src/web/client/common/authenticationProvider.ts
+++ b/src/web/client/common/authenticationProvider.ts
@@ -3,63 +3,121 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-import * as vscode from 'vscode';
-import WebExtensionContext from '../WebExtensionContext';
-import { telemetryEventNames } from '../telemetry/constants';
-import { PROVIDER_ID, SCOPE_OPTION_DEFAULT, SCOPE_OPTION_OFFLINE_ACCESS } from './constants';
-import { ERRORS, showErrorDialog } from './errorHandler';
+import * as vscode from "vscode";
+import WebExtensionContext from "../WebExtensionContext";
+import { telemetryEventNames } from "../telemetry/constants";
+import {
+    PROVIDER_ID,
+    SCOPE_OPTION_DEFAULT,
+    SCOPE_OPTION_OFFLINE_ACCESS,
+} from "./constants";
+import { ERRORS, showErrorDialog } from "./errorHandler";
 
-export function getHeader(accessToken: string, useOctetStreamContentType?: boolean) {
+export function getCommonHeaders(
+    accessToken: string,
+    useOctetStreamContentType?: boolean
+) {
     return {
         authorization: "Bearer " + accessToken,
-        'content-type': useOctetStreamContentType ? 'application/octet-stream' : "application/json; charset=utf-8",
+        "content-type": useOctetStreamContentType
+            ? "application/octet-stream"
+            : "application/json; charset=utf-8",
         accept: "application/json",
-        'OData-MaxVersion': "4.0",
-        'OData-Version': "4.0",
+        "OData-MaxVersion": "4.0",
+        "OData-Version": "4.0",
     };
 }
 
-export async function dataverseAuthentication(dataverseOrgURL: string): Promise<string> {
-    let accessToken = '';
-    WebExtensionContext.telemetry.sendInfoTelemetry(telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_STARTED);
+export async function dataverseAuthentication(
+    dataverseOrgURL: string
+): Promise<string> {
+    let accessToken = "";
+    WebExtensionContext.telemetry.sendInfoTelemetry(
+        telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_STARTED
+    );
     try {
-
-        let session = await vscode.authentication.getSession(PROVIDER_ID, [`${dataverseOrgURL}${SCOPE_OPTION_DEFAULT}`, `${SCOPE_OPTION_OFFLINE_ACCESS}`], { silent: true });
+        let session = await vscode.authentication.getSession(
+            PROVIDER_ID,
+            [
+                `${dataverseOrgURL}${SCOPE_OPTION_DEFAULT}`,
+                `${SCOPE_OPTION_OFFLINE_ACCESS}`,
+            ],
+            { silent: true }
+        );
         if (!session) {
-            session = await vscode.authentication.getSession(PROVIDER_ID, [`${dataverseOrgURL}${SCOPE_OPTION_DEFAULT}`, `${SCOPE_OPTION_OFFLINE_ACCESS}`], { createIfNone: true });
+            session = await vscode.authentication.getSession(
+                PROVIDER_ID,
+                [
+                    `${dataverseOrgURL}${SCOPE_OPTION_DEFAULT}`,
+                    `${SCOPE_OPTION_OFFLINE_ACCESS}`,
+                ],
+                { createIfNone: true }
+            );
         }
 
-        accessToken = session?.accessToken ?? '';
+        accessToken = session?.accessToken ?? "";
         if (!accessToken) {
             throw new Error(ERRORS.NO_ACCESS_TOKEN);
         }
 
-        WebExtensionContext.telemetry.sendInfoTelemetry(telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_COMPLETED, { "userId": session?.account.id.split('/').pop() ?? session?.account.id ?? '' });
+        WebExtensionContext.telemetry.sendInfoTelemetry(
+            telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_COMPLETED,
+            {
+                userId:
+                    session?.account.id.split("/").pop() ??
+                    session?.account.id ??
+                    "",
+            }
+        );
     } catch (error) {
         const authError = (error as Error)?.message;
-        showErrorDialog(vscode.l10n.t("Authorization Failed. Please run again to authorize it"),
-        vscode.l10n.t("There was a permissions problem with the server"));
-        WebExtensionContext.telemetry.sendErrorTelemetry(telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_FAILED, authError);
+        showErrorDialog(
+            vscode.l10n.t(
+                "Authorization Failed. Please run again to authorize it"
+            ),
+            vscode.l10n.t("There was a permissions problem with the server")
+        );
+        WebExtensionContext.telemetry.sendErrorTelemetry(
+            telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_FAILED,
+            authError
+        );
     }
 
     return accessToken;
 }
 
-export async function npsAuthentication(cesSurveyAuthorizationEndpoint: string): Promise<string> {
-    let accessToken = '';
-    WebExtensionContext.telemetry.sendInfoTelemetry(telemetryEventNames.NPS_AUTHENTICATION_STARTED);
+export async function npsAuthentication(
+    cesSurveyAuthorizationEndpoint: string
+): Promise<string> {
+    let accessToken = "";
+    WebExtensionContext.telemetry.sendInfoTelemetry(
+        telemetryEventNames.NPS_AUTHENTICATION_STARTED
+    );
     try {
-        const session = await vscode.authentication.getSession(PROVIDER_ID, [cesSurveyAuthorizationEndpoint], { silent: true });
-        accessToken = session?.accessToken ?? '';
+        const session = await vscode.authentication.getSession(
+            PROVIDER_ID,
+            [cesSurveyAuthorizationEndpoint],
+            { silent: true }
+        );
+        accessToken = session?.accessToken ?? "";
         if (!accessToken) {
             throw new Error(ERRORS.NO_ACCESS_TOKEN);
         }
-        WebExtensionContext.telemetry.sendInfoTelemetry(telemetryEventNames.NPS_AUTHENTICATION_COMPLETED);
+        WebExtensionContext.telemetry.sendInfoTelemetry(
+            telemetryEventNames.NPS_AUTHENTICATION_COMPLETED
+        );
     } catch (error) {
         const authError = (error as Error)?.message;
-        showErrorDialog(vscode.l10n.t("Authorization Failed. Please run again to authorize it"),
-            vscode.l10n.t("There was a permissions problem with the server"));
-        WebExtensionContext.telemetry.sendErrorTelemetry(telemetryEventNames.NPS_AUTHENTICATION_FAILED, authError);
+        showErrorDialog(
+            vscode.l10n.t(
+                "Authorization Failed. Please run again to authorize it"
+            ),
+            vscode.l10n.t("There was a permissions problem with the server")
+        );
+        WebExtensionContext.telemetry.sendErrorTelemetry(
+            telemetryEventNames.NPS_AUTHENTICATION_FAILED,
+            authError
+        );
     }
 
     return accessToken;

--- a/src/web/client/common/constants.ts
+++ b/src/web/client/common/constants.ts
@@ -19,6 +19,8 @@ export const PUBLIC = "public";
 export const MIMETYPE = "mimetype";
 export const IS_FIRST_RUN_EXPERIENCE = "isFirstRunExperience";
 export const ODATA_ETAG = "@odata.etag";
+export const ODATA_NEXT_LINK = "@odata.nextLink";
+export const MAX_ENTITY_FETCH_COUNT = "3";
 
 // FEATURE FLAGS
 // Version control feature flag

--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -6,7 +6,11 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { pathHasEntityFolderName } from "../utilities/urlBuilderUtil";
-import { PORTALS_URI_SCHEME, queryParameters } from "../common/constants";
+import {
+    ENABLE_MULTI_FILE_FEATURE,
+    PORTALS_URI_SCHEME,
+    queryParameters,
+} from "../common/constants";
 import WebExtensionContext from "../WebExtensionContext";
 import { fetchDataFromDataverseAndUpdateVFS } from "./remoteFetchProvider";
 import { saveData } from "./remoteSaveProvider";
@@ -413,7 +417,17 @@ export class PortalsFS implements vscode.FileSystemProvider {
             ) as string
         );
 
-        await fetchDataFromDataverseAndUpdateVFS(this);
+        // Load default file first
+        await fetchDataFromDataverseAndUpdateVFS(
+            this,
+            WebExtensionContext.defaultEntityId,
+            WebExtensionContext.defaultEntityType
+        );
+
+        if (ENABLE_MULTI_FILE_FEATURE) {
+            // load rest of the files
+            await fetchDataFromDataverseAndUpdateVFS(this);
+        }
     }
 
     private async _saveFileToDataverseFromVFS(uri: vscode.Uri) {

--- a/src/web/client/dal/remoteSaveProvider.ts
+++ b/src/web/client/dal/remoteSaveProvider.ts
@@ -5,7 +5,7 @@
 
 import fetch, { RequestInit } from "node-fetch";
 import * as vscode from "vscode";
-import { getHeader } from "../common/authenticationProvider";
+import { getCommonHeaders } from "../common/authenticationProvider";
 import { BAD_REQUEST, MIMETYPE, queryParameters } from "../common/constants";
 import { showErrorDialog } from "../common/errorHandler";
 import { FileData } from "../context/fileData";
@@ -35,7 +35,8 @@ export async function saveData(fileUri: vscode.Uri) {
         dataMap.get(fileUri.fsPath)?.entityName as string,
         dataMap.get(fileUri.fsPath)?.entityId as string,
         httpMethod.PATCH,
-        true
+        true,
+        false
     );
 
     const fileDataMap = WebExtensionContext.fileDataMap.getFileMap;
@@ -75,7 +76,7 @@ async function getSaveParameters(
             webFileV2
         );
 
-        saveCallParameters.requestInit.headers = getHeader(
+        saveCallParameters.requestInit.headers = getCommonHeaders(
             accessToken,
             useOctetStreamContentType(entityName, attributePath.source)
         );

--- a/src/web/client/schema/portalSchema.ts
+++ b/src/web/client/schema/portalSchema.ts
@@ -73,9 +73,9 @@ export const portal_schema_V1 = {
                 _languagefield: "_adx_webpagelanguageid_value",
                 _languagegroupby: "adx_rootwebpageid",
                 _fetchQueryParameters:
-                    "?$filter=adx_webpageid eq {entityId}&$select=adx_name,adx_copy,adx_customcss,adx_customjavascript,adx_partialurl,_adx_webpagelanguageid_value",
+                    "?$filter=adx_webpageid eq {entityId}&$select=adx_name,adx_copy,adx_customcss,adx_customjavascript,adx_partialurl,_adx_webpagelanguageid_value&$count=true",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_adx_websiteid_value eq {websiteId}&$select=adx_webpageid,_adx_webpagelanguageid_value,adx_name,adx_copy,adx_customcss,adx_customjavascript,adx_partialurl",
+                    "?$filter=_adx_websiteid_value eq {websiteId}&$select=adx_webpageid,_adx_webpagelanguageid_value,adx_name,adx_copy,adx_customcss,adx_customjavascript,adx_partialurl&$count=true",
                 _attributes: "adx_customcss,adx_customjavascript,adx_copy",
                 _attributesExtension: new Map([
                     ["adx_customcss", "customcss.css"],
@@ -97,7 +97,7 @@ export const portal_schema_V1 = {
                 _exporttype: "SingleFolder",
                 _fetchQueryParameters:
                     "?$filter=_objectid_value eq {entityId} &$select=mimetype,documentbody,filename,annotationid,_objectid_value",
-                _multiFileFetchQueryParameters: "",
+                _multiFileFetchQueryParameters: "?$count=true",
                 _attributes: "documentbody",
                 _attributesExtension: new Map([["documentbody", "css"]]),
                 _mappingEntityId: "annotationid", // Webfile in old schema are maintained with two dataverse entity adx_webfile and annotations. This Id acts as foreign key for that mapping
@@ -119,7 +119,7 @@ export const portal_schema_V1 = {
                 _fetchQueryParameters:
                     "?$filter=adx_contentsnippetid eq {entityId}&$select=adx_name,adx_value,_adx_contentsnippetlanguageid_value,_adx_contentsnippetlanguageid_value",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_adx_websiteid_value eq {websiteId}&$select=adx_name,adx_value,_adx_contentsnippetlanguageid_value,_adx_contentsnippetlanguageid_value",
+                    "?$filter=_adx_websiteid_value eq {websiteId}&$select=adx_name,adx_value,_adx_contentsnippetlanguageid_value,_adx_contentsnippetlanguageid_value&$count=true",
                 _attributes: "adx_value",
                 _attributesExtension: new Map([["adx_value", "html"]]),
             },
@@ -138,7 +138,7 @@ export const portal_schema_V1 = {
                 _fetchQueryParameters:
                     "?$filter=adx_webtemplateid eq {entityId}&$select=adx_name,adx_source",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_adx_websiteid_value eq {websiteId}&$select=adx_name,adx_source",
+                    "?$filter=_adx_websiteid_value eq {websiteId}&$select=adx_name,adx_source&$count=true",
                 _attributes: "adx_source",
                 _attributesExtension: new Map([["adx_source", "html"]]),
             },
@@ -155,7 +155,7 @@ export const portal_schema_V1 = {
                 _propextension: "",
                 _exporttype: "SingleFolder",
                 _fetchQueryParameters: "",
-                _multiFileFetchQueryParameters: "",
+                _multiFileFetchQueryParameters: "?$count=true",
                 _attributes: "",
                 _attributesExtension: new Map([["", ""]]),
             },
@@ -172,7 +172,7 @@ export const portal_schema_V1 = {
                 _propextension: "",
                 _exporttype: "SingleFolder",
                 _fetchQueryParameters: "",
-                _multiFileFetchQueryParameters: "",
+                _multiFileFetchQueryParameters: "?$count=true",
                 _attributes: "",
                 _attributesExtension: new Map([["", ""]]),
             },
@@ -189,7 +189,7 @@ export const portal_schema_V1 = {
                 _propextension: "",
                 _exporttype: "SubFolders",
                 _fetchQueryParameters: "",
-                _multiFileFetchQueryParameters: "",
+                _multiFileFetchQueryParameters: "?$count=true",
                 _attributes: "",
                 _attributesExtension: new Map([["", ""]]),
             },
@@ -265,7 +265,7 @@ export const portal_schema_V2 = {
                 _fetchQueryParameters:
                     "?$filter=powerpagecomponentid eq {entityId}&$select=name,content,powerpagesitelanguageid",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 2 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value",
+                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 2 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value&$count=true",
                 _attributes:
                     "content.customcss,content.customjavascript,content.copy",
                 _attributesExtension: new Map([
@@ -288,7 +288,7 @@ export const portal_schema_V2 = {
                 _fetchQueryParameters:
                     "?$filter=powerpagecomponentid eq {entityId}&$select=name",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 3&$select=name,content,_powerpagesitelanguageid_value",
+                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 3&$select=name,content,_powerpagesitelanguageid_value&$count=true",
                 _attributes: "filecontent",
                 _attributesExtension: new Map([["filecontent", "css"]]),
                 _mappingAttributeFetchQuery: new Map([
@@ -309,7 +309,7 @@ export const portal_schema_V2 = {
                 _fetchQueryParameters:
                     "?$filter=powerpagecomponentid eq {entityId}&$select=name,content",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 7 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value",
+                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 7 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value&$count=true",
                 _attributes: "content.value",
                 _attributesExtension: new Map([["content.value", "html"]]),
             },
@@ -327,7 +327,7 @@ export const portal_schema_V2 = {
                 _fetchQueryParameters:
                     "?$filter=powerpagecomponentid eq {entityId}&$select=name,content",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 8&$select=name,content,_powerpagesitelanguageid_value",
+                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 8&$select=name,content,_powerpagesitelanguageid_value&$count=true",
                 _attributes: "content.source",
                 _attributesExtension: new Map([["content.source", "html"]]),
             },
@@ -345,7 +345,7 @@ export const portal_schema_V2 = {
                 _fetchQueryParameters:
                     "?$filter=powerpagecomponentid eq {entityId}&$select=name,content",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 17 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value",
+                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 17 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value&$count=true",
                 _attributes: "content.source",
                 _attributesExtension: new Map([["", ""]]),
             },
@@ -363,7 +363,7 @@ export const portal_schema_V2 = {
                 _fetchQueryParameters:
                     "?$filter=powerpagecomponentid eq {entityId}&$select=name,content",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 15 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value",
+                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 15 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value&$count=true",
                 _attributes: "content.source",
                 _attributesExtension: new Map([["", ""]]),
             },
@@ -381,7 +381,7 @@ export const portal_schema_V2 = {
                 _fetchQueryParameters:
                     "?$filter=powerpagecomponentid eq {entityId}&$select=name,content",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 19 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value",
+                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 19 and _powerpagesitelanguageid_value ne null&$select=name,content,_powerpagesitelanguageid_value&$count=true",
                 _attributes: "content.source",
                 _attributesExtension: new Map([["", ""]]),
             },

--- a/src/web/client/services/etagHandlerService.ts
+++ b/src/web/client/services/etagHandlerService.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from "vscode";
-import { getHeader } from "../common/authenticationProvider";
+import { getCommonHeaders } from "../common/authenticationProvider";
 import { httpMethod, ODATA_ETAG, queryParameters } from "../common/constants";
 import { IAttributePath } from "../common/interfaces";
 import { PortalsFS } from "../dal/fileSystemProvider";
@@ -41,7 +41,8 @@ export class EtagHandlerService {
             entityName,
             entityId,
             httpMethod.GET,
-            true
+            true,
+            false
         );
 
         const attributePath: IAttributePath =
@@ -51,7 +52,9 @@ export class EtagHandlerService {
         try {
             const requestInit: RequestInit = {
                 method: httpMethod.GET,
-                headers: getHeader(WebExtensionContext.dataverseAccessToken),
+                headers: getCommonHeaders(
+                    WebExtensionContext.dataverseAccessToken
+                ),
             };
 
             if (entityEtag) {

--- a/src/web/client/test/integration/AuthenticationProvider.test.ts
+++ b/src/web/client/test/integration/AuthenticationProvider.test.ts
@@ -7,12 +7,12 @@ import sinon from "sinon";
 import { expect } from "chai";
 import {
     dataverseAuthentication,
-    getHeader,
+    getCommonHeaders,
 } from "../../common/authenticationProvider";
 import vscode from "vscode";
 import WebExtensionContext from "../../WebExtensionContext";
-import { telemetryEventNames } from '../../telemetry/constants';
-import * as errorHandler from '../../common/errorHandler';
+import { telemetryEventNames } from "../../telemetry/constants";
+import * as errorHandler from "../../common/errorHandler";
 
 describe("Authentication Provider", () => {
     afterEach(() => {
@@ -21,7 +21,7 @@ describe("Authentication Provider", () => {
     });
     it("getHeader", () => {
         const accessToken = "f068ee9f-a010-47b9-b1e1-7e6353730e7d";
-        const result = getHeader(accessToken);
+        const result = getCommonHeaders(accessToken);
         expect(result.authorization).eq("Bearer " + accessToken);
         expect(result["content-type"]).eq("application/json; charset=utf-8");
         expect(result.accept).eq("application/json");
@@ -60,11 +60,7 @@ describe("Authentication Provider", () => {
                 scopes: [],
             });
 
-
-        const showErrorDialog = sinon.spy(
-            errorHandler,
-            "showErrorDialog"
-        );
+        const showErrorDialog = sinon.spy(errorHandler, "showErrorDialog");
 
         const sendErrorTelemetry = sinon.spy(
             WebExtensionContext.telemetry,

--- a/src/web/client/test/integration/WebExtensionContext.test.ts
+++ b/src/web/client/test/integration/WebExtensionContext.test.ts
@@ -15,7 +15,7 @@ import * as authenticationProvider from "../../common/authenticationProvider";
 import { telemetryEventNames } from "../../telemetry/constants";
 import * as schemaHelperUtil from "../../utilities/schemaHelperUtil";
 import * as urlBuilderUtil from "../../utilities/urlBuilderUtil";
-import { getHeader } from "../../common/authenticationProvider";
+import { getCommonHeaders } from "../../common/authenticationProvider";
 import { IAttributePath } from "../../common/interfaces";
 
 describe("WebExtensionContext", () => {
@@ -514,7 +514,7 @@ describe("WebExtensionContext", () => {
         //#endregion
 
         //#region  Fetch
-        const header = getHeader(accessToken);
+        const header = getCommonHeaders(accessToken);
         assert.callCount(_mockFetch, 3);
         const firstFetchCall = _mockFetch.getCalls()[0];
         expect(firstFetchCall.args[0], requestUrl);
@@ -700,7 +700,7 @@ describe("WebExtensionContext", () => {
         //#endregion
 
         //#region  Fetch
-        const header = getHeader(accessToken);
+        const header = getCommonHeaders(accessToken);
         assert.calledThrice(_mockFetch);
         const firstFetchCall = _mockFetch.getCalls()[0];
         expect(firstFetchCall.args[0], requestUrl);
@@ -795,7 +795,7 @@ describe("WebExtensionContext", () => {
 
         assert.calledOnceWithExactly(dataverseAuthentication, ORG_URL);
         //#region  Fetch
-        const header = getHeader(accessToken);
+        const header = getCommonHeaders(accessToken);
         assert.calledThrice(_mockFetch);
         const firstFetchCall = _mockFetch.getCalls()[0];
         expect(firstFetchCall.args[0], requestUrl);

--- a/src/web/client/test/integration/urlBuilderUtil.test.ts
+++ b/src/web/client/test/integration/urlBuilderUtil.test.ts
@@ -215,7 +215,8 @@ describe("URLBuilder", () => {
             entity,
             entityId,
             method,
-            isSingleEntity
+            isSingleEntity,
+            false
         );
 
         const expResult = "singleEntityURL";
@@ -281,7 +282,8 @@ describe("URLBuilder", () => {
             entity,
             entityId,
             method,
-            isSingleEntity
+            isSingleEntity,
+            false
         );
 
         const expResult = `dataverseOrgUrl DATAVERSE_ENTITY_NAME id data api 1.0`;

--- a/src/web/client/utilities/folderHelperUtility.ts
+++ b/src/web/client/utilities/folderHelperUtility.ts
@@ -55,8 +55,7 @@ export function getRequestUrlForEntities(
             entityId.length > 0
                 ? entityId
                 : WebExtensionContext.defaultEntityId,
-            httpMethod.GET,
-            false
+            httpMethod.GET
         );
         return [
             {
@@ -78,8 +77,7 @@ export function getRequestUrlForEntities(
                         schemaEntityKey.VSCODE_ENTITY_NAME
                     ) as string,
                     "",
-                    httpMethod.GET,
-                    false
+                    httpMethod.GET
                 );
 
                 entityRequestURLs.push({

--- a/src/web/client/utilities/urlBuilderUtil.ts
+++ b/src/web/client/utilities/urlBuilderUtil.ts
@@ -17,8 +17,10 @@ import {
 } from "../schema/constants";
 import { getEntity } from "./schemaHelperUtil";
 
-export const getParameterizedRequestUrlTemplate = (isSingleEntity: boolean) => {
-    if (isSingleEntity) {
+export const getParameterizedRequestUrlTemplate = (
+    useSingleEntityUrl: boolean
+) => {
+    if (useSingleEntityUrl) {
         return WebExtensionContext.schemaDataSourcePropertiesMap.get(
             schemaKey.SINGLE_ENTITY_URL
         ) as string;
@@ -34,13 +36,14 @@ export function getRequestURL(
     entity: string,
     entityId: string,
     method: string,
-    isSingleEntity: boolean,
+    useSingleEntityUrl = false,
+    applyFilter = true,
     attributeQueryParameters?: string
 ): string {
     let parameterizedUrlTemplate =
-        getParameterizedRequestUrlTemplate(isSingleEntity);
+        getParameterizedRequestUrlTemplate(useSingleEntityUrl);
 
-    if (!isSingleEntity) {
+    if (applyFilter) {
         switch (method) {
             case httpMethod.GET:
                 parameterizedUrlTemplate =


### PR DESCRIPTION
 Dataverse odata calls response with "@odata.nextLink" gives the option to fetch all associated entities for a large portal. Introducing this change here behind multi-file feature flag.