### PR TITLE
Add referrerSource query parameter to telemetry data.

### DIFF
--- a/src/common/OneDSLoggerTelemetry/IEventTypes.ts
+++ b/src/common/OneDSLoggerTelemetry/IEventTypes.ts
@@ -46,4 +46,5 @@ export interface ICustomEvent {
     correlationId?: string;
     referrer? :string;
     envId?: string;
+    referrerSource?: string;
   }

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -44,7 +44,7 @@ export class OneDSLogger implements ITelemetryLogger{
                 typeof payload.data === "string"
                     ? payload.data
                     : new TextDecoder().decode(payload.data);
-    
+
             const requestInit: RequestInit = {
                 body: telemetryRequestData,
                 method: "POST",
@@ -57,7 +57,7 @@ export class OneDSLogger implements ITelemetryLogger{
                     response.headers.forEach((value: string, name: string) => {
                         headerMap[name] = value;
                     });
-    
+
                     if (response.body) {
                         response
                             .text()
@@ -81,7 +81,7 @@ export class OneDSLogger implements ITelemetryLogger{
                 });
         },
     };
-    
+
     public constructor(geo?:string ) {
 
         this.appInsightsCore = new AppInsightsCore();
@@ -93,7 +93,7 @@ export class OneDSLogger implements ITelemetryLogger{
 		};
 
         const instrumentationSetting : IInstrumentationSettings= OneDSLogger.getInstrumentationSettings(geo); // Need to replace with actual data
-		
+
 		// Configure App insights core to send to collector
 		const coreConfig: IExtendedConfiguration = {
 			instrumentationKey: instrumentationSetting.instrumentationKey,
@@ -128,7 +128,8 @@ export class OneDSLogger implements ITelemetryLogger{
             schema: "",
             correlationId: "",
             referrer: "",
-            envId: ""
+            envId: "",
+            referrerSource: "",
         }
     }
 
@@ -189,10 +190,10 @@ export class OneDSLogger implements ITelemetryLogger{
             case 'rx':
             default:
               break;
-          }    
+          }
         return instrumentationSettings;
       }
-    
+
 	/// Trace info log
 	public traceInfo(eventName:string, eventInfo?:object, measurement?: object) {
 		const event = {
@@ -266,7 +267,7 @@ export class OneDSLogger implements ITelemetryLogger{
     }
 
     /// Populate attributes that are common to all events
-	private populateCommonAttributes() {	
+	private populateCommonAttributes() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (envelope:any) => {
 			try {
@@ -279,7 +280,7 @@ export class OneDSLogger implements ITelemetryLogger{
                     envelope.data.vscodeExtensionVersion = getExtensionVersion();
                     envelope.data.vscodeVersion = vscode.version;
                     envelope.data.domain = vscode.env.appHost;
-                    // Adding below attributes so they get populated in Geneva. 
+                    // Adding below attributes so they get populated in Geneva.
                     // TODO: It needs implementation for populating the actual value
                     envelope.data.eventSubType = "test";
                     envelope.data.scenarioId = "test";
@@ -294,7 +295,7 @@ export class OneDSLogger implements ITelemetryLogger{
                     envelope.data.browserVersion = "test";
                     envelope.data.browserLanguage = "test";
                     envelope.data.screenResolution = "test";
-                    envelope.data.osName = "test"; 
+                    envelope.data.osName = "test";
                     envelope.data.osVersion = "test";
                     if (getExtensionType() == 'Web'){
                         this.populateVscodeWebAttributes(envelope);
@@ -310,7 +311,7 @@ export class OneDSLogger implements ITelemetryLogger{
                   //  envelope = this.redactSensitiveDataFromEvent(envelope);
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            catch (exception:any) 
+            catch (exception:any)
 			{
 				// Such exceptions are likely if we are trying to process event attributes which don't exist
 				// In such cases, only add common attributes and current exception details, and avoid processing the event attributes further
@@ -337,6 +338,7 @@ export class OneDSLogger implements ITelemetryLogger{
             OneDSLogger.contextInfo.correlationId = JSON.parse(envelope.data.eventInfo).referrerSessionId;
             OneDSLogger.contextInfo.referrer = JSON.parse(envelope.data.eventInfo).referrer;
             OneDSLogger.contextInfo.envId = JSON.parse(envelope.data.eventInfo).envId;
+            OneDSLogger.contextInfo.referrerSource = JSON.parse(envelope.data.eventInfo).referrerSource;
         }
         if (envelope.data.eventName ==  telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_COMPLETED){
             OneDSLogger.userInfo.oid= JSON.parse(envelope.data.eventInfo).userId;

--- a/src/web/client/common/constants.ts
+++ b/src/web/client/common/constants.ts
@@ -98,7 +98,8 @@ export enum queryParameters {
     ENV_ID = "envid",
     GEO = "geo",
     ENABLE_MULTIFILE = "enablemultifile",
-    WEBSITE_PREVIEW_URL = "websitepreviewurl"
+    WEBSITE_PREVIEW_URL = "websitepreviewurl",
+    REFERRER_SOURCE = "referrersource"
 }
 
 export enum httpMethod {

--- a/src/web/client/telemetry/webExtensionTelemetry.ts
+++ b/src/web/client/telemetry/webExtensionTelemetry.ts
@@ -52,7 +52,8 @@ export class WebExtensionTelemetry {
                 siteVisibility: queryParamsMap.get(queryParameters.SITE_VISIBILITY),
                 region: queryParamsMap.get(queryParameters.REGION),
                 geo: queryParamsMap.get(queryParameters.GEO),
-                envId: queryParamsMap.get(queryParameters.ENV_ID)
+                envId: queryParamsMap.get(queryParameters.ENV_ID),
+                referrerSource: queryParamsMap.get(queryParameters.REFERRER_SOURCE)
             }
         }
         this._telemetry?.sendTelemetryEvent(telemetryData.eventName, telemetryData.properties);

--- a/src/web/client/telemetry/webExtensionTelemetryInterface.ts
+++ b/src/web/client/telemetry/webExtensionTelemetryInterface.ts
@@ -19,6 +19,7 @@ export interface IPortalWebExtensionInitQueryParametersTelemetryData extends IWe
         'region'?: string;
         'geo'?: string;
         'envId'?: string;
+        'referrerSource'?: string;
     }
 }
 

--- a/src/web/client/test/integration/webExtensionTelemetry.test.ts
+++ b/src/web/client/test/integration/webExtensionTelemetry.test.ts
@@ -99,7 +99,8 @@ describe("webExtensionTelemetry", () => {
             [queryParameters.SITE_VISIBILITY, "false"],
             [queryParameters.REGION, "NAM"],
             [queryParameters.GEO, "US"],
-            [queryParameters.ENV_ID, "c4dc3686-1e6b-e428-b886-16cd0b9f4918"]
+            [queryParameters.ENV_ID, "c4dc3686-1e6b-e428-b886-16cd0b9f4918"],
+            [queryParameters.REFERRER_SOURCE, "test"],
         ]);
 
         const sendTelemetryEvent = stub(telemetry, "sendTelemetryEvent");
@@ -118,6 +119,7 @@ describe("webExtensionTelemetry", () => {
             region: queryParamsMap.get(queryParameters.REGION),
             geo: queryParamsMap.get(queryParameters.GEO),
             envId: queryParamsMap.get(queryParameters.ENV_ID),
+            referrerSource: queryParamsMap.get(queryParameters.REFERRER_SOURCE),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any;
 
@@ -154,6 +156,7 @@ describe("webExtensionTelemetry", () => {
             region: queryParamsMap.get(queryParameters.REGION),
             geo: queryParamsMap.get(queryParameters.GEO),
             envId: queryParamsMap.get(queryParameters.ENV_ID),
+            referrerSource: queryParamsMap.get(queryParameters.REFERRER_SOURCE),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any;
 


### PR DESCRIPTION
This pull request primarily focuses on adding the referrerSource query parameter to telemetry data. The referrerSource refers to the name of the entry point component from which the VSCode extension was launched from other surfaces.