### PR TITLE
Support loading all webfiles - old and new data model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "command-exists": "^1.2.9",
         "find-process": "^1.4.7",
         "glob": "^7.1.7",
+        "js-base64": "3.6.1",
         "liquidjs": "^10.2.0",
         "n-readlines": "^1.0.1",
         "puppeteer-core": "^14.4.1",
@@ -8245,6 +8246,11 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.1.tgz",
+      "integrity": "sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ=="
     },
     "node_modules/js-sdsl": {
       "version": "4.2.0",
@@ -21406,6 +21412,11 @@
           }
         }
       }
+    },
+    "js-base64": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.1.tgz",
+      "integrity": "sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ=="
     },
     "js-sdsl": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -891,6 +891,7 @@
     "command-exists": "^1.2.9",
     "find-process": "^1.4.7",
     "glob": "^7.1.7",
+    "js-base64": "3.6.1",
     "liquidjs": "^10.2.0",
     "n-readlines": "^1.0.1",
     "puppeteer-core": "^14.4.1",

--- a/src/web/client/WebExtensionContext.ts
+++ b/src/web/client/WebExtensionContext.ts
@@ -288,7 +288,8 @@ class WebExtensionContext implements IWebExtensionContext {
         fileExtension: string,
         attributePath: IAttributePath,
         encodeAsBase64: boolean,
-        mimeType?: string
+        mimeType?: string,
+        isContentLoaded?: boolean
     ) {
         this.fileDataMap.setEntity(
             fileUri,
@@ -299,7 +300,8 @@ class WebExtensionContext implements IWebExtensionContext {
             fileExtension,
             attributePath,
             encodeAsBase64,
-            mimeType
+            mimeType,
+            isContentLoaded
         );
     }
 

--- a/src/web/client/common/constants.ts
+++ b/src/web/client/common/constants.ts
@@ -22,6 +22,17 @@ export const ODATA_ETAG = "@odata.etag";
 export const ODATA_NEXT_LINK = "@odata.nextLink";
 export const MAX_ENTITY_FETCH_COUNT = "1000";
 
+// Web extension constants
+export const BASE_64= ';base64,';
+export const DATA = 'data:';
+export const ALL_AUDIO_MIME_TYPE = 'audio/*';
+export const ALL_DOCUMENT_MIME_TYPE =
+  '.doc,.dot,.wbk,.docx,.docm,.dotx,.dotm,.docb,.xls,.xlt,.xlm,.xlsx,.xlsm,.xltx,.xltm,.ppt,.pot,.pps,.pptx,.pptm,.potx,.potm,.ppam,.ppsx,.ppsm,.sldx,.sldm,.pdf';
+export const ALL_DOCUMENT_MIME_TYPE_SHORTENED =
+  '.doc,.dot,.docx,.docm,.xls,.xlt,.xlm,.xlsx,.xlsm,.xltm,.ppt,.pptx,.pptm,.pdf';
+export const ALL_AUDIO_IMAGE_TYPE = 'image/*';
+export const ALL_AUDIO_VIDEO_TYPE = 'video/*';
+
 // FEATURE FLAGS
 // Version control feature flag
 export const VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME =

--- a/src/web/client/common/constants.ts
+++ b/src/web/client/common/constants.ts
@@ -25,13 +25,15 @@ export const MAX_ENTITY_FETCH_COUNT = "1000";
 // Web extension constants
 export const BASE_64= ';base64,';
 export const DATA = 'data:';
-export const ALL_AUDIO_MIME_TYPE = 'audio/*';
 export const ALL_DOCUMENT_MIME_TYPE =
   '.doc,.dot,.wbk,.docx,.docm,.dotx,.dotm,.docb,.xls,.xlt,.xlm,.xlsx,.xlsm,.xltx,.xltm,.ppt,.pot,.pps,.pptx,.pptm,.potx,.potm,.ppam,.ppsx,.ppsm,.sldx,.sldm,.pdf';
 export const ALL_DOCUMENT_MIME_TYPE_SHORTENED =
   '.doc,.dot,.docx,.docm,.xls,.xlt,.xlm,.xlsx,.xlsm,.xltm,.ppt,.pptx,.pptm,.pdf';
-export const ALL_AUDIO_IMAGE_TYPE = 'image/*';
-export const ALL_AUDIO_VIDEO_TYPE = 'video/*';
+export const ALL_AUDIO_MIME_TYPE = 'audio/';
+export const ALL_IMAGE_MIME_TYPE = 'image/';
+export const ALL_VIDEO_MIME_TYPE = 'video/';
+export const ALL_TEXT_MIME_TYPE = 'text/';
+export const ALL_APPLICATION_MIME_TYPE = 'application/';
 
 // FEATURE FLAGS
 // Version control feature flag

--- a/src/web/client/context/fileData.ts
+++ b/src/web/client/context/fileData.ts
@@ -15,6 +15,7 @@ export interface IFileData {
     hasDirtyChanges: boolean;
     encodeAsBase64: boolean | undefined;
     mimeType: string | undefined;
+    isContentLoaded?: boolean;
 }
 
 export class FileData implements IFileData {
@@ -27,6 +28,7 @@ export class FileData implements IFileData {
     private _hasDirtyChanges!: boolean;
     private _encodeAsBase64: boolean | undefined;
     private _mimeType: string | undefined;
+    private _isContentLoaded: boolean | undefined;
 
     // Getters
     public get entityName(): string {
@@ -57,6 +59,10 @@ export class FileData implements IFileData {
         return this._hasDirtyChanges;
     }
 
+    public get isContentLoaded(): boolean | undefined {
+        return this._isContentLoaded;
+    }
+
     // Setters
     public set setHasDirtyChanges(value: boolean) {
         this._hasDirtyChanges = value;
@@ -64,7 +70,7 @@ export class FileData implements IFileData {
     public set setEntityEtag(value: string) {
         this._entityEtag = value;
     }
-
+    
     constructor(
         entityId: string,
         entityName: string,
@@ -73,7 +79,8 @@ export class FileData implements IFileData {
         entityFileExtensionType: string,
         attributePath: IAttributePath,
         encodeAsBase64?: boolean,
-        mimeType?: string
+        mimeType?: string,
+        isContentLoaded?: boolean
     ) {
         this._entityId = entityId;
         this._entityName = entityName;
@@ -84,5 +91,6 @@ export class FileData implements IFileData {
         this._encodeAsBase64 = encodeAsBase64;
         this._mimeType = mimeType;
         this._hasDirtyChanges = false;
+        this._isContentLoaded = isContentLoaded;
     }
 }

--- a/src/web/client/context/fileDataMap.ts
+++ b/src/web/client/context/fileDataMap.ts
@@ -23,7 +23,8 @@ export class FileDataMap {
         fileExtension: string,
         attributePath: IAttributePath,
         isBase64Encoded: boolean,
-        mimeType?: string
+        mimeType?: string,
+        isContentLoaded?: boolean
     ) {
         const fileData = new FileData(
             entityId,
@@ -33,7 +34,8 @@ export class FileDataMap {
             fileExtension,
             attributePath,
             isBase64Encoded,
-            mimeType
+            mimeType,
+            isContentLoaded
         );
         this.fileMap.set(vscode.Uri.parse(fileUri).fsPath, fileData);
     }

--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -205,7 +205,7 @@ export class PortalsFS implements vscode.FileSystemProvider {
                 }
             );
         }
-
+        
         entry.mtime = Date.now();
         entry.size = content.byteLength;
         entry.data = content;

--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -204,8 +204,8 @@ export class PortalsFS implements vscode.FileSystemProvider {
                     await this._saveFileToDataverseFromVFS(uri);
                 }
             );
-        }        
-        
+        }
+
         entry.mtime = Date.now();
         entry.size = content.byteLength;
         entry.data = content;

--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -204,8 +204,7 @@ export class PortalsFS implements vscode.FileSystemProvider {
                     await this._saveFileToDataverseFromVFS(uri);
                 }
             );
-        }
-        
+        }        
         entry.mtime = Date.now();
         entry.size = content.byteLength;
         entry.data = content;

--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -205,6 +205,7 @@ export class PortalsFS implements vscode.FileSystemProvider {
                 }
             );
         }        
+        
         entry.mtime = Date.now();
         entry.size = content.byteLength;
         entry.data = content;

--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -375,6 +375,9 @@ async function createFile(
         entityName,
         attribute
     );
+
+    // By default content is preloaded for all the files except for non-text webfiles for V2
+    const isPreloadedContent = mappingEntityFetchQuery ? isContentPreloadNeeded(fileNameWithExtension) : true;
     
     // update func for webfiles for V2
     const attributePath: IAttributePath = getAttributePath(
@@ -382,7 +385,7 @@ async function createFile(
     );
 
     let fileContent = GetFileContent(result, attributePath);
-    if (mappingEntityFetchQuery && isContentPreloadNeeded(fileNameWithExtension)) {
+    if (mappingEntityFetchQuery && isPreloadedContent) {
         fileContent = await getMappingEntityContent(
             mappingEntityFetchQuery,
             attribute,
@@ -407,7 +410,8 @@ async function createFile(
         result[attributePath.source] ?? Constants.NO_CONTENT,
         fileExtension,
         result[Constants.ODATA_ETAG],
-        result[Constants.MIMETYPE]
+        result[Constants.MIMETYPE],
+        isPreloadedContent
     );
 }
 
@@ -561,7 +565,8 @@ async function createVirtualFile(
     originalAttributeContent: string,
     fileExtension: string,
     odataEtag: string,
-    mimeType?: string
+    mimeType?: string,
+    isPreloadedContent?: boolean
 ) {
     // Maintain file information in context
     await WebExtensionContext.updateFileDetailsInContext(
@@ -573,7 +578,8 @@ async function createVirtualFile(
         fileExtension,
         attributePath,
         encodeAsBase64,
-        mimeType
+        mimeType,
+        isPreloadedContent
     );
 
     // Call file system provider write call for buffering file data in VFS

--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -9,6 +9,7 @@ import {
     convertfromBase64ToString,
     GetFileContent,
     GetFileNameWithExtension,
+    isContentPreloadNeeded,
     setFileContent,
 } from "../utilities/commonUtil";
 import { getCustomRequestURL, getRequestURL, updateEntityId } from "../utilities/urlBuilderUtil";
@@ -308,7 +309,7 @@ async function processDataAndCreateFile(
         );
 
         const expandedContent = GetFileContent(result, attributePath);
-        if(expandedContent && fileExtension === undefined){
+        if(fileExtension === undefined && expandedContent){
             await processExpandedData(
                  entityName,
                  expandedContent,
@@ -381,7 +382,7 @@ async function createFile(
     );
 
     let fileContent = GetFileContent(result, attributePath);
-    if (mappingEntityFetchQuery) {
+    if (mappingEntityFetchQuery && isContentPreloadNeeded(fileNameWithExtension)) {
         fileContent = await getMappingEntityContent(
             mappingEntityFetchQuery,
             attribute,

--- a/src/web/client/schema/portalSchema.ts
+++ b/src/web/client/schema/portalSchema.ts
@@ -102,7 +102,7 @@ export const portal_schema_V1 = {
                 _exporttype: "SingleFolder",
                 _fetchQueryParameters:
                     "?$filter=_objectid_value eq {entityId} &$select=mimetype,documentbody,filename,annotationid,_objectid_value",
-                _multiFileFetchQueryParameters: "?$count=true",
+                _multiFileFetchQueryParameters: "?$select=mimetype,documentbody,filename,annotationid,_objectid_value&$count=true",
                 _attributes: "documentbody",
                 _attributesExtension: new Map([["documentbody", "css"]]),
                 _mappingEntityId: "annotationid", // Webfile in old schema are maintained with two dataverse entity adx_webfile and annotations. This Id acts as foreign key for that mapping

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -120,6 +120,7 @@ export function isNullOrUndefined(object: any | null | undefined): boolean {
 }
 
 // Clean up the file name to remove special characters
+// Ex: For input: "my_file!@#$%^&*()_|+=?;:'\",<>{}[]\\/"; the output will be "my_file"
 export function getSanitizedFileName(fileName: string): string {
   return fileName.trim().replace(/[`~!@#$%^&*()_|+=?;:'",<>{}[\]\\/]/g, '');
 }

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -5,23 +5,26 @@
 
 import * as vscode from "vscode";
 import {
+    BASE_64,
+    DATA,
     NO_CONTENT,
-    VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME,
+    VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME
 } from "../common/constants";
 import { IAttributePath } from "../common/interfaces";
 import { schemaEntityName } from "../schema/constants";
 import { telemetryEventNames } from "../telemetry/constants";
 import WebExtensionContext from "../WebExtensionContext";
 import { SETTINGS_EXPERIMENTAL_STORE_NAME } from "../../../client/constants";
+import { decode, encode } from 'js-base64';
 
 // decodes base64 to text
 export function convertfromBase64ToString(data: string) {
-    return decodeURIComponent(escape(atob(data)));
+  return decode(data);
 }
 
 // encodes text to UTF-8 bytes which are then encoded to base64
 export function convertStringtoBase64(data: string) {
-    return btoa(unescape(encodeURIComponent(data)));
+  return encode(data);
 }
 
 export function GetFileNameWithExtension(
@@ -33,7 +36,7 @@ export function GetFileNameWithExtension(
     fileName = isLanguageCodeNeededInFileName(entity) ? `${fileName}.${languageCode}` : fileName;
     fileName = isExtensionNeededInFileName(entity) ? `${fileName}.${extension}` : fileName;
 
-    return fileName;
+    return getSanitizedFileName(fileName);
 }
 
 export function isLanguageCodeNeededInFileName(entity: string){
@@ -114,4 +117,28 @@ export function isVersionControlEnabled() {
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function isNullOrUndefined(object: any | null | undefined): boolean {
     return object === null || object === undefined;
+}
+
+// Clean up the file name to remove special characters
+export function getSanitizedFileName(fileName: string): string {
+  return fileName.trim().replace(/[`~!@#$%^&*()_|+=?;:'",<>{}[\]\\/]/g, '');
+}
+
+// Get the file's extension
+export function getFileExtension(fileName: string): string | undefined{
+    return fileName.split('.').pop();
+}
+
+export function getFileExtensionForPreload() {
+  return ['css', 'json', 'txt'];
+}
+
+export function getImageContent(mimeType: string, fileContent: string) {
+    return DATA + mimeType + BASE_64 + fileContent
+}
+
+export function isContentPreloadNeeded(fileName: string): boolean {
+    const fileExtension = getFileExtension(fileName);
+    const validImageExtensions = getFileExtensionForPreload();
+    return fileExtension !== undefined && validImageExtensions.includes(fileExtension.toLowerCase());
 }


### PR DESCRIPTION
Webfile support all files in old and new data model
![ODM_SupportMediaFileInExplorer](https://github.com/microsoft/powerplatform-vscode/assets/6157891/c3c95194-1bb2-429f-9965-ebbb0c1161ca)
![NDM_SupportMediaFileInExplorer](https://github.com/microsoft/powerplatform-vscode/assets/6157891/4a00bbb5-0ad2-428a-834d-ce99d9044318)

File content can be lazy loaded for new data model as that is an explicit call to get content. For media files this content is marked for on-click load as this doesn't impact time-to-search.

NOTE: There is an issue in loading content of media files for preview that will be addressed in a separate PR.