### PR TITLE
Mimetype regression fix for old data model webfiles save scenario

### DIFF
--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -12,7 +12,7 @@ import {
     isWebfileContentLoadNeeded,
     setFileContent,
 } from "../utilities/commonUtil";
-import { getCustomRequestURL, getMappingEntityContent, getMappingEntityId, getRequestURL } from "../utilities/urlBuilderUtil";
+import { getCustomRequestURL, getMappingEntityContent, getMappingEntityId, getMimeType, getRequestURL } from "../utilities/urlBuilderUtil";
 import { getCommonHeaders } from "../common/authenticationProvider";
 import * as Constants from "../common/constants";
 import { ERRORS, showErrorDialog } from "../common/errorHandler";
@@ -413,6 +413,7 @@ async function createFile(
         attribute
     );
     let fileContent = Constants.NO_CONTENT;
+    let mimeType = undefined;
     let mappingEntityId = null
     // By default content is preloaded for all the files except for non-text webfiles for V2
     const isPreloadedContent = mappingEntityFetchQuery ? isWebfileContentLoadNeeded(fileNameWithExtension, fileUri) : true;
@@ -431,7 +432,8 @@ async function createFile(
             WebExtensionContext.dataverseAccessToken,
             dataverseOrgUrl
         );
-        mappingEntityId = getMappingEntityId(entityName, mappingContent);
+        mappingEntityId = getMappingEntityId(entityName, mappingContent);       
+        mimeType = getMimeType(mappingContent);
         fileContent = getMappingEntityContent(entityName, mappingContent, attribute);
     } else {
         fileContent = GetFileContent(result, attributePath, entityName, entityId);
@@ -449,7 +451,7 @@ async function createFile(
         result[attributePath.source] ?? Constants.NO_CONTENT,
         fileExtension,
         result[Constants.ODATA_ETAG],
-        result[Constants.MIMETYPE],
+        mimeType ?? result[Constants.MIMETYPE],
         isPreloadedContent,
         mappingEntityId
     );

--- a/src/web/client/utilities/urlBuilderUtil.ts
+++ b/src/web/client/utilities/urlBuilderUtil.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    MIMETYPE,
     httpMethod,
     queryParameters,
 } from "../common/constants";
@@ -189,6 +190,12 @@ export function getMappingEntityContent(entity: string, result: any, attribute: 
     }
 
     return result;
+}
+
+// TODO - Make Json for different response type and update any here
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getMimeType(result: any) {
+    return result[MIMETYPE];
 }
 
 export function pathHasEntityFolderName(uri: string): boolean {


### PR DESCRIPTION
CSS mime type was getting corrupted after edit from vscode web extension causing the CSS rendering on runtime to be off for a power pages site. This fix reads the mimetype correctly from backend and writes back the field during save of webfile content.