### PR TITLE
Setting to enable authentication against other Azure clouds

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -56,6 +56,9 @@
       "{0} represents the name of the file"
     ]
   },
+  "Enter the name of the web template": "Enter the name of the web template",
+  "Please enter a name for the web template.": "Please enter a name for the web template.",
+  "A webtemplate with the same name already exists. Please enter a different name.": "A webtemplate with the same name already exists. Please enter a different name.",
   "No page templates found": "No page templates found",
   "No webpages found": "No webpages found",
   "New Webpage": "New Webpage",
@@ -68,9 +71,6 @@
   "File(s) already exist. No new files to add": "File(s) already exist. No new files to add",
   "Web files": "Web files",
   "Webfile(s) added successfully": "Webfile(s) added successfully",
-  "Enter the name of the web template": "Enter the name of the web template",
-  "Please enter a name for the web template.": "Please enter a name for the web template.",
-  "A webtemplate with the same name already exists. Please enter a different name.": "A webtemplate with the same name already exists. Please enter a different name.",
   "Page Template name cannot be empty.": "Page Template name cannot be empty.",
   "New Page Template": "New Page Template",
   "Choose web template": "Choose web template",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -376,6 +376,10 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     <trans-unit id="pacCLI.openPacLab.title">
       <source xml:lang="en">Open PAC Lab</source>
     </trans-unit>
+    <trans-unit id="powerPlatform.experimental.auth.testCloudOverride.description">
+      <source xml:lang="en">Overrides `#powerPlatform.auth.cloud#` for test targets. Leave blank for default behavior.</source>
+      <note>This is a Markdown formatted string, and `#powerPlatform.auth.cloud#` must remain unmodified.</note>
+    </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.walkthrough.overview.title">
       <source xml:lang="en">Overview</source>
     </trans-unit>
@@ -423,6 +427,9 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
       <note>This is a Markdown formatted string, and the formatting must persist across translations.
 The fifth line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.advancedCapabilities-learn-more) TRANSLATION', keeping brackets and the text in the parentheses unmodified
 The seventh line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.advancedCapabilities-start-coding)', keeping brackets and the text in the parentheses unmodified</note>
+    </trans-unit>
+    <trans-unit id="powerPlatform.auth.cloud.description">
+      <source xml:lang="en">Which Azure Cloud Power Platform Tools should use for authentication.</source>
     </trans-unit>
   </body></file>
 </xliff>

--- a/package.json
+++ b/package.json
@@ -326,6 +326,23 @@
           "default": false,
           "markdownDescription": "Whether the generator installation is complete."
         },
+        "powerPlatform.auth.cloud": {
+          "type": "string",
+          "default": "Public",
+          "enum": [
+            "Public",
+            "USGov",
+            "USGovHigh",
+            "USGovDoD",
+            "China"
+          ],
+          "description": "%powerPlatform.auth.cloud.description%"
+        },
+        "powerPlatform.experimental.auth.testCloudOverride": {
+          "type": "string",
+          "default": null,
+          "markdownDescription": "%powerPlatform.experimental.auth.testCloudOverride.description%"
+        },
         "powerPlatform.experimental.disableActivityBarPanels": {
           "type": "boolean",
           "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -48,6 +48,14 @@
   "pacCLI.envAndSolutionsPanel.copyUniqueName.title": "Copy Unique Name",
   "pacCLI.envAndSolutionsPanel.copyVersionNumber.title": "Copy Version Number",
 
+  "powerPlatform.auth.cloud.description": "Which Azure Cloud Power Platform Tools should use for authentication.",
+  "powerPlatform.experimental.auth.testCloudOverride.description": {
+    "message": "Overrides `#powerPlatform.auth.cloud#` for test targets. Leave blank for default behavior.",
+    "comment": [
+      "This is a Markdown formatted string, and `#powerPlatform.auth.cloud#` must remain unmodified."
+    ]
+  },
+
   "microsoft-powerapps-portals.preview-show.title": "PowerApps Portal -> Show preview",
   "microsoft-powerapps-portals.webExtension.init.title": "Initialize Web Extension",
   "microsoft-powerapps-portals.walkthrough.title": "Edit Power Pages code",

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -18,6 +18,7 @@ export interface IPacWrapperContext {
     readonly telemetry: ITelemetry;
     readonly automationAgent: string;
     IsTelemetryEnabled(): boolean;
+    GetCloudSetting(): string;
 }
 
 export interface IPacInterop {
@@ -118,7 +119,7 @@ export class PacWrapper {
 
     public async authCreateNewAuthProfile(): Promise<PacAuthListOutput> {
         return this.executeCommandAndParseResults<PacAuthListOutput>(
-            new PacArguments("auth", "create"));
+            new PacArguments("auth", "create", "--cloud", this.context.GetCloudSetting()));
     }
 
     public async authCreateNewAuthProfileForOrg(orgUrl: string): Promise<PacAuthListOutput> {

--- a/src/client/pac/PacWrapperContext.ts
+++ b/src/client/pac/PacWrapperContext.ts
@@ -19,4 +19,10 @@ export class PacWrapperContext implements IPacWrapperContext {
     public IsTelemetryEnabled(): boolean {
         return vscode.env.isTelemetryEnabled;
     }
+    public GetCloudSetting(): string {
+        const config = vscode.workspace.getConfiguration('powerPlatform');
+        const cloud = config.get<string>('auth.cloud');
+        const override = config.get<string>('experimental.auth.testCloudOverride')?.trim();
+        return override || cloud || 'Public';
+    }
 }

--- a/src/client/test/unit/PacWrapper.test.ts
+++ b/src/client/test/unit/PacWrapper.test.ts
@@ -12,9 +12,8 @@ class MockContext implements IPacWrapperContext {
     public get globalStorageLocalPath(): string { return ""; }
     public get telemetry(): ITelemetry { return NoopTelemetryInstance; }
     public get automationAgent(): string { return "powerplatform-vscode-tests/0.1.0-dev"; }
-    public IsTelemetryEnabled(): boolean {
-        return true;
-    }
+    public IsTelemetryEnabled(): boolean { return true; }
+    public GetCloudSetting(): string { return 'Public'; }
 }
 
 class MockPacInterop implements IPacInterop {


### PR DESCRIPTION
[AB#3491579](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/3491579)
Previously, logging in against any cloud other than Public needed to be done on the command line, as seen in #544 
This change provides configuration options in the VS Code Settings to choose another cloud:
![image](https://github.com/microsoft/powerplatform-vscode/assets/3751389/bad4eebf-f1c8-488a-bf87-1e7e896c74f8)


