### PR TITLE
created entity foreign key data map

### DIFF
--- a/src/web/client/WebExtensionContext.ts
+++ b/src/web/client/WebExtensionContext.ts
@@ -29,6 +29,7 @@ import { FileDataMap } from "./context/fileDataMap";
 import { IAttributePath, IEntityInfo } from "./common/interfaces";
 import { ConcurrencyHandler } from "./dal/concurrencyHandler";
 import { isMultifileEnabled } from "./utilities/commonUtil";
+import { EntityForeignKeyDataMap } from "./context/entityForeignKeyDataMap";
 
 export interface IWebExtensionContext {
     // From portalSchema properties
@@ -94,6 +95,7 @@ class WebExtensionContext implements IWebExtensionContext {
     private _extensionUri: vscode.Uri;
     private _dataverseAccessToken: string;
     private _entityDataMap: EntityDataMap;
+    private _entityForeignKeyDataMap: EntityForeignKeyDataMap;
     private _isContextSet: boolean;
     private _currentSchemaVersion: string;
     private _websiteLanguageCode: string;
@@ -160,6 +162,9 @@ class WebExtensionContext implements IWebExtensionContext {
     public get entityDataMap() {
         return this._entityDataMap;
     }
+    public get entityForeignKeyDataMap() {
+        return this._entityForeignKeyDataMap;
+    }
     public get isContextSet() {
         return this._isContextSet;
     }
@@ -201,6 +206,7 @@ class WebExtensionContext implements IWebExtensionContext {
         this._rootDirectory = vscode.Uri.parse("");
         this._fileDataMap = new FileDataMap();
         this._entityDataMap = new EntityDataMap();
+        this._entityForeignKeyDataMap = new EntityForeignKeyDataMap();
         this._defaultFileUri = vscode.Uri.parse(``);
         this._showMultifileInVSCode = false;
         this._extensionActivationTime = new Date().getTime();
@@ -379,6 +385,16 @@ class WebExtensionContext implements IWebExtensionContext {
             mappingEntityId,
             fileUri,
             rootWebPageId);
+    }
+
+    public async updateForeignKeyDetailsInContext(
+        rootWebPageId: string,
+        entityId: string,
+    ) {
+        this.entityForeignKeyDataMap.setEntityForeignKey(
+            rootWebPageId,
+            entityId
+        );
     }
 
     public async updateSingleFileUrisInContext(uri: vscode.Uri) {

--- a/src/web/client/context/entityForeignKeyDataMap.ts
+++ b/src/web/client/context/entityForeignKeyDataMap.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+export class EntityForeignKeyDataMap {
+    private entityForeignKeyMap: Map<string, Set<string>> = new Map<string, Set<string>>();
+
+    public get getEntityForeignKeyMap(): Map<string, Set<string>> {
+        return this.entityForeignKeyMap;
+    }
+
+    public setEntityForeignKey(
+        rootWebPageId: string,
+        entityId: string
+    ) {
+        const existingEntity = this.entityForeignKeyMap.get(rootWebPageId) ?? new Set<string>();
+        existingEntity.add(entityId);
+        this.entityForeignKeyMap.set(rootWebPageId, existingEntity);
+    }
+}

--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -662,4 +662,22 @@ async function createVirtualFile(
         fileUri,
         rootWebPageId,
     );
+
+    // Maintain foreign key details in context
+    if (rootWebPageId) {
+        try {
+            await WebExtensionContext.updateForeignKeyDetailsInContext(
+                rootWebPageId,
+                entityId,
+            );
+        } catch (error) {
+            const errorMsg = (error as Error)?.message;
+            WebExtensionContext.telemetry.sendErrorTelemetry(
+                telemetryEventNames.WEB_EXTENSION_FAILED_TO_UPDATE_FOREIGN_KEY_DETAILS,
+                createVirtualFile.name,
+                errorMsg,
+                error as Error
+            );
+        }
+    }
 }

--- a/src/web/client/telemetry/constants.ts
+++ b/src/web/client/telemetry/constants.ts
@@ -99,4 +99,5 @@ export enum telemetryEventNames {
     WEB_EXTENSION_PREVIEW_SITE_TRIGGERED = 'webExtensionPreviewSiteTriggered',
     WEB_EXTENSION_IMAGE_EDIT_SUPPORTED_FILE_EXTENSION = 'webExtensionImageEditSupportedFileExtension',
     WEB_EXTENSION_SAVE_IMAGE_FILE_TRIGGERED = 'webExtensionSaveImageFileTriggered',
+    WEB_EXTENSION_FAILED_TO_UPDATE_FOREIGN_KEY_DETAILS = 'webExtensionFailedToUpdateForeignKeyDetails',
 }


### PR DESCRIPTION
created Entity Foreign Key Data Map
storing rootWebPageId as Key vs Set of content page id
Content Page Id is Entity Id in terms of vscode for web and a single root page id can correspond to multiple entity id if content is localized in multiple language