### PR TITLE
In case of multiple annotations/attachments associated with a  webfile pick the latest modified by the user

### DIFF
--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -432,7 +432,7 @@ async function createFile(
             WebExtensionContext.dataverseAccessToken,
             dataverseOrgUrl
         );
-        mappingEntityId = getMappingEntityId(entityName, mappingContent);       
+        mappingEntityId = getMappingEntityId(entityName, mappingContent);
         mimeType = getMimeType(mappingContent);
         fileContent = getMappingEntityContent(entityName, mappingContent, attribute);
     } else {
@@ -515,7 +515,7 @@ async function fetchMappingEntityContent(
 
     const result = await response.json();
     const data = result.value ?? result;
-    if (result[Constants.ODATA_COUNT] !== 0 && data.length === 1) {
+    if (result[Constants.ODATA_COUNT] !== 0 && data.length >= 1) {
         return data[0];
     }
 

--- a/src/web/client/schema/portalSchema.ts
+++ b/src/web/client/schema/portalSchema.ts
@@ -108,7 +108,7 @@ export const portal_schema_V1 = {
                 _mappingEntityId: "annotationid", // Webfile in old schema are maintained with two dataverse entity adx_webfile and annotations. This Id acts as foreign key for that mapping
                 _mappingEntity: "annotations",
                 _mappingEntityFetchQuery: new Map([
-                    ["documentbody", "?$filter=_objectid_value eq {entityId} &$select=mimetype,documentbody,filename,annotationid,_objectid_value&$count=true"],
+                    ["documentbody", "?$filter=_objectid_value eq {entityId} &$select=mimetype,documentbody,filename,annotationid,_objectid_value &$count=true &$orderby=modifiedon desc"],
                 ]),
             },
             {


### PR DESCRIPTION
FOr old data model we can have multiple files attached to a single webfile instance. IN vscode web extension view - we will default to showing the latest modified file in the attched file list