### PR TITLE
Populate Website ID in context for desktop extension

### DIFF
--- a/src/client/PortalWebView.ts
+++ b/src/client/PortalWebView.ts
@@ -170,7 +170,7 @@ export class PortalWebView {
         return html;
     }
 
-    private static getPortalRootFolder(): vscode.Uri | null {
+    public static getPortalRootFolder(): vscode.Uri | null {
         const fileBeingEdited = vscode.window.activeTextEditor as vscode.TextEditor;
         if (fileBeingEdited) {
             for (let i = 0; !!(vscode.workspace.workspaceFolders) && (i < vscode.workspace.workspaceFolders?.length); i++) {

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -11,9 +11,9 @@ import { ITelemetryLogger } from "./ITelemetryLogger";
 import { IContextInfo, IUserInfo } from "./IEventTypes";
 import { EventType, Severity } from "./telemetryConstants";
 import * as vscode from "vscode";
-import {getExtensionType, getExtensionVersion} from "../../common/Utils";
+import { getExtensionType, getExtensionVersion, getWebsiteIdFromPACData } from "../../common/Utils";
 import { EXTENSION_ID } from "../../client/constants";
-import {OneDSCollectorEventName} from "./EventContants";
+import { OneDSCollectorEventName } from "./EventContants";
 import { telemetryEventNames } from "../../web/client/telemetry/constants";
 import { region } from "../telemetry-generated/buildRegionConfiguration";
 import { geoMappingsToAzureRegion } from "./shortNameMappingToAzureRegion";
@@ -194,11 +194,14 @@ export class OneDSLogger implements ITelemetryLogger{
         return instrumentationSettings;
       }
 
-	/// Trace info log
-	public traceInfo(eventName:string, eventInfo?:object, measurement?: object) {
-		const event = {
-			name: OneDSCollectorEventName.VSCODE_EVENT,
-			data: {
+    /// Trace info log
+    public async traceInfo(eventName: string, eventInfo?: object, measurement?: object) {
+        if (getExtensionType() == 'Desktop') {
+            OneDSLogger.contextInfo.websiteId = await getWebsiteIdFromPACData();
+        }
+        const event = {
+            name: OneDSCollectorEventName.VSCODE_EVENT,
+            data: {
                 eventName: eventName,
                 eventType: EventType.TRACE,
                 severity: Severity.INFO,
@@ -210,11 +213,14 @@ export class OneDSLogger implements ITelemetryLogger{
 		this.appInsightsCore.track(event);
 	}
 
-	/// Trace warning log
-	public traceWarning(eventName:string, eventInfo?: object, measurement?: object) {
-		const event = {
-			name: OneDSCollectorEventName.VSCODE_EVENT,
-			data: {
+    /// Trace warning log
+    public async traceWarning(eventName: string, eventInfo?: object, measurement?: object) {
+        if (getExtensionType() == 'Desktop') {
+            OneDSLogger.contextInfo.websiteId = await getWebsiteIdFromPACData();
+        }
+        const event = {
+            name: OneDSCollectorEventName.VSCODE_EVENT,
+            data: {
                 eventName: eventName,
 				eventType: EventType.TRACE,
                 severity: Severity.WARN,
@@ -227,10 +233,14 @@ export class OneDSLogger implements ITelemetryLogger{
 	}
 
     // Trace error log
-	public traceError(eventName: string, errorMessage: string, exception: Error, eventInfo?:object, measurement?: object) {
-		const event = {
-			name: OneDSCollectorEventName.VSCODE_EVENT,
-			data: {
+    public async traceError(eventName: string, errorMessage: string, exception: Error, eventInfo?: object, measurement?: object) {
+        if (getExtensionType() == 'Desktop') {
+            OneDSLogger.contextInfo.websiteId = await getWebsiteIdFromPACData();
+        }
+
+        const event = {
+            name: OneDSCollectorEventName.VSCODE_EVENT,
+            data: {
                 eventName: eventName,
 				eventType: EventType.TRACE,
                 severity: Severity.ERROR,
@@ -244,12 +254,14 @@ export class OneDSLogger implements ITelemetryLogger{
         this.appInsightsCore.track(event);
     }
 
-    public  featureUsage(
+    public async featureUsage(
         featureName: string,
         eventName: string,
         customDimensions?: object
-      ) {
-
+    ) {
+        if (getExtensionType() == 'Desktop') {
+            OneDSLogger.contextInfo.websiteId = await getWebsiteIdFromPACData();
+        }
         const event = {
 			name: OneDSCollectorEventName.VSCODE_EVENT,
 			data: {

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -7,6 +7,7 @@
 import * as vscode from "vscode";
 import { EXTENSION_ID, SETTINGS_EXPERIMENTAL_STORE_NAME } from "../client/constants";
 import { CUSTOM_TELEMETRY_FOR_POWER_PAGES_SETTING_NAME } from "./OneDSLoggerTelemetry/telemetryConstants";
+import { PortalWebView } from "../client/PortalWebView";
 
 export function getSelectedCode(editor: vscode.TextEditor): string {
     if (!editor) {
@@ -122,4 +123,19 @@ export function isCustomTelemetryEnabled():boolean {
         .getConfiguration(SETTINGS_EXPERIMENTAL_STORE_NAME)
         .get(CUSTOM_TELEMETRY_FOR_POWER_PAGES_SETTING_NAME);
     return isCustomTelemetryEnabled as boolean;
+}
+
+export const getWebsiteIdFromPACData = async (): Promise<string> => {
+    const rootFolder = PortalWebView.getPortalRootFolder();
+    if (!rootFolder) return '';
+    const l = rootFolder?.with({ path: rootFolder.path + "/.portalconfig/websitebinding.yml" });
+    const websiteBindingYmlContent = new TextDecoder().decode(await vscode.workspace.fs.readFile(l));
+    const regex = /adx_websitebindingid:\s*([^\s]+)/i;
+    // Use the regular expression to find a match in the fileContent
+    const match = regex.exec(websiteBindingYmlContent);
+    // If a match is found, return the value of adx_websitebindingid
+    if (match && match[1]) {
+        return match[1];
+    }
+    return '';
 }


### PR DESCRIPTION
Description

Populate context object in desktop extension - website ID field to be logged for every trace.
The value for this field will be logged based on the active file in vs code. 
If no active file or issue in finding root folder for the data - empty string gets logged as website id.
