### PR TITLE
[Desktop and Web] Poc For ECS API call

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -191,7 +191,30 @@ export async function activate(
         activateDebugger(context, _telemetry);
     }
 
+    await fetchECSConfig();
+
     _telemetry.sendTelemetryEvent("activated");
+
+}
+
+export async function fetchECSConfig() {
+    const requestURL = "https://ecs.office.com/config/v1/PortalsMakerExperiences/1.0.0.0?EnvironmentID=c4dc3686-1e6b-e428-b886-16cd0b9f4918&Locale=en-US&AppName=powerpages-microsoft-com&UserID=b9298493-f260-4bea-ac1a-ecb5fad8a891&TenantID=72f988bf-86f1-41af-91ab-2d7cd011db47";
+
+    const requestInit: RequestInit = {
+        method: 'GET'
+    };
+
+    try {
+        const response = await fetch(requestURL, requestInit);
+        if (!response.ok) {
+            throw new Error('Request failed');
+        }
+        const result = await response.json();
+        console.log(result);
+        return result;
+    } catch (error) {
+        return null;
+    }
 
 }
 

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -18,7 +18,7 @@ import {
     showErrorDialog,
 } from "./common/errorHandler";
 import { WebExtensionTelemetry } from "./telemetry/webExtensionTelemetry";
-import { isCoPresenceEnabled, updateFileContentInFileDataMap } from "./utilities/commonUtil";
+import { getEnvironmentIdFromUrl, isCoPresenceEnabled, updateFileContentInFileDataMap } from "./utilities/commonUtil";
 import { NPSService } from "./services/NPSService";
 import { vscodeExtAppInsightsResourceProvider } from "../../common/telemetry-generated/telemetryConfiguration";
 import { NPSWebView } from "./webViews/NPSWebView";
@@ -144,6 +144,8 @@ export function activate(context: vscode.ExtensionContext): void {
                                         context.extensionUri
                                     );
                                 }
+
+                                await fetchECSConfig();
                             }
                             break;
                         default:
@@ -188,6 +190,31 @@ export function activate(context: vscode.ExtensionContext): void {
     processWillStartCollaboartion();
 
     showWalkthrough(context, WebExtensionContext.telemetry);
+}
+
+
+
+export async function fetchECSConfig() {
+    const requestURL = `https://ecs.office.com/config/v1/PortalsMakerExperiences/1.0.0.0?EnvironmentID=${getEnvironmentIdFromUrl()}&AppName=powerpages-microsoft-com&UserID=${WebExtensionContext.userId}&TenantID=${WebExtensionContext.urlParametersMap?.get(
+        queryParameters.TENANT_ID
+    )}`;
+
+    const requestInit: RequestInit = {
+        method: 'GET'
+    };
+
+    try {
+        const response = await fetch(requestURL, requestInit);
+        if (!response.ok) {
+            throw new Error('Request failed');
+        }
+        const result = await response.json();
+        console.log(result);
+        return result;
+    } catch (error) {
+        return null;
+    }
+
 }
 
 export function powerPagesNavigation() {


### PR DESCRIPTION
This PoC PR makes a quick direct call to public ECS API for a user - with hard-coded params in desktop and dynamically fetch params in Web extension (most of the information in Web is readily available as part of WebExtensionContext)