### PR TITLE
Integration test case failure fix: Bump up vscode/test-electron version per solution for vscode launch failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "@vscode/l10n-dev": "^0.0.24",
-        "@vscode/test-electron": "^2.3.3",
+        "@vscode/test-electron": "^2.3.8",
         "@vscode/test-web": "^0.0.44",
         "@vscode/vsce": "^2.19.0",
         "assert": "^2.0.0",
@@ -3718,15 +3718,15 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.3.tgz",
-      "integrity": "sha512-hgXCkDP0ibboF1K6seqQYyHAzCURgTwHS/6QU7slhwznDLwsRwg9bhfw1CZdyUEw8vvCmlrKWnd7BlQnI0BC4w==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
         "jszip": "^3.10.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -1027,7 +1027,7 @@
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "@vscode/l10n-dev": "^0.0.24",
-    "@vscode/test-electron": "^2.3.3",
+    "@vscode/test-electron": "^2.3.8",
     "@vscode/test-web": "^0.0.44",
     "@vscode/vsce": "^2.19.0",
     "assert": "^2.0.0",


### PR DESCRIPTION
Per the discussion on [this thread ](https://github.com/microsoft/vscode/issues/200895) the issue with integration test case run failure is due to failure to unbundle and launch vscode in integration test run process. Upgrading the test-electron version fixed the issue on local. Creating this PR to validate and fix this issue.