### PR TITLE
Set collectorEndpoint URL at build time

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -64,6 +64,17 @@ function setTelemetryTarget() {
         .pipe(gulp.dest(path.join('src', 'common', 'telemetry-generated')));
 }
 
+function setCollectorEndpoint() {
+    const collectorEndpointSource = isOfficialBuild
+        ? 'src/common/telemetry/collectorEndpointProd.ts'
+        : 'src/common/telemetry/collectorEndpointTip.ts';
+
+    return gulp
+        .src(collectorEndpointSource)
+        .pipe(rename('collectorEndpointConfiguration.ts'))
+        .pipe(gulp.dest(path.join('src', 'common', 'telemetry-generated')));
+}
+
 
 function compile() {
     return gulp
@@ -345,6 +356,7 @@ const recompile = gulp.series(
     translationsExport,
     translationsImport,
     setTelemetryTarget,
+    setCollectorEndpoint,
     compile,
     compileWeb,
     compileWorker,

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -15,6 +15,7 @@ import {getExtensionType, getExtensionVersion} from "../../common/Utils";
 import { EXTENSION_ID } from "../../client/constants";
 import {OneDSCollectorEventName} from "./EventContants";
 import { telemetryEventNames } from "../../web/client/telemetry/constants";
+import { collectorEndpointUrl } from "../telemetry-generated/collectorEndpointConfiguration";
 
 interface IInstrumentationSettings {
     endpointURL: string;
@@ -133,7 +134,7 @@ export class OneDSLogger implements ITelemetryLogger{
     private static getInstrumentationSettings(geo?:string): IInstrumentationSettings {
         const region:string = "test"; // TODO: Remove it from here and replace it with value getting from build. Check gulp.mjs (setTelemetryTarget)
         const instrumentationSettings:IInstrumentationSettings = {
-            endpointURL: 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/',
+            endpointURL: collectorEndpointUrl,
             instrumentationKey: 'bd47fc8d971f4283a6686ec46fd48782-bdef6c1c-75ab-417c-a1f7-8bbe21e12da6-7708'
         };
         switch (region) {
@@ -145,11 +146,11 @@ export class OneDSLogger implements ITelemetryLogger{
             case 'preview':
               switch (geo) {
                 case 'eu':
-                    instrumentationSettings.endpointURL = '' //prod endpoint;
+                    instrumentationSettings.endpointURL =collectorEndpointUrl,
                     instrumentationSettings.instrumentationKey = '' //prod key;
                   break;
                 default:
-                    instrumentationSettings.endpointURL = '' //prod endpoint;
+                    instrumentationSettings.endpointURL = collectorEndpointUrl,
                     instrumentationSettings.instrumentationKey = '' //prod key;
               }
               break;
@@ -157,7 +158,7 @@ export class OneDSLogger implements ITelemetryLogger{
             case 'high':
             case 'dod':
             case 'mooncake':
-                instrumentationSettings.endpointURL = '' //prod endpoint;
+                instrumentationSettings.endpointURL = collectorEndpointUrl,
                 instrumentationSettings.instrumentationKey = '' //prod key;
               break;
             case 'ex':

--- a/src/common/telemetry/collectorEndpointProd.ts
+++ b/src/common/telemetry/collectorEndpointProd.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+export const collectorEndpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0/';

--- a/src/common/telemetry/collectorEndpointTip.ts
+++ b/src/common/telemetry/collectorEndpointTip.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+export const collectorEndpointUrl = 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/';


### PR DESCRIPTION
We need to send telemetry data to TIP or PROD region. Using officialBuild we decide the endpoint. Introduced another function setCollectorEndpoint which determines the collectorEndpointURL and the same is consumed in oneDSLogger.