### PR TITLE
passing aadObject Id in container in user data map instead of user id

### DIFF
--- a/src/web/client/common/worker/webworker.js
+++ b/src/web/client/common/worker/webworker.js
@@ -115,7 +115,7 @@ async function loadContainer(config, swpId, entityInfo) {
                 self.postMessage({
                     type: "client-data",
                     userName: otherUser.userName,
-                    userId: key,
+                    userId: otherUser.additionalDetails.AadObjectId,
                     containerId: swpId,
                     entityId: userEntityIdArray,
                 });
@@ -141,7 +141,7 @@ async function loadContainer(config, swpId, entityInfo) {
                 // eslint-disable-next-line no-undef
                 await self.postMessage({
                     type: "client-data",
-                    userId: changed.key,
+                    userId: otherUser.additionalDetails.AadObjectId,
                     userName: otherUser.userName,
                     containerId: swpId,
                     entityId: userEntityIdArray,


### PR DESCRIPTION
Updating data to passed in user data map, adding Aad Object Id instead of user Id, because it can be further consumed to get mail and profile picture using Microsoft graph client.