### PR TITLE
Dependabot alerts package override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1896,76 +1896,40 @@
       }
     },
     "node_modules/@fluidframework/server-services-client": {
-      "version": "0.1036.5001",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
-      "integrity": "sha512-e+Zk2uPcds9yqlalAZ0PpfEAKPPUIpIoQb3YSm42ZVpAgQmLYIRqTpXrmTC7qdeQnSGFJUAliW4DfHBEwpSXlQ==",
+      "version": "0.1040.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1040.1000.tgz",
+      "integrity": "sha512-udOTa/JPCCEtRFEavEYGXMDq2taWBG/QuSnXduUvfBfIaK/ko9jmDJibN66QCWOGFhAIbpHFRRdomAZUFpnndg==",
       "dependencies": {
-        "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/gitresources": "^0.1036.5001",
-        "@fluidframework/protocol-base": "^0.1036.5001",
-        "@fluidframework/protocol-definitions": "^0.1028.2000",
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/gitresources": "^0.1040.1000",
+        "@fluidframework/protocol-base": "^0.1040.1000",
+        "@fluidframework/protocol-definitions": "^1.1.0",
         "axios": "^0.26.0",
         "crc-32": "1.2.0",
         "debug": "^4.1.1",
         "json-stringify-safe": "^5.0.1",
-        "jsrsasign": "^10.2.0",
+        "jsrsasign": "^10.5.25",
         "jwt-decode": "^3.0.0",
         "querystring": "^0.2.0",
         "sillyname": "^0.1.0",
         "uuid": "^8.3.1"
       }
     },
-    "node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/common-utils": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.2.tgz",
-      "integrity": "sha512-PoGX7/l0vWKt5JaAxcgFOdGje30Q6qSE06YzFIKh9Ba3oq7B60+TFqu7c2ErQt6sNddmvcAcAiLVNaTGAip3vw==",
+    "node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/gitresources": {
+      "version": "0.1040.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1040.1000.tgz",
+      "integrity": "sha512-NBCluUrkiUUgcXbyyvNkaCIAqgJbZOsNF7rRUVpFBOI4nwwu4RvoIFbANi+CKPaarcFekO8Qz+ppAzIH2AJwdw=="
+    },
+    "node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/protocol-base": {
+      "version": "0.1040.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1040.1000.tgz",
+      "integrity": "sha512-qAysPKtFaWDkkl4fMEZMEhcqCj/nLZYvebOoeyoEB8Q2IU5gLWSLwFY9bKnWZpDur2UiFr5ebdrS2lVgiwUjWQ==",
       "dependencies": {
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@types/events": "^3.0.0",
-        "base64-js": "^1.5.1",
-        "buffer": "^6.0.3",
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/gitresources": "^0.1040.1000",
+        "@fluidframework/protocol-definitions": "^1.1.0",
         "events": "^3.1.0",
-        "lodash": "^4.17.21",
-        "sha.js": "^2.4.11"
-      }
-    },
-    "node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/protocol-definitions": {
-      "version": "0.1028.2000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
-      "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
-      "dependencies": {
-        "@fluidframework/common-definitions": "^0.20.1"
-      }
-    },
-    "node_modules/@fluidframework/server-services-client/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
-    "node_modules/@fluidframework/server-services-client/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@fluidframework/server-services-client/node_modules/jwt-decode": {
@@ -5012,8 +4976,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -5049,11 +5012,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
+      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/azure-devops-node-api": {
@@ -6399,7 +6377,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -7117,7 +7094,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -12348,9 +12324,9 @@
       ]
     },
     "node_modules/jsrsasign": {
-      "version": "10.8.6",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
-      "integrity": "sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.0.0.tgz",
+      "integrity": "sha512-BtRwVKS+5dsgPpAtzJcpo5OoWjSs1/zllSBG0+8o8/aV0Ki76m6iZwHnwnsqoTdhfFZDN1XIdcaZr5ZkP+H2gg==",
       "funding": {
         "url": "https://github.com/kjur/jsrsasign#donations"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
         "yargs": "^16.2.0"
       },
       "engines": {
+        "npm": ">=8.3.0",
         "vscode": "^1.73.0"
       },
       "optionalDependencies": {
@@ -732,6 +733,76 @@
         "fluid-framework": "^1.3.3"
       }
     },
+    "node_modules/@fluidframework/azure-client/node_modules/@fluidframework/server-services-client": {
+      "version": "0.1036.5001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
+      "integrity": "sha512-e+Zk2uPcds9yqlalAZ0PpfEAKPPUIpIoQb3YSm42ZVpAgQmLYIRqTpXrmTC7qdeQnSGFJUAliW4DfHBEwpSXlQ==",
+      "dependencies": {
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/gitresources": "^0.1036.5001",
+        "@fluidframework/protocol-base": "^0.1036.5001",
+        "@fluidframework/protocol-definitions": "^0.1028.2000",
+        "axios": "^0.26.0",
+        "crc-32": "1.2.0",
+        "debug": "^4.1.1",
+        "json-stringify-safe": "^5.0.1",
+        "jsrsasign": "^10.2.0",
+        "jwt-decode": "^3.0.0",
+        "querystring": "^0.2.0",
+        "sillyname": "^0.1.0",
+        "uuid": "^8.3.1"
+      }
+    },
+    "node_modules/@fluidframework/azure-client/node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/common-utils": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.2.tgz",
+      "integrity": "sha512-PoGX7/l0vWKt5JaAxcgFOdGje30Q6qSE06YzFIKh9Ba3oq7B60+TFqu7c2ErQt6sNddmvcAcAiLVNaTGAip3vw==",
+      "dependencies": {
+        "@fluidframework/common-definitions": "^0.20.1",
+        "@types/events": "^3.0.0",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "events": "^3.1.0",
+        "lodash": "^4.17.21",
+        "sha.js": "^2.4.11"
+      }
+    },
+    "node_modules/@fluidframework/azure-client/node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/protocol-definitions": {
+      "version": "0.1028.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
+      "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
+      "dependencies": {
+        "@fluidframework/common-definitions": "^0.20.1"
+      }
+    },
+    "node_modules/@fluidframework/azure-client/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@fluidframework/azure-client/node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "node_modules/@fluidframework/common-definitions": {
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
@@ -1256,14 +1327,6 @@
         "@fluidframework/common-definitions": "^0.20.1"
       }
     },
-    "node_modules/@fluidframework/driver-utils/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
     "node_modules/@fluidframework/driver-utils/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1687,6 +1750,26 @@
         "@fluidframework/common-definitions": "^0.20.1"
       }
     },
+    "node_modules/@fluidframework/routerlicious-driver/node_modules/@fluidframework/server-services-client": {
+      "version": "0.1036.5001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
+      "integrity": "sha512-e+Zk2uPcds9yqlalAZ0PpfEAKPPUIpIoQb3YSm42ZVpAgQmLYIRqTpXrmTC7qdeQnSGFJUAliW4DfHBEwpSXlQ==",
+      "dependencies": {
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/gitresources": "^0.1036.5001",
+        "@fluidframework/protocol-base": "^0.1036.5001",
+        "@fluidframework/protocol-definitions": "^0.1028.2000",
+        "axios": "^0.26.0",
+        "crc-32": "1.2.0",
+        "debug": "^4.1.1",
+        "json-stringify-safe": "^5.0.1",
+        "jsrsasign": "^10.2.0",
+        "jwt-decode": "^3.0.0",
+        "querystring": "^0.2.0",
+        "sillyname": "^0.1.0",
+        "uuid": "^8.3.1"
+      }
+    },
     "node_modules/@fluidframework/routerlicious-driver/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1709,6 +1792,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/@fluidframework/routerlicious-driver/node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/@fluidframework/runtime-definitions": {
       "version": "1.3.7",
@@ -1894,48 +1982,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
-    },
-    "node_modules/@fluidframework/server-services-client": {
-      "version": "0.1040.1000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1040.1000.tgz",
-      "integrity": "sha512-udOTa/JPCCEtRFEavEYGXMDq2taWBG/QuSnXduUvfBfIaK/ko9jmDJibN66QCWOGFhAIbpHFRRdomAZUFpnndg==",
-      "dependencies": {
-        "@fluidframework/common-utils": "^1.1.1",
-        "@fluidframework/gitresources": "^0.1040.1000",
-        "@fluidframework/protocol-base": "^0.1040.1000",
-        "@fluidframework/protocol-definitions": "^1.1.0",
-        "axios": "^0.26.0",
-        "crc-32": "1.2.0",
-        "debug": "^4.1.1",
-        "json-stringify-safe": "^5.0.1",
-        "jsrsasign": "^10.5.25",
-        "jwt-decode": "^3.0.0",
-        "querystring": "^0.2.0",
-        "sillyname": "^0.1.0",
-        "uuid": "^8.3.1"
-      }
-    },
-    "node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/gitresources": {
-      "version": "0.1040.1000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1040.1000.tgz",
-      "integrity": "sha512-NBCluUrkiUUgcXbyyvNkaCIAqgJbZOsNF7rRUVpFBOI4nwwu4RvoIFbANi+CKPaarcFekO8Qz+ppAzIH2AJwdw=="
-    },
-    "node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/protocol-base": {
-      "version": "0.1040.1000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1040.1000.tgz",
-      "integrity": "sha512-qAysPKtFaWDkkl4fMEZMEhcqCj/nLZYvebOoeyoEB8Q2IU5gLWSLwFY9bKnWZpDur2UiFr5ebdrS2lVgiwUjWQ==",
-      "dependencies": {
-        "@fluidframework/common-utils": "^1.1.1",
-        "@fluidframework/gitresources": "^0.1040.1000",
-        "@fluidframework/protocol-definitions": "^1.1.0",
-        "events": "^3.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@fluidframework/server-services-client/node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/@fluidframework/shared-object-base": {
       "version": "1.3.7",

--- a/package.json
+++ b/package.json
@@ -1121,5 +1121,14 @@
   "optionalDependencies": {
     "bufferutil": "^4.0.6",
     "utf-8-validate": "^5.0.9"
+  },
+  "overrides": {
+    "@fluidframework/azure-client": {
+      "jsrsasign": "~11.0.0",
+      "follow-redirects": "~1.15.4",
+      "axios": "~0.28.0",
+      "@fluidframework/driver-utils": "~1.3.7",
+      "@fluidframework/server-services-client": "~0.1040.1000"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "email": "PPTools@microsoft.com"
   },
   "engines": {
-    "vscode": "^1.73.0"
+    "vscode": "^1.73.0",
+    "npm": ">=8.3.0"
   },
   "extensionKind": [
     "workspace"
@@ -1123,12 +1124,7 @@
     "utf-8-validate": "^5.0.9"
   },
   "overrides": {
-    "@fluidframework/azure-client": {
-      "jsrsasign": "~11.0.0",
-      "follow-redirects": "~1.15.4",
-      "axios": "~0.28.0",
-      "@fluidframework/driver-utils": "~1.3.7",
-      "@fluidframework/server-services-client": "~0.1040.1000"
-    }
+    "jsrsasign": "^11.0.0",
+    "axios": "^0.28.0"
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `package.json` file to specify the minimum required version of `npm` and to override certain package versions. 

Here are the key changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L59-R60): The `engines` field now includes a specification for `npm` version `>=8.3.0`. This means that the project now requires at least version `8.3.0` of `npm` to run.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1125-R1128): The `overrides` field has been added to the `optionalDependencies` section. This field specifies that the versions of `jsrsasign` and `axios` should be `^11.0.0` and `^0.28.0` respectively, overriding any other specified versions.