### PR TITLE
Vscode-dev updated pages route

### DIFF
--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -116,6 +116,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 if (appName) {
                     switch (appName) {
                         case "portal":
+                        case "pages":
                             {
                                 WebExtensionContext.telemetry.sendExtensionInitQueryParametersTelemetry(
                                     queryParamsMap


### PR DESCRIPTION
Vscode team has updated extension routes to redirect to follow new structure: https://github.com/microsoft/vscode-dev/pull/996

In our case it means the route changes from “vscode.dev/powerplatform/portal” to “vscode.dev/power/pages.”We need to now support this new Appname in our extension to make sure pages code loads properly.