### PR TITLE
Update Entity Etag in case-of server side changes chosen scenario

### DIFF
--- a/src/web/client/context/fileData.ts
+++ b/src/web/client/context/fileData.ts
@@ -10,6 +10,7 @@ export interface IFileData extends IFileInfo {
     entityFileExtensionType: string;
     attributePath: IAttributePath;
     hasDirtyChanges: boolean;
+    hasDiffViewTriggered: boolean;
     encodeAsBase64: boolean | undefined;
     mimeType: string | undefined;
     isContentLoaded?: boolean;
@@ -23,6 +24,7 @@ export class FileData implements IFileData {
     private _entityFileExtensionType: string;
     private _attributePath: IAttributePath;
     private _hasDirtyChanges!: boolean;
+    private _hasDiffViewTriggered!: boolean;
     private _encodeAsBase64: boolean | undefined;
     private _mimeType: string | undefined;
     private _isContentLoaded: boolean | undefined;
@@ -55,7 +57,9 @@ export class FileData implements IFileData {
     public get hasDirtyChanges(): boolean {
         return this._hasDirtyChanges;
     }
-
+    public get hasDiffViewTriggered(): boolean {
+        return this._hasDiffViewTriggered;
+    }
     public get isContentLoaded(): boolean | undefined {
         return this._isContentLoaded;
     }
@@ -66,6 +70,9 @@ export class FileData implements IFileData {
     }
     public set setEntityEtag(value: string) {
         this._entityEtag = value;
+    }
+    public set setHasDiffViewTriggered(value: boolean) {
+        this._hasDiffViewTriggered = value;
     }
 
     constructor(
@@ -88,6 +95,7 @@ export class FileData implements IFileData {
         this._encodeAsBase64 = encodeAsBase64;
         this._mimeType = mimeType;
         this._hasDirtyChanges = false;
+        this._hasDiffViewTriggered = false;
         this._isContentLoaded = isContentLoaded;
     }
 }

--- a/src/web/client/context/fileDataMap.ts
+++ b/src/web/client/context/fileDataMap.ts
@@ -50,6 +50,16 @@ export class FileDataMap {
         throw Error("File does not exist in the map"); // TODO - Revisit errors and dialog experience here
     }
 
+    public updateDiffViewTriggered(fileFsPath: string, diffViewTriggerValue: boolean) {
+        const existingEntity = this.fileMap.get(fileFsPath);
+
+        if (existingEntity) {
+            existingEntity.setHasDiffViewTriggered = diffViewTriggerValue;
+            return;
+        }
+        throw Error("File does not exist in the map"); // TODO - Revisit errors and dialog experience here
+    }
+
     public updateEtagValue(fileFsPath: string, etag: string) {
         const existingEntity = this.fileMap.get(fileFsPath);
 

--- a/src/web/client/services/etagHandlerService.ts
+++ b/src/web/client/services/etagHandlerService.ts
@@ -12,6 +12,7 @@ import { PortalsFS } from "../dal/fileSystemProvider";
 import { telemetryEventNames } from "../telemetry/constants";
 import { GetFileContent } from "../utilities/commonUtil";
 import {
+    getFileEntityEtag,
     getFileEntityId,
     getFileEntityName,
     updateEntityEtag,
@@ -30,10 +31,7 @@ export class EtagHandlerService {
 
         const requestSentAtTime = new Date().getTime();
 
-        const entityEtag =
-            WebExtensionContext.fileDataMap.getFileMap.get(
-                fileFsPath
-            )?.entityEtag;
+        const entityEtag = getFileEntityEtag(fileFsPath);
 
         const dataverseOrgUrl = WebExtensionContext.urlParametersMap.get(
             queryParameters.ORG_URL
@@ -88,13 +86,9 @@ export class EtagHandlerService {
                     await portalFs.readFile(vscode.Uri.parse(fileFsPath))
                 );
                 const latestContent = GetFileContent(result, attributePath, entityName, entityId);
+                updateEntityEtag(entityId, result[ODATA_ETAG]);
 
                 if (currentContent !== latestContent) {
-                    updateEntityEtag(
-                        entityId,
-                        result[ODATA_ETAG]
-                    );
-
                     WebExtensionContext.telemetry.sendInfoTelemetry(
                         telemetryEventNames.WEB_EXTENSION_ENTITY_CONTENT_CHANGED
                     );

--- a/src/web/client/utilities/fileAndEntityUtil.ts
+++ b/src/web/client/utilities/fileAndEntityUtil.ts
@@ -13,6 +13,11 @@ export function fileHasDirtyChanges(fileFsPath: string) {
         ?.hasDirtyChanges as boolean;
 }
 
+export function fileHasDiffViewTriggered(fileFsPath: string) {
+    return WebExtensionContext.fileDataMap.getFileMap.get(fileFsPath)
+        ?.hasDiffViewTriggered as boolean;
+}
+
 export function getFileEntityId(fileFsPath: string) {
     return WebExtensionContext.fileDataMap.getFileMap.get(fileFsPath)
         ?.entityId as string ?? WebExtensionContext.getVscodeWorkspaceState(fileFsPath)?.entityId as string;
@@ -39,6 +44,16 @@ export function updateFileDirtyChanges(
     WebExtensionContext.fileDataMap.updateDirtyChanges(
         fileFsPath,
         hasDirtyChanges
+    );
+}
+
+export function updateDiffViewTriggered(
+    fileFsPath: string,
+    hasDiffViewTriggered: boolean
+) {
+    WebExtensionContext.fileDataMap.updateDiffViewTriggered(
+        fileFsPath,
+        hasDiffViewTriggered
     );
 }
 


### PR DESCRIPTION
This change addresses the scenario when a Conflict resolution editor is opened for user to compare the code changes in Dataverse entity v/s local changes, and the user discards the local changes to accept incoming server changes. Subsequent diff view calls are now optimized since the entity Etag is updated to latest in this scenario as well.