### PR TITLE
Do not show welcome banner in non-us orgs

### DIFF
--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -140,9 +140,9 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
     const pacOutput = await this._pacWrapper?.activeOrg();
 
     if (pacOutput && pacOutput.Status === PAC_SUCCESS) {
-      this.handleOrgChangeSuccess(pacOutput.Results);
+      await this.handleOrgChangeSuccess(pacOutput.Results);
     } else if (!IS_DESKTOP && orgID && activeOrgUrl) {
-      this.handleOrgChangeSuccess({ OrgId: orgID, UserId: userID, OrgUrl: activeOrgUrl } as ActiveOrgOutput);
+      await this.handleOrgChangeSuccess({ OrgId: orgID, UserId: userID, OrgUrl: activeOrgUrl } as ActiveOrgOutput);
     }
 
     webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
@@ -150,6 +150,11 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
     webviewView.webview.onDidReceiveMessage(async (data) => {
       switch (data.type) {
         case "webViewLoaded": {
+          if (this.aibEndpoint === COPILOT_UNAVAILABLE) {
+            this.sendMessageToWebview({ type: 'Unavailable' });
+            return;
+          }
+
           sendTelemetryEvent(this.telemetry, { eventName: CopilotLoadedEvent, copilotSessionId: sessionID, orgId: orgID });
           this.sendMessageToWebview({ type: 'env' }); //TODO Use IS_DESKTOP
           await this.checkAuthentication();
@@ -327,7 +332,7 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
 
     this.aibEndpoint = await getIntelligenceEndpoint(orgID, this.telemetry, sessionID);
     if (this.aibEndpoint === COPILOT_UNAVAILABLE) {
-      sendTelemetryEvent(this.telemetry, {eventName: CopilotNotAvailable, copilotSessionId: sessionID, orgId: orgID});
+      sendTelemetryEvent(this.telemetry, { eventName: CopilotNotAvailable, copilotSessionId: sessionID, orgId: orgID });
       this.sendMessageToWebview({ type: 'Unavailable' });
     } else {
       this.sendMessageToWebview({ type: 'Available' });


### PR DESCRIPTION
We are currently showing unavailable message and the welcome banner in vscode web copilot - which can be confusing for the users. This was happening in web co-pilot due to async execution of webview event  causing the unavailable banner to be executing first compared to the welcome event tirggered from Copilot JS script. 