### PR TITLE
Integrate OneDSLoggerWrapper in WebExtensionTelemetry

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -64,14 +64,14 @@ function setTelemetryTarget() {
         .pipe(gulp.dest(path.join('src', 'common', 'telemetry-generated')));
 }
 
-function setCollectorEndpoint() {
-    const collectorEndpointSource = isOfficialBuild
-        ? 'src/common/telemetry/collectorEndpointProd.ts'
-        : 'src/common/telemetry/collectorEndpointTip.ts';
+function setBuildRegion() {
+    const buildRegion = isOfficialBuild
+        ? 'src/common/telemetry/buildRegionProd.ts'
+        : 'src/common/telemetry/buildRegionTip.ts';
 
     return gulp
-        .src(collectorEndpointSource)
-        .pipe(rename('collectorEndpointConfiguration.ts'))
+        .src(buildRegion)
+        .pipe(rename('buildRegionConfiguration.ts'))
         .pipe(gulp.dest(path.join('src', 'common', 'telemetry-generated')));
 }
 
@@ -356,7 +356,7 @@ const recompile = gulp.series(
     translationsExport,
     translationsImport,
     setTelemetryTarget,
-    setCollectorEndpoint,
+    setBuildRegion,
     compile,
     compileWeb,
     compileWorker,

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -16,7 +16,7 @@ import { EXTENSION_ID } from "../../client/constants";
 import {OneDSCollectorEventName} from "./EventContants";
 import { telemetryEventNames } from "../../web/client/telemetry/constants";
 import { region } from "../telemetry-generated/buildRegionConfiguration";
-import { geoMappingsToAzureRegion, regionShortName } from "./shortNameMappingToAzureRegion";
+import { geoMappingsToAzureRegion } from "./shortNameMappingToAzureRegion";
 
 interface IInstrumentationSettings {
     endpointURL: string;
@@ -138,7 +138,10 @@ export class OneDSLogger implements ITelemetryLogger{
             endpointURL: 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/',
             instrumentationKey: 'ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402'
         };
-        const geoName = geoMappingsToAzureRegion[geo ?? regionShortName.wus].geoName;
+        let geoName = 'us';
+        if(geoMappingsToAzureRegion[geo!]) {
+            geoName = geoMappingsToAzureRegion[geo!].geoName;
+        }
         switch (buildRegion) {
             case 'tie':
             case 'test':

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -15,7 +15,8 @@ import {getExtensionType, getExtensionVersion} from "../../common/Utils";
 import { EXTENSION_ID } from "../../client/constants";
 import {OneDSCollectorEventName} from "./EventContants";
 import { telemetryEventNames } from "../../web/client/telemetry/constants";
-import { collectorEndpointUrl } from "../telemetry-generated/collectorEndpointConfiguration";
+import { region } from "../telemetry-generated/buildRegionConfiguration";
+import { geoMappingsToAzureRegion } from "./shortNameMappingToAzureRegion";
 
 interface IInstrumentationSettings {
     endpointURL: string;
@@ -132,33 +133,53 @@ export class OneDSLogger implements ITelemetryLogger{
     }
 
     private static getInstrumentationSettings(geo?:string): IInstrumentationSettings {
-        const region:string = "test"; // TODO: Remove it from here and replace it with value getting from build. Check gulp.mjs (setTelemetryTarget)
+        const buildRegion:string = region;
         const instrumentationSettings:IInstrumentationSettings = {
-            endpointURL: collectorEndpointUrl,
-            instrumentationKey: 'bd47fc8d971f4283a6686ec46fd48782-bdef6c1c-75ab-417c-a1f7-8bbe21e12da6-7708'
+            endpointURL: 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/',
+            instrumentationKey: 'ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402'
         };
-        switch (region) {
+        const geoName = geoMappingsToAzureRegion[geo!].geoName;
+        switch (buildRegion) {
             case 'tie':
             case 'test':
             case 'preprod':
                 break;
             case 'prod':
             case 'preview':
-              switch (geo) {
+              switch (geoName) {
+                case 'us':
+                case 'br':
+                case 'jp':
+                case 'in':
+                case 'au':
+                case 'ca':
+                case 'as':
+                case 'za':
+                case 'ae':
+                case 'kr':
+                    instrumentationSettings.endpointURL ='https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
+                    instrumentationSettings.instrumentationKey =  '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                    break;
                 case 'eu':
-                    instrumentationSettings.endpointURL =collectorEndpointUrl,
-                    instrumentationSettings.instrumentationKey = '' //prod key;
-                  break;
+                case 'uk':
+                case 'de':
+                case 'fr':
+                case 'no':
+                case 'ch':
+                    instrumentationSettings.endpointURL ='https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/',
+                    instrumentationSettings.instrumentationKey =  '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                    break;
                 default:
-                    instrumentationSettings.endpointURL = collectorEndpointUrl,
-                    instrumentationSettings.instrumentationKey = '' //prod key;
+                    instrumentationSettings.endpointURL ='https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
+                    instrumentationSettings.instrumentationKey =  '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                    break;
               }
               break;
             case 'gov':
             case 'high':
             case 'dod':
             case 'mooncake':
-                instrumentationSettings.endpointURL = collectorEndpointUrl,
+                instrumentationSettings.endpointURL = '',
                 instrumentationSettings.instrumentationKey = '' //prod key;
               break;
             case 'ex':

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -16,7 +16,7 @@ import { EXTENSION_ID } from "../../client/constants";
 import {OneDSCollectorEventName} from "./EventContants";
 import { telemetryEventNames } from "../../web/client/telemetry/constants";
 import { region } from "../telemetry-generated/buildRegionConfiguration";
-import { geoMappingsToAzureRegion } from "./shortNameMappingToAzureRegion";
+import { geoMappingsToAzureRegion, regionShortName } from "./shortNameMappingToAzureRegion";
 
 interface IInstrumentationSettings {
     endpointURL: string;
@@ -138,7 +138,7 @@ export class OneDSLogger implements ITelemetryLogger{
             endpointURL: 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/',
             instrumentationKey: 'ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402'
         };
-        const geoName = geoMappingsToAzureRegion[geo!].geoName;
+        const geoName = geoMappingsToAzureRegion[geo ?? regionShortName.wus].geoName;
         switch (buildRegion) {
             case 'tie':
             case 'test':

--- a/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
+++ b/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
@@ -181,10 +181,12 @@ export const geoMappingsToAzureRegion = {
     [regionShortName.wno]: { geoName: 'no', azureRegion: azureRegions.NorwayWest },     
     [regionShortName.ckr]: { geoName: 'kr', azureRegion: azureRegions.KoreaCentral },
     [regionShortName.skr]: { geoName: 'kr', azureRegion: azureRegions.KoreaSouth },
-    [regionShortName.ugtx]: { geoName: 'us', azureRegion: azureRegions.GovernmentUSTexas },
-    [regionShortName.ugva]: { geoName: 'us', azureRegion: azureRegions.GovernmentUSVirginia },
-    [regionShortName.udc]: { geoName: 'us', azureRegion: azureRegions.GovernmentUSDodCentral },
-    [regionShortName.ude]: { geoName: 'us', azureRegion: azureRegions.GovernmentUSDodEast },
+    // Government US.
+    [regionShortName.ugtx]: { geoName: 'usgov', azureRegion: azureRegions.GovernmentUSTexas },
+    [regionShortName.ugva]: { geoName: 'usgov', azureRegion: azureRegions.GovernmentUSVirginia },
+    [regionShortName.udc]: { geoName: 'usgov', azureRegion: azureRegions.GovernmentUSDodCentral },
+    [regionShortName.ude]: { geoName: 'usgov', azureRegion: azureRegions.GovernmentUSDodEast },
+    // Goverment China Mooncake
     [regionShortName.cne]: { geoName: 'cn', azureRegion: azureRegions.ChinaEast },
     [regionShortName.cne2]: { geoName: 'cn', azureRegion: azureRegions.ChinaEast2 },
     [regionShortName.cne3]: { geoName: 'cn', azureRegion: azureRegions.ChinaEast3 },

--- a/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
+++ b/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-const azureRegions = {
+export const azureRegions = {
     // Americas
     USWest: 'westus',
     USWest2: 'westus2',
@@ -94,7 +94,7 @@ const azureRegions = {
     ChinaEast3: 'chinaeast3',
   };
   
-  const regionShortName = {
+  export const regionShortName = {
     wus: 'wus',
     cus: 'cus',
     eus: 'eus',

--- a/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
+++ b/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
@@ -143,7 +143,7 @@ const azureRegions = {
     cnn3: 'cnn3'
   };
   
-export const azureRegionsToGeoMappings = {
+export const geoMappingsToAzureRegion = {
     // Public
     [regionShortName.wus]: { geoName: 'us', azureRegion: azureRegions.USWest },
     [regionShortName.cus]: { geoName: 'us', azureRegion: azureRegions.USCentral },

--- a/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
+++ b/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+const azureRegions = {
+    // Americas
+    USWest: 'westus',
+    USWest2: 'westus2',
+    USCentral: 'centralus',
+    USEast: 'eastus',
+    USEast2: 'eastus2',
+    USNorthCentral: 'northcentralus',
+    USSouthCentral: 'southcentralus',
+    USWestCentral: 'westcentralus',
+    CanadaCentral: 'canadacentral',
+    CanadaEast: 'canadaeast',
+    BrazilSouth: 'brazilsouth',
+  
+    // Europe
+    EuropeNorth: 'northeurope',
+    EuropeWest: 'westeurope',
+    UKSouth: 'uksouth',
+    UKWest: 'ukwest',
+    FranceCentral: 'francecentral',
+    FranceSouth: 'francesouth',
+    SwitzerlandNorth: 'switzerlandnorth',
+    SwitzerlandWest: 'switzerlandwest',
+    GermanyNorth: 'germanynorth',
+    GermanyWestCentral: 'germanywestcentral',
+    NorwayWest: 'norwaywest',
+    NorwayEast: 'norwayeast',
+  
+    // Asia
+    AsiaEast: 'eastasia',
+    AsiaSouthEast: 'southeastasia',
+    JapanEast: 'japaneast',
+    JapanWest: 'japanwest',
+    AustraliaEast: 'australiaeast',
+    AustraliaSouthEast: 'australiasoutheast',
+    AustraliaCentral: 'australiacentral',
+    AustraliaCentral2: 'australiacentral2',
+    IndiaCentral: 'centralindia',
+    IndiaSouth: 'southindia',
+    IndiaWest: 'westindia',
+    KoreaSouth: 'koreasouth',
+    KoreaCentral: 'koreacentral',
+  
+    // UAE
+    UAECentral: 'uaecentral',
+    UAENorth: 'uaenorth',
+    SouthAfricaNorth: 'southafricanorth',
+    SouthAfricaWest: 'southafricawest',
+  
+    // Germany
+    GermanyCentral: 'germanycentral',
+    GermanyNorthEast: 'germanynortheast',
+  
+    // Singapore
+    SingaporeSouthEast: 'southeastasia',
+  
+    /// <summary>
+    /// U.S. government cloud in Virginia.
+    /// </summary>
+  
+    GovernmentUSVirginia: 'usgovvirginia',
+  
+    /// <summary>
+    /// U.S. government cloud in Iowa.
+    /// </summary>
+    GovernmentUSIowa: 'usgoviowa',
+  
+    /// <summary>
+    /// U.S. government cloud in Arizona.
+    /// </summary>
+    GovernmentUSArizona: 'usgovarizona',
+  
+    /// <summary>
+    /// U.S. government cloud in Texas.
+    /// </summary>
+    GovernmentUSTexas: 'usgovtexas',
+  
+    GovernmentUSDodEast: 'usdodeast',
+    GovernmentUSDodCentral: 'usdodcentral',
+  
+    /// <summary>
+    /// China Environment
+    /// <summary>
+    ChinaNorth: 'chinanorth',
+    ChinaNorth2: 'chinanorth2',
+    ChinaNorth3: 'chinanorth3',
+    ChinaEast: 'chinaeast',
+    ChinaEast2: 'chinaeast2',
+    ChinaEast3: 'chinaeast3',
+  };
+  
+  const regionShortName = {
+    wus: 'wus',
+    cus: 'cus',
+    eus: 'eus',
+    eus2: 'eus2',
+    wcus: 'wcus',
+    wus2: 'wus2',
+    scus: 'scus',
+    sbr: 'sbr',
+    suk: 'suk',
+    wuk: 'wuk',
+    ejp: 'ejp',
+    wjp: 'wjp',
+    cin: 'cin',
+    sin: 'sin',
+    wcde: 'wcde',
+    nde: 'nde',
+    neu: 'neu',
+    weu: 'weu',
+    eau: 'eau',
+    seau: 'seau',
+    seas: 'seas',
+    eas: 'eas',
+    cca: 'cca',
+    eca: 'eca',
+    nza: 'nza',
+    wza: 'wza',
+    cfr: 'cfr',
+    sfr: 'sfr',
+    nae: 'nae',
+    cae: 'cae',
+    nch: 'nch',
+    wch: 'wch',
+    eno: 'eno',
+    wno: 'wno',
+    ckr: 'ckr',
+    skr: 'skr',
+    ugtx: 'ugtx',
+    ugva: 'ugva',
+    udc: 'udc',
+    ude: 'ude',
+    cne: 'cne',
+    cne2: 'cne2',
+    cne3: 'cne3',
+    cnn: 'cnn',
+    cnn2: 'cnn2',
+    cnn3: 'cnn3'
+  };
+  
+export const azureRegionsToGeoMappings = {
+    // Public
+    [regionShortName.wus]: { geoName: 'us', azureRegion: azureRegions.USWest },
+    [regionShortName.cus]: { geoName: 'us', azureRegion: azureRegions.USCentral },
+    [regionShortName.eus]: { geoName: 'us', azureRegion: azureRegions.USEast },
+    [regionShortName.eus2]: { geoName: 'us', azureRegion: azureRegions.USEast2 },
+    [regionShortName.wcus]: { geoName: 'us', azureRegion: azureRegions.USWestCentral },
+    [regionShortName.wus2]: { geoName: 'us', azureRegion: azureRegions.USWest2 },
+    [regionShortName.scus]: { geoName: 'us', azureRegion: azureRegions.USSouthCentral },
+    [regionShortName.sbr]: { geoName: 'br', azureRegion: azureRegions.BrazilSouth },
+    [regionShortName.suk]: { geoName: 'uk', azureRegion: azureRegions.UKSouth },
+    [regionShortName.wuk]: { geoName: 'uk', azureRegion: azureRegions.UKWest },
+    [regionShortName.ejp]: { geoName: 'jp', azureRegion: azureRegions.JapanEast },
+    [regionShortName.wjp]: { geoName: 'jp', azureRegion: azureRegions.JapanWest },
+    [regionShortName.cin]: { geoName: 'in', azureRegion: azureRegions.IndiaCentral },
+    [regionShortName.sin]: { geoName: 'in', azureRegion: azureRegions.IndiaSouth },
+    [regionShortName.wcde]: { geoName: 'de', azureRegion: azureRegions.GermanyWestCentral },
+    [regionShortName.nde]: { geoName: 'de', azureRegion: azureRegions.GermanyNorth },
+    [regionShortName.neu]: { geoName: 'eu', azureRegion: azureRegions.EuropeNorth },
+    [regionShortName.weu]: { geoName: 'eu', azureRegion: azureRegions.EuropeWest },
+    [regionShortName.eau]: { geoName: 'au', azureRegion: azureRegions.AustraliaEast },
+    [regionShortName.seau]: { geoName: 'au', azureRegion: azureRegions.AustraliaSouthEast },
+    [regionShortName.seas]: { geoName: 'as', azureRegion: azureRegions.AsiaSouthEast },
+    [regionShortName.eas]: { geoName: 'as', azureRegion: azureRegions.AsiaEast },
+    [regionShortName.cca]: { geoName: 'ca', azureRegion: azureRegions.CanadaCentral },
+    [regionShortName.eca]: { geoName: 'ca', azureRegion: azureRegions.CanadaEast },
+    [regionShortName.nza]: { geoName: 'za', azureRegion: azureRegions.SouthAfricaNorth },
+    [regionShortName.wza]: { geoName: 'za', azureRegion: azureRegions.SouthAfricaWest },
+    [regionShortName.cfr]: { geoName: 'fr', azureRegion: azureRegions.FranceCentral },
+    [regionShortName.sfr]: { geoName: 'fr', azureRegion: azureRegions.FranceSouth },
+    [regionShortName.nae]: { geoName: 'ae', azureRegion: azureRegions.UAENorth },
+    [regionShortName.cae]: { geoName: 'ae', azureRegion: azureRegions.UAECentral },
+    [regionShortName.nch]: { geoName: 'ch', azureRegion: azureRegions.SwitzerlandNorth },
+    [regionShortName.wch]: { geoName: 'ch', azureRegion: azureRegions.SwitzerlandWest },
+    [regionShortName.eno]: { geoName: 'no', azureRegion: azureRegions.NorwayEast },
+    [regionShortName.wno]: { geoName: 'no', azureRegion: azureRegions.NorwayWest },     
+    [regionShortName.ckr]: { geoName: 'kr', azureRegion: azureRegions.KoreaCentral },
+    [regionShortName.skr]: { geoName: 'kr', azureRegion: azureRegions.KoreaSouth },
+    [regionShortName.ugtx]: { geoName: 'us', azureRegion: azureRegions.GovernmentUSTexas },
+    [regionShortName.ugva]: { geoName: 'us', azureRegion: azureRegions.GovernmentUSVirginia },
+    [regionShortName.udc]: { geoName: 'us', azureRegion: azureRegions.GovernmentUSDodCentral },
+    [regionShortName.ude]: { geoName: 'us', azureRegion: azureRegions.GovernmentUSDodEast },
+    [regionShortName.cne]: { geoName: 'cn', azureRegion: azureRegions.ChinaEast },
+    [regionShortName.cne2]: { geoName: 'cn', azureRegion: azureRegions.ChinaEast2 },
+    [regionShortName.cne3]: { geoName: 'cn', azureRegion: azureRegions.ChinaEast3 },
+    [regionShortName.cnn]: { geoName: 'cn', azureRegion: azureRegions.ChinaNorth },
+    [regionShortName.cnn2]: { geoName: 'cn', azureRegion: azureRegions.ChinaNorth2 },
+    [regionShortName.cnn3]: { geoName: 'cn', azureRegion: azureRegions.ChinaNorth3 },
+  };
+  

--- a/src/common/telemetry/buildRegionProd.ts
+++ b/src/common/telemetry/buildRegionProd.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-export const collectorEndpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0/';
+export const region = 'prod';

--- a/src/common/telemetry/buildRegionTip.ts
+++ b/src/common/telemetry/buildRegionTip.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-export const collectorEndpointUrl = 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/';
+export const region = 'test';

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -46,7 +46,7 @@ export function activate(context: vscode.ExtensionContext): void {
         vscodeExtAppInsightsResourceProvider.GetAppInsightsResourceForDataBoundary(
             dataBoundary
         );
-    // Unauthenticated scenarios
+    // TODO: Need to replace the geo on confirmation from our Privacy champ. Unauthenticated scenarios
     oneDSLoggerWrapper.instantiate();
     WebExtensionContext.setVscodeWorkspaceState(context.workspaceState);
     WebExtensionContext.telemetry.setTelemetryReporter(

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -92,10 +92,10 @@ export function activate(context: vscode.ExtensionContext): void {
                         );
                     }
                 }
-                const geo = queryParamsMap.get('geo')?.toUpperCase();
+                const geo = queryParamsMap.get('geo')?.toLowerCase();
                 // Authenticated scenario. Pass the geo to OneDSLogger for data boundary
                 if(geo){
-                    oneDSLoggerWrapper.instantiate(queryParamsMap.get('geo')?.toUpperCase());
+                    oneDSLoggerWrapper.instantiate(geo);
                 }
                 if (
                     !checkMandatoryParameters(

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -93,6 +93,7 @@ export function activate(context: vscode.ExtensionContext): void {
                     }
                 }
                 const geo = queryParamsMap.get('geo')?.toUpperCase();
+                // Authenticated scenario. Pass the geo to OneDSLogger for data boundary
                 if(geo !== undefined && geo !== null && geo !== ''){
                     oneDSLoggerWrapper.instantiate(queryParamsMap.get('geo')?.toUpperCase());
                 }

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -94,7 +94,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 }
                 const geo = queryParamsMap.get('geo')?.toUpperCase();
                 // Authenticated scenario. Pass the geo to OneDSLogger for data boundary
-                if(geo !== undefined && geo !== null && geo !== ''){
+                if(geo){
                     oneDSLoggerWrapper.instantiate(queryParamsMap.get('geo')?.toUpperCase());
                 }
                 if (

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -36,6 +36,7 @@ import { copilotNotificationPanel, disposeNotificationPanel } from "../../common
 import { COPILOT_NOTIFICATION_DISABLED } from "../../common/copilot/constants";
 import * as Constants from "./common/constants"
 import { fetchArtemisResponse } from "../../common/ArtemisService";
+import { oneDSLoggerWrapper } from "../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
 export function activate(context: vscode.ExtensionContext): void {
     // setup telemetry
@@ -45,6 +46,8 @@ export function activate(context: vscode.ExtensionContext): void {
         vscodeExtAppInsightsResourceProvider.GetAppInsightsResourceForDataBoundary(
             dataBoundary
         );
+    // Unauthenticated scenarios
+    oneDSLoggerWrapper.instantiate();
     WebExtensionContext.setVscodeWorkspaceState(context.workspaceState);
     WebExtensionContext.telemetry.setTelemetryReporter(
         context.extension.id,
@@ -89,7 +92,10 @@ export function activate(context: vscode.ExtensionContext): void {
                         );
                     }
                 }
-
+                const geo = queryParamsMap.get('geo')?.toUpperCase();
+                if(geo !== undefined && geo !== null && geo !== ''){
+                    oneDSLoggerWrapper.instantiate(queryParamsMap.get('geo')?.toUpperCase());
+                }
                 if (
                     !checkMandatoryParameters(
                         appName,

--- a/src/web/client/telemetry/webExtensionTelemetry.ts
+++ b/src/web/client/telemetry/webExtensionTelemetry.ts
@@ -10,6 +10,7 @@ import { sanitizeURL } from "../utilities/urlBuilderUtil";
 import { telemetryEventNames } from "./constants";
 import { IPortalWebExtensionInitQueryParametersTelemetryData, IWebExtensionAPITelemetryData, IWebExtensionExceptionTelemetryData, IWebExtensionInitPathTelemetryData, IWebExtensionPerfTelemetryData } from "./webExtensionTelemetryInterface";
 import { isNullOrUndefined } from '../utilities/commonUtil';
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
 export class WebExtensionTelemetry {
     private _telemetry: TelemetryReporter | undefined;
@@ -33,6 +34,7 @@ export class WebExtensionTelemetry {
             }
         }
         this._telemetry?.sendTelemetryEvent(telemetryData.eventName, telemetryData.properties);
+        oneDSLoggerWrapper.getLogger().traceInfo(telemetryData.eventName, telemetryData.properties);
     }
 
     public sendExtensionInitQueryParametersTelemetry(queryParamsMap: Map<string, string>) {
@@ -54,6 +56,7 @@ export class WebExtensionTelemetry {
             }
         }
         this._telemetry?.sendTelemetryEvent(telemetryData.eventName, telemetryData.properties);
+        oneDSLoggerWrapper.getLogger().traceInfo(telemetryData.eventName, telemetryData.properties);
     }
 
     public sendErrorTelemetry(eventName: string, methodName: string, errorMessage?: string, error?: Error) {
@@ -71,13 +74,18 @@ export class WebExtensionTelemetry {
         if (errorMessage || error) {
             const error: Error = new Error(errorMessage);
             this._telemetry?.sendTelemetryException(error, telemetryData.properties);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            oneDSLoggerWrapper.getLogger().traceError(eventName, errorMessage!, error, telemetryData.properties);
         } else {
             this._telemetry?.sendTelemetryException(new Error(), telemetryData.properties);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            oneDSLoggerWrapper.getLogger().traceError(eventName, errorMessage!, new Error(), telemetryData.properties);
         }
     }
 
     public sendInfoTelemetry(eventName: string, properties?: Record<string, string>) {
         this._telemetry?.sendTelemetryEvent(eventName, properties);
+        oneDSLoggerWrapper.getLogger().traceInfo(eventName, properties);
     }
 
     public sendAPITelemetry(
@@ -112,8 +120,10 @@ export class WebExtensionTelemetry {
         if (errorMessage) {
             const error: Error = new Error(errorMessage);
             this._telemetry?.sendTelemetryException(error, { ...telemetryData.properties, eventName: eventName }, telemetryData.measurements);
+            oneDSLoggerWrapper.getLogger().traceError(eventName, errorMessage, error, telemetryData.properties, telemetryData.measurements);
         } else {
             this._telemetry?.sendTelemetryEvent(telemetryData.eventName, telemetryData.properties, telemetryData.measurements);
+            oneDSLoggerWrapper.getLogger().traceInfo(telemetryData.eventName, telemetryData.properties,  telemetryData.measurements);
         }
     }
 
@@ -172,6 +182,7 @@ export class WebExtensionTelemetry {
             }
         }
         this._telemetry?.sendTelemetryEvent(telemetryData.eventName, undefined, telemetryData.measurements);
+        oneDSLoggerWrapper.getLogger().traceInfo(telemetryData.eventName, undefined, telemetryData.measurements);
     }
 
     private getPathParameterValue(parameter: string | undefined | null): string {

--- a/src/web/client/test/integration/AuthenticationProvider.test.ts
+++ b/src/web/client/test/integration/AuthenticationProvider.test.ts
@@ -13,6 +13,7 @@ import vscode from "vscode";
 import WebExtensionContext from "../../WebExtensionContext";
 import { telemetryEventNames } from "../../telemetry/constants";
 import * as errorHandler from "../../common/errorHandler";
+import { oneDSLoggerWrapper } from "../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
 describe("Authentication Provider", () => {
     afterEach(() => {
@@ -67,6 +68,11 @@ describe("Authentication Provider", () => {
             "sendErrorTelemetry"
         );
 
+        const sendErrorTelemetry1 = sinon.spy(
+            oneDSLoggerWrapper.getLogger(),
+            "traceError"
+        );
+
         //Act
         const result = await dataverseAuthentication(dataverseOrgURL);
 
@@ -83,6 +89,7 @@ describe("Authentication Provider", () => {
         sinon.assert.calledOnce(showErrorDialog);
         sinon.assert.calledOnce(sendErrorTelemetry);
         sinon.assert.calledOnce(_mockgetSession);
+        sinon.assert.calledOnce(sendErrorTelemetry1);
         expect(result).empty;
     });
 

--- a/src/web/client/test/integration/AuthenticationProvider.test.ts
+++ b/src/web/client/test/integration/AuthenticationProvider.test.ts
@@ -13,9 +13,20 @@ import vscode from "vscode";
 import WebExtensionContext from "../../WebExtensionContext";
 import { telemetryEventNames } from "../../telemetry/constants";
 import * as errorHandler from "../../common/errorHandler";
-import { oneDSLoggerWrapper } from "../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import {oneDSLoggerWrapper} from "../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+
+let traceError: any
 
 describe("Authentication Provider", () => {
+    before(() => {
+        oneDSLoggerWrapper.instantiate();
+        traceError = sinon.stub(oneDSLoggerWrapper.getLogger(), "traceError")
+    })
+
+    after(() => {
+        traceError.restore()
+    })
+
     afterEach(() => {
         // Restore the default sandbox here
         sinon.restore();
@@ -68,11 +79,6 @@ describe("Authentication Provider", () => {
             "sendErrorTelemetry"
         );
 
-        const sendErrorTelemetry1 = sinon.spy(
-            oneDSLoggerWrapper.getLogger(),
-            "traceError"
-        );
-
         //Act
         const result = await dataverseAuthentication(dataverseOrgURL);
 
@@ -89,7 +95,6 @@ describe("Authentication Provider", () => {
         sinon.assert.calledOnce(showErrorDialog);
         sinon.assert.calledOnce(sendErrorTelemetry);
         sinon.assert.calledOnce(_mockgetSession);
-        sinon.assert.calledOnce(sendErrorTelemetry1);
         expect(result).empty;
     });
 

--- a/src/web/client/test/integration/AuthenticationProvider.test.ts
+++ b/src/web/client/test/integration/AuthenticationProvider.test.ts
@@ -15,6 +15,7 @@ import { telemetryEventNames } from "../../telemetry/constants";
 import * as errorHandler from "../../common/errorHandler";
 import {oneDSLoggerWrapper} from "../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let traceError: any
 
 describe("Authentication Provider", () => {


### PR DESCRIPTION
Integrate OneDSLoggerWrapper in WebExtensionTelemetry
Introduce a constant shortNameMappingtoAzureRegion. It will later used in OneDSLogger.