### PR TITLE
Fixing exception handling for remoteFetchProvider

### DIFF
--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -533,7 +533,7 @@ export async function preprocessData(
 
             const advancedFormStepData = new Map();
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            formsData.forEach((dataItem: any) => {
+            formsData?.forEach((dataItem: any) => {
                 const entityId = fetchedFileId ? dataItem[fetchedFileId] : null;
                 if (!entityId) {
                     throw new Error(ERRORS.FILE_ID_EMPTY);
@@ -542,13 +542,13 @@ export async function preprocessData(
             });
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            data.forEach((dataItem: any) => {
+            data?.forEach((dataItem: any) => {
                 const webFormSteps = GetFileContent(dataItem, attributePath) as [];
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const steps: any[] = [];
 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                webFormSteps.forEach((step: any) => {
+                webFormSteps?.forEach((step: any) => {
                     const formStepData = advancedFormStepData.get(step);
 
                     if (formStepData) {


### PR DESCRIPTION
Getting NPE on webformSteps:

		"handledExceptions": [
			{
				"trackedAtMemberName": "",
				"problemId": "Error at WebExtensionTelemetry.sendErrorTelemetry",
				"outerType": "Error",
				"outerMethod": "WebExtensionTelemetry.sendErrorTelemetry",
				"innermostType": "Error",
				"innermostMethod": "WebExtensionTelemetry.sendErrorTelemetry",
				"eventName": "webExtensionPreprocessDataFailed",
				"errorMessage": "**webFormSteps.forEach is not a function**",
				"stackTrace": "TypeError: webFormSteps.forEach is not a function\n\tat eval (https://microsoft-isvexptools.vscode-unpkg.net/microsoft-IsvExpTools/powerplatform-vscode-preview/1.1.32/extension/dist/web/extension.js#vscode-extension:8110:34)\n\tat Array.forEach (<anonymous>)\n\tat eval (https://microsoft-isvexptools.vscode-unpkg.net/microsoft-IsvExpTools/powerplatform-vscode-preview/1.1.32/extension/dist/web/extension.js#vscode-extension:8105:22)\n\tat Generator.next (<anonymous>)\n\tat fulfilled (https://microsoft-isvexptools.vscode-unpkg.net/microsoft-IsvExpTools/powerplatform-vscode-preview/1.1.32/extension/dist/web/extension.js#vscode-extension:7842:58)"
			}
		]
	},