### PR TITLE
[Bug Fix] Initial Load Failure

### DIFF
--- a/src/web/client/common/errorHandler.ts
+++ b/src/web/client/common/errorHandler.ts
@@ -127,7 +127,7 @@ export function checkMandatoryQueryParameters(
                 WebExtensionContext.telemetry.sendErrorTelemetry(
                     telemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
                     checkMandatoryQueryParameters.name,
-                    `orgURL, dataSource:${dataSource}, schemaName:${schemaName} ,websiteId:${websiteId}`
+                    `${orgURL ? `orgURL, ` : ``}dataSource:${dataSource}, schemaName:${schemaName} ,websiteId:${websiteId}`
                 );
                 showErrorDialog(
                     vscode.l10n.t("There was a problem opening the workspace"),

--- a/src/web/client/common/errorHandler.ts
+++ b/src/web/client/common/errorHandler.ts
@@ -127,7 +127,7 @@ export function checkMandatoryQueryParameters(
                 WebExtensionContext.telemetry.sendErrorTelemetry(
                     telemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
                     checkMandatoryQueryParameters.name,
-                    `orgURL:${orgURL}, dataSource:${dataSource}, schemaName:${schemaName} ,websiteId:${websiteId}`
+                    `orgURL, dataSource:${dataSource}, schemaName:${schemaName} ,websiteId:${websiteId}`
                 );
                 showErrorDialog(
                     vscode.l10n.t("There was a problem opening the workspace"),

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -92,9 +92,6 @@ export function activate(context: vscode.ExtensionContext): void {
                         );
                     }
                 }
-                const orgId = queryParamsMap.get(queryParameters.ORG_ID) as string;
-                const orgGeo = await fetchArtemisData(orgId);
-                oneDSLoggerWrapper.instantiate(orgGeo);
                 if (
                     !checkMandatoryParameters(
                         appName,
@@ -111,6 +108,11 @@ export function activate(context: vscode.ExtensionContext): void {
                     queryParamsMap,
                     context.extensionUri
                 );
+
+                const orgId = queryParamsMap.get(queryParameters.ORG_ID) as string;
+                const orgGeo = await fetchArtemisData(orgId);
+                oneDSLoggerWrapper.instantiate(orgGeo);
+
                 WebExtensionContext.telemetry.sendExtensionInitPathParametersTelemetry(
                     appName,
                     entity,

--- a/src/web/client/test/integration/errorHandler.test.ts
+++ b/src/web/client/test/integration/errorHandler.test.ts
@@ -323,7 +323,7 @@ describe("errorHandler", () => {
             _mockSendErrorTelemetry,
             telemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
             checkMandatoryQueryParameters.name,
-            `orgURL:, dataSource:SQL, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
+            `dataSource:SQL, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
         );
     });
 
@@ -362,7 +362,7 @@ describe("errorHandler", () => {
             _mockSendErrorTelemetry,
             telemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
             checkMandatoryQueryParameters.name,
-            `orgURL:ORG_URL, dataSource:, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
+            `orgURL, dataSource:, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
         );
     });
 
@@ -401,7 +401,7 @@ describe("errorHandler", () => {
             _mockSendErrorTelemetry,
             telemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
             checkMandatoryQueryParameters.name,
-            `orgURL:ORG_URL, dataSource:SQL, schemaName: ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
+            `orgURL, dataSource:SQL, schemaName: ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
         );
     });
 
@@ -437,7 +437,7 @@ describe("errorHandler", () => {
             _mockSendErrorTelemetry,
             telemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
             checkMandatoryQueryParameters.name,
-            `orgURL:ORG_URL, dataSource:SQL, schemaName:1.0.0.0 ,websiteId:`
+            `orgURL, dataSource:SQL, schemaName:1.0.0.0 ,websiteId:`
         );
     });
 


### PR DESCRIPTION
This pull request includes changes to the `activate` function in the `src/web/client/extension.ts` file. The changes involve the repositioning of the instantiation of `oneDSLoggerWrapper` with `orgGeo` data fetched from `fetchArtemisData(orgId)`. The instantiation, which was previously done before the `checkMandatoryParameters` function call, is now done after the parameters check.

Here are the key changes:

* [`src/web/client/extension.ts`](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360L95-L97): Moved the instantiation of `oneDSLoggerWrapper` with `orgGeo` data fetched from `fetchArtemisData(orgId)` to after the `checkMandatoryParameters` function call. This change ensures that the logger is instantiated only after the mandatory parameters have been checked. [[1]](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360L95-L97) [[2]](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360R111-R115)