### PR TITLE
Always trigger activation path load of folders - fix race condition on preemptive root directory creation

### DIFF
--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -108,11 +108,9 @@ export class PortalsFS implements vscode.FileSystemProvider {
         return await this._lookup(uri, false);
     }
 
-    async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
+    async readDirectory(uri: vscode.Uri, isActivationFlow = false): Promise<[string, vscode.FileType][]> {
         const result: [string, vscode.FileType][] = [];
-        const entry = await this._lookup(uri, true);
-
-        if (!entry && isValidDirectoryPath(uri.fsPath)) {
+        if (isActivationFlow && isValidDirectoryPath(uri.fsPath)) {
             WebExtensionContext.telemetry.sendInfoTelemetry(
                 telemetryEventNames.WEB_EXTENSION_FETCH_DIRECTORY_TRIGGERED
             );
@@ -120,12 +118,12 @@ export class PortalsFS implements vscode.FileSystemProvider {
             return result;
         }
 
+        const entry = await this._lookup(uri, true);
         if (entry instanceof Directory) {
             for (const [name, child] of entry.entries) {
                 result.push([name, child.type]);
             }
         }
-
         return result;
     }
 

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -126,7 +126,7 @@ export function activate(context: vscode.ExtensionContext): void {
                                         title: vscode.l10n.t("Fetching your file ..."),
                                     },
                                     async () => {
-                                        await portalsFS.readDirectory(WebExtensionContext.rootDirectory);
+                                        await portalsFS.readDirectory(WebExtensionContext.rootDirectory, true);
                                     }
                                 );
 


### PR DESCRIPTION
We have a race condition where while we pro-actively load a file open in editor from a previous session, the load entire power pages code path is not triggered, This happens as the load of already open file flow creates the root directory, and hence the readDirectory flow for first time data load is not hit as entry is already present. 