### PR TITLE
Writing back in fluid container from web side

### DIFF
--- a/src/web/client/common/interfaces.ts
+++ b/src/web/client/common/interfaces.ts
@@ -16,6 +16,7 @@ export interface IAttributePath {
 export interface IEntityInfo {
     entityId: string;
     entityName: string;
+    rootWebPageId?: string;
 }
 
 export interface IFileInfo {

--- a/src/web/client/common/worker/webworker.js
+++ b/src/web/client/common/worker/webworker.js
@@ -87,7 +87,13 @@ async function loadContainer(config, swpId, entityInfo) {
 
         const existingMembers = audience.getMembers();
 
-        // TODO: yet to be decided how entity id will be passed in container from vscode side
+        const myself = audience.getMyself();
+
+        if (audience && myself) {
+            const myConnectionId = audience['container'].clientId;
+            const entityIdObj = new Array(entityInfo.rootWebPageId);
+            (await container.initialObjects.sharedState.get('selection').get()).set(myConnectionId, entityIdObj);
+        }
 
         audience.on("memberRemoved", (clientId, member) => {
             if (!existingMembers.get(member.userId)) {

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -238,7 +238,8 @@ export function processWorkspaceStateChanges(context: vscode.ExtensionContext) {
                     const document = tab.input;
                     const entityInfo: IEntityInfo = {
                         entityId: getFileEntityId(document.uri.fsPath),
-                        entityName: getFileEntityName(document.uri.fsPath)
+                        entityName: getFileEntityName(document.uri.fsPath),
+                        rootWebPageId: WebExtensionContext.entityDataMap.getEntityMap.get(getFileEntityId(document.uri.fsPath))?.rootWebPageId as string
                     };
                     if (entityInfo.entityId && entityInfo.entityName) {
                         context.workspaceState.update(document.uri.fsPath, entityInfo);


### PR DESCRIPTION
In this PR I'm writing back in fluid container from the web extension
I'm writing the rootWebPageId of the file user is present on against his current connection
resulting in showing his presence on studio on the same file

https://github.com/microsoft/powerplatform-vscode/assets/56073559/5a38ec61-4e32-4b9c-890e-e1d62115646c

