### PR TITLE
Extending the name sanitization done on file names to folder names which are based on entity name values

### DIFF
--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -8,6 +8,7 @@ import {
     convertContentToUint8Array,
     GetFileContent,
     GetFileNameWithExtension,
+    getSanitizedFileName,
     isWebfileContentLoadNeeded,
     setFileContent,
 } from "../utilities/commonUtil";
@@ -234,7 +235,7 @@ async function createContentFiles(
         // Create folder paths
         filePathInPortalFS = filePathInPortalFS ?? `${Constants.PORTALS_URI_SCHEME}:/${portalFolderName}/${subUri}/`;
         if (exportType && exportType === folderExportType.SubFolders) {
-            filePathInPortalFS = `${filePathInPortalFS}${fileName}/`;
+            filePathInPortalFS = `${filePathInPortalFS}${getSanitizedFileName(fileName)}/`;
             await portalsFS.createDirectory(
                 vscode.Uri.parse(filePathInPortalFS, true)
             );


### PR DESCRIPTION
File names used to for files loaded in file explorer is already sanitized. But, for entities like webpages, and advanced forms - we do not sanitize the folder name currently - which is also based on Name parameter fetched from entity records. This is an optimization PR based on the exceptions monitoring.