### PR TITLE
Fixing codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # Top level code owners
 
-* @ashishchoudhary001
-* @microsoft/PowerPlatform-ISV-Tools-Admin
+* @ashishchoudhary001 @microsoft/PowerPlatform-ISV-Tools-Admin


### PR DESCRIPTION
[Codeowners docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file)

Multiple owners can be listed per line, and the last line which matches the pattern takes precedence, so Ashish's line would never kick in.