### PR TITLE
New data model load file content fix

### DIFF
--- a/src/web/client/common/constants.ts
+++ b/src/web/client/common/constants.ts
@@ -85,3 +85,8 @@ export enum SurveyConstants {
     EVENT_NAME = "VscodeWeb",
     AUTHORIZATION_ENDPOINT = "https://microsoft.onmicrosoft.com/cessurvey/user",
 }
+
+export enum portalSchemaVersion {
+    V1 = "portalschemav1",
+    V2 = "portalschemav2",
+}

--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -9,6 +9,8 @@ import {
     GetFileContent,
     GetFileNameWithExtension,
     getSanitizedFileName,
+    isPortalVersionV1,
+    isPortalVersionV2,
     isWebfileContentLoadNeeded,
     setFileContent,
 } from "../utilities/commonUtil";
@@ -515,11 +517,11 @@ async function fetchMappingEntityContent(
 
     const result = await response.json();
     const data = result.value ?? result;
-    if (result[Constants.ODATA_COUNT] !== 0 && data.length >= 1) {
+    if (isPortalVersionV1() && result[Constants.ODATA_COUNT] > 0 && data.length > 0) {
         return data[0];
     }
 
-    return data ?? Constants.NO_CONTENT;
+    return isPortalVersionV2() ? data : Constants.NO_CONTENT;
 }
 
 export async function preprocessData(

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -9,7 +9,8 @@ import {
     DATA,
     MULTI_FILE_FEATURE_SETTING_NAME,
     NO_CONTENT,
-    VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME
+    VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME,
+    portalSchemaVersion
 } from "../common/constants";
 import { IAttributePath } from "../common/interfaces";
 import { schemaEntityName } from "../schema/constants";
@@ -168,4 +169,12 @@ export function isWebfileContentLoadNeeded(fileName: string, fsPath: string): bo
     return fileExtension !== undefined ?
         validImageExtensions.includes(fileExtension.toLowerCase()) ||
         doesFileExist(fsPath) : false;
+}
+
+export function isPortalVersionV1(): boolean {
+    return WebExtensionContext.currentSchemaVersion.toLowerCase() === portalSchemaVersion.V1;
+}
+
+export function isPortalVersionV2(): boolean {
+    return WebExtensionContext.currentSchemaVersion.toLowerCase() === portalSchemaVersion.V2;
 }


### PR DESCRIPTION
Webfile attachements maintained in dataverse will now be pulled depending on the right schema version validation and for old data model attachements present validation as well. This fix address new data model load file regression introduced while fixing old data model multiple annotations scenario. 