### PR TITLE
Action icon buttons code path correction

### DIFF
--- a/src/web/client/webViews/powerPagesNavigationProvider.ts
+++ b/src/web/client/webViews/powerPagesNavigationProvider.ts
@@ -145,8 +145,8 @@ export class PowerPagesNode extends vscode.TreeItem {
 
     getIconPath(svgFileName: string) {
         return {
-            light: vscode.Uri.joinPath(WebExtensionContext.extensionUri, '..', '..', 'src', 'web', 'client', 'assets', svgFileName),
-            dark: vscode.Uri.joinPath(WebExtensionContext.extensionUri, '..', '..', 'src', 'web', 'client', 'assets', svgFileName)
+            light: vscode.Uri.joinPath(WebExtensionContext.extensionUri, 'src', 'web', 'client', 'assets', svgFileName),
+            dark: vscode.Uri.joinPath(WebExtensionContext.extensionUri, 'src', 'web', 'client', 'assets', svgFileName)
         };
     }
 }


### PR DESCRIPTION
There is a bug in Vscode dev extension testing for css and svg path load in vscode currently which makes verifying this scenario tricky in development. 
https://github.com/microsoft/vscode-dev/issues/987

Updating the path to correctly fetch the svg file for action icon display now.