### PR TITLE
Fixing web limitation message

### DIFF
--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -343,9 +343,6 @@ The second line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newAuthPr
     <trans-unit id="microsoft-powerapps-portals.walkthrough.overview.title">
       <source xml:lang="en">Overview</source>
     </trans-unit>
-    <trans-unit id="microsoft-powerapps-portals.webExtension.limitation">
-      <source xml:lang="en">PAC CLI is not supported in VS Code for the Web</source>
-    </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.walkthrough.overview.description">
       <source xml:lang="en">Power Pages extension enables a customized file system which is synced with the project structure of the Power Pages studio.
 [Learn More](command:powerplatform-walkthrough.overview-learn-more)</source>

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     },
     "virtualWorkspaces": {
       "supported": "limited",
-      "description": "%microsoft-powerapps-portals.webExtension.limitation%"
+      "description": "PAC CLI is not supported in VS Code for the Web"
     }
   },
   "contributes": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -50,7 +50,6 @@
 
   "microsoft-powerapps-portals.preview-show.title": "PowerApps Portal -> Show preview",
   "microsoft-powerapps-portals.webExtension.init.title": "Initialize Web Extension",
-  "microsoft-powerapps-portals.webExtension.limitation": "PAC CLI is not supported in VS Code for the Web",
   "microsoft-powerapps-portals.walkthrough.title": "Edit Power Pages code",
   "microsoft-powerapps-portals.walkthrough.description": "Discover how you can make complete, modern websites right in VS Code",
   "microsoft-powerapps-portals.walkthrough.overview.title": "Overview",


### PR DESCRIPTION
[AB#3380985](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/3380985)

When installing the Extension on a web-only environment such as vscode.dev, our limitation warning shows the localization slug instead of the explaination text:
![image](https://github.com/microsoft/powerplatform-vscode/assets/3751389/d40b1ed0-658e-477f-8cda-362d7664d27e)

This warning is displayed by VS Code itself (not our extension), and thus our extension does not run and the string cannot be replaced with the localized version.   This will unfortunately need to just be a plain English text.