### PR TITLE
Indentation Fixed

### DIFF
--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -17,6 +17,7 @@ import {OneDSCollectorEventName} from "./EventContants";
 import { telemetryEventNames } from "../../web/client/telemetry/constants";
 import { region } from "../telemetry-generated/buildRegionConfiguration";
 import { telemetryEventNames as desktopExtTelemetryEventNames } from "../../client/telemetry/TelemetryEventNames";
+import { geoMappingsToAzureRegion } from "./shortNameMappingToAzureRegion";
 
 interface IInstrumentationSettings {
     endpointURL: string;
@@ -324,22 +325,24 @@ export class OneDSLogger implements ITelemetryLogger{
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private populateVscodeWebAttributes(envelope: any) {
-        if (envelope.data.eventName ==  telemetryEventNames.WEB_EXTENSION_INIT_QUERY_PARAMETERS){
-            OneDSLogger.userInfo.tid= JSON.parse(envelope.data.eventInfo).tenantId;
-            OneDSLogger.userRegion = JSON.parse(envelope.data.eventInfo).geo;
-            OneDSLogger.contextInfo.orgId = JSON.parse(envelope.data.eventInfo).orgId;
-            OneDSLogger.contextInfo.portalId = JSON.parse(envelope.data.eventInfo).portalId;
-            OneDSLogger.contextInfo.websiteId = JSON.parse(envelope.data.eventInfo).websiteId;
-            OneDSLogger.contextInfo.dataSource = JSON.parse(envelope.data.eventInfo).dataSource;
-            OneDSLogger.contextInfo.schema = JSON.parse(envelope.data.eventInfo).schema;
-            OneDSLogger.contextInfo.correlationId = JSON.parse(envelope.data.eventInfo).referrerSessionId;
-            OneDSLogger.contextInfo.referrer = JSON.parse(envelope.data.eventInfo).referrer;
-            OneDSLogger.contextInfo.envId = JSON.parse(envelope.data.eventInfo).envId;
-            OneDSLogger.contextInfo.referrerSource = JSON.parse(envelope.data.eventInfo).referrerSource;
-            OneDSLogger.contextInfo.orgGeo = JSON.parse(envelope.data.eventInfo).orgGeo;
+        if (envelope.data.eventName == telemetryEventNames.WEB_EXTENSION_INIT_QUERY_PARAMETERS) {
+            const eventInfo = JSON.parse(envelope.data.eventInfo);
+
+            OneDSLogger.userInfo.tid = eventInfo.tenantId;
+            OneDSLogger.userRegion = eventInfo.geo ? geoMappingsToAzureRegion[eventInfo.geo.toLowerCase()].geoName : eventInfo.geo;
+            OneDSLogger.contextInfo.orgId = eventInfo.orgId;
+            OneDSLogger.contextInfo.portalId = eventInfo.portalId;
+            OneDSLogger.contextInfo.websiteId = eventInfo.websiteId;
+            OneDSLogger.contextInfo.dataSource = eventInfo.dataSource;
+            OneDSLogger.contextInfo.schema = eventInfo.schema;
+            OneDSLogger.contextInfo.correlationId = eventInfo.referrerSessionId;
+            OneDSLogger.contextInfo.referrer = eventInfo.referrer;
+            OneDSLogger.contextInfo.envId = eventInfo.envId;
+            OneDSLogger.contextInfo.referrerSource = eventInfo.referrerSource;
+            OneDSLogger.contextInfo.orgGeo = eventInfo.orgGeo;
         }
-        if (envelope.data.eventName ==  telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_COMPLETED){
-            OneDSLogger.userInfo.oid= JSON.parse(envelope.data.eventInfo).userId;
+        if (envelope.data.eventName == telemetryEventNames.WEB_EXTENSION_DATAVERSE_AUTHENTICATION_COMPLETED) {
+            OneDSLogger.userInfo.oid = JSON.parse(envelope.data.eventInfo).userId;
         }
     }
 

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -11,9 +11,9 @@ import { ITelemetryLogger } from "./ITelemetryLogger";
 import { IContextInfo, IUserInfo } from "./IEventTypes";
 import { EventType, Severity } from "./telemetryConstants";
 import * as vscode from "vscode";
-import {getExtensionType, getExtensionVersion} from "../../common/Utils";
+import { getExtensionType, getExtensionVersion } from "../../common/Utils";
 import { EXTENSION_ID } from "../../client/constants";
-import {OneDSCollectorEventName} from "./EventContants";
+import { OneDSCollectorEventName } from "./EventContants";
 import { telemetryEventNames } from "../../web/client/telemetry/constants";
 import { region } from "../telemetry-generated/buildRegionConfiguration";
 import { telemetryEventNames as desktopExtTelemetryEventNames } from "../../client/telemetry/TelemetryEventNames";
@@ -24,14 +24,14 @@ interface IInstrumentationSettings {
     instrumentationKey: string;
 }
 
-export class OneDSLogger implements ITelemetryLogger{
+export class OneDSLogger implements ITelemetryLogger {
 
-    private readonly appInsightsCore :AppInsightsCore;
-	private readonly postChannel: PostChannel;
+    private readonly appInsightsCore: AppInsightsCore;
+    private readonly postChannel: PostChannel;
 
-    private static userInfo: IUserInfo = {oid: "", tid: "", puid: ""};
-    private static contextInfo: IContextInfo ;
-    private static userRegion : string = "";
+    private static userInfo: IUserInfo = { oid: "", tid: "", puid: "" };
+    private static contextInfo: IContextInfo;
+    private static userRegion: string = "";
 
     private readonly regexPatternsToRedact = [
         /key["\\ ']*[:=]+["\\ ']*([a-zA-Z0-9]*)/igm,
@@ -83,44 +83,44 @@ export class OneDSLogger implements ITelemetryLogger{
         },
     };
 
-    public constructor(geo?:string ) {
+    public constructor(geo?: string) {
 
         this.appInsightsCore = new AppInsightsCore();
         this.postChannel = new PostChannel();
 
         const channelConfig: IChannelConfiguration = {
-			alwaysUseXhrOverride: true,
-			httpXHROverride: this.fetchHttpXHROverride,
-		};
+            alwaysUseXhrOverride: true,
+            httpXHROverride: this.fetchHttpXHROverride,
+        };
 
-        const instrumentationSetting : IInstrumentationSettings= OneDSLogger.getInstrumentationSettings(geo); // Need to replace with actual data
+        const instrumentationSetting: IInstrumentationSettings = OneDSLogger.getInstrumentationSettings(geo); // Need to replace with actual data
 
-		// Configure App insights core to send to collector
-		const coreConfig: IExtendedConfiguration = {
-			instrumentationKey: instrumentationSetting.instrumentationKey,
-			loggingLevelConsole: 0, // Do not log to console
-			disableDbgExt: true, // Small perf optimization
-			extensions: [
-				// Passing no channels here when the user opts out of telemetry would be ideal, completely ensuring telemetry
-				// could not be sent out at all.
-				this.postChannel,
-			],
+        // Configure App insights core to send to collector
+        const coreConfig: IExtendedConfiguration = {
+            instrumentationKey: instrumentationSetting.instrumentationKey,
+            loggingLevelConsole: 0, // Do not log to console
+            disableDbgExt: true, // Small perf optimization
+            extensions: [
+                // Passing no channels here when the user opts out of telemetry would be ideal, completely ensuring telemetry
+                // could not be sent out at all.
+                this.postChannel,
+            ],
             endpointUrl: instrumentationSetting.endpointURL,
-			extensionConfig: {
-				[this.postChannel.identifier]: channelConfig,
-			},
+            extensionConfig: {
+                [this.postChannel.identifier]: channelConfig,
+            },
 
-		};
+        };
 
-		if ((coreConfig.instrumentationKey ?? "") !== "") {
-			this.appInsightsCore.initialize(coreConfig, []);
-		}
+        if ((coreConfig.instrumentationKey ?? "") !== "") {
+            this.appInsightsCore.initialize(coreConfig, []);
+        }
         this.intitializeContextInfo();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.appInsightsCore.addTelemetryInitializer(this.populateCommonAttributes());
-	}
+    }
 
-    private intitializeContextInfo(){
+    private intitializeContextInfo() {
         OneDSLogger.contextInfo = {
             orgId: "",
             portalId: "",
@@ -135,9 +135,9 @@ export class OneDSLogger implements ITelemetryLogger{
         }
     }
 
-    private static getInstrumentationSettings(geo?:string): IInstrumentationSettings {
-        const buildRegion:string = region;
-        const instrumentationSettings:IInstrumentationSettings = {
+    private static getInstrumentationSettings(geo?: string): IInstrumentationSettings {
+        const buildRegion: string = region;
+        const instrumentationSettings: IInstrumentationSettings = {
             endpointURL: 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/',
             instrumentationKey: 'ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402'
         };
@@ -148,180 +148,179 @@ export class OneDSLogger implements ITelemetryLogger{
                 break;
             case 'prod':
             case 'preview':
-              switch (geo) {
-                case 'us':
-                case 'br':
-                case 'jp':
-                case 'in':
-                case 'au':
-                case 'ca':
-                case 'as':
-                case 'za':
-                case 'ae':
-                case 'kr':
-                    instrumentationSettings.endpointURL ='https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
-                    instrumentationSettings.instrumentationKey =  '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
-                    break;
-                case 'eu':
-                case 'uk':
-                case 'de':
-                case 'fr':
-                case 'no':
-                case 'ch':
-                    instrumentationSettings.endpointURL ='https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/',
-                    instrumentationSettings.instrumentationKey =  '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
-                    break;
-                default:
-                    instrumentationSettings.endpointURL ='https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
-                    instrumentationSettings.instrumentationKey =  '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
-                    break;
-              }
-              break;
+                switch (geo) {
+                    case 'us':
+                    case 'br':
+                    case 'jp':
+                    case 'in':
+                    case 'au':
+                    case 'ca':
+                    case 'as':
+                    case 'za':
+                    case 'ae':
+                    case 'kr':
+                        instrumentationSettings.endpointURL = 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
+                            instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        break;
+                    case 'eu':
+                    case 'uk':
+                    case 'de':
+                    case 'fr':
+                    case 'no':
+                    case 'ch':
+                        instrumentationSettings.endpointURL = 'https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/',
+                            instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        break;
+                    default:
+                        instrumentationSettings.endpointURL = 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
+                            instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        break;
+                }
+                break;
             case 'gov':
             case 'high':
             case 'dod':
             case 'mooncake':
                 instrumentationSettings.endpointURL = '',
-                instrumentationSettings.instrumentationKey = '' //prod key;
-              break;
+                    instrumentationSettings.instrumentationKey = '' //prod key;
+                break;
             case 'ex':
             case 'rx':
             default:
-              break;
-          }
+                break;
+        }
         return instrumentationSettings;
-      }
+    }
 
-	/// Trace info log
-	public traceInfo(eventName:string, eventInfo?:object, measurement?: object) {
-		const event = {
-			name: OneDSCollectorEventName.VSCODE_EVENT,
-			data: {
+    /// Trace info log
+    public traceInfo(eventName: string, eventInfo?: object, measurement?: object) {
+        const event = {
+            name: OneDSCollectorEventName.VSCODE_EVENT,
+            data: {
                 eventName: eventName,
                 eventType: EventType.TRACE,
                 severity: Severity.INFO,
                 eventInfo: JSON.stringify(eventInfo!),
-                measurement:  JSON.stringify(measurement!)
-			}
-		};
+                measurement: JSON.stringify(measurement!)
+            }
+        };
 
-		this.appInsightsCore.track(event);
-	}
-
-	/// Trace warning log
-	public traceWarning(eventName:string, eventInfo?: object, measurement?: object) {
-		const event = {
-			name: OneDSCollectorEventName.VSCODE_EVENT,
-			data: {
-                eventName: eventName,
-				eventType: EventType.TRACE,
-                severity: Severity.WARN,
-                eventInfo: JSON.stringify(eventInfo!),
-                measurement:  JSON.stringify(measurement!)
-			}
-		};
-
-		this.appInsightsCore.track(event);
-	}
-
-    // Trace error log
-	public traceError(eventName: string, errorMessage: string, exception: Error, eventInfo?:object, measurement?: object) {
-		const event = {
-			name: OneDSCollectorEventName.VSCODE_EVENT,
-			data: {
-                eventName: eventName,
-				eventType: EventType.TRACE,
-                severity: Severity.ERROR,
-				message: errorMessage!,
-                errorName: exception ? exception.name : "",
-                errorStack: JSON.stringify(exception!),
-                eventInfo: JSON.stringify(eventInfo!),
-                measurement:  JSON.stringify(measurement!)
-			}
-		};
         this.appInsightsCore.track(event);
     }
 
-    public  featureUsage(
+    /// Trace warning log
+    public traceWarning(eventName: string, eventInfo?: object, measurement?: object) {
+        const event = {
+            name: OneDSCollectorEventName.VSCODE_EVENT,
+            data: {
+                eventName: eventName,
+                eventType: EventType.TRACE,
+                severity: Severity.WARN,
+                eventInfo: JSON.stringify(eventInfo!),
+                measurement: JSON.stringify(measurement!)
+            }
+        };
+
+        this.appInsightsCore.track(event);
+    }
+
+    // Trace error log
+    public traceError(eventName: string, errorMessage: string, exception: Error, eventInfo?: object, measurement?: object) {
+        const event = {
+            name: OneDSCollectorEventName.VSCODE_EVENT,
+            data: {
+                eventName: eventName,
+                eventType: EventType.TRACE,
+                severity: Severity.ERROR,
+                message: errorMessage!,
+                errorName: exception ? exception.name : "",
+                errorStack: JSON.stringify(exception!),
+                eventInfo: JSON.stringify(eventInfo!),
+                measurement: JSON.stringify(measurement!)
+            }
+        };
+        this.appInsightsCore.track(event);
+    }
+
+    public featureUsage(
         featureName: string,
         eventName: string,
         customDimensions?: object
-      ) {
+    ) {
 
         const event = {
-			name: OneDSCollectorEventName.VSCODE_EVENT,
-			data: {
+            name: OneDSCollectorEventName.VSCODE_EVENT,
+            data: {
                 eventName: 'Portal_Metrics_Event',
-				eventType: EventType.TRACE,
+                eventType: EventType.TRACE,
                 severity: Severity.INFO,
                 eventInfo: JSON.stringify({
                     featureName: featureName,
                     customDimensions: customDimensions,
                     eventName: eventName
                 })
-			}
-		};
+            }
+        };
         this.appInsightsCore.track(event);
     }
 
     /// Populate attributes that are common to all events
-	private populateCommonAttributes() {
+    private populateCommonAttributes() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (envelope:any) => {
-			try {
-                    envelope.data = envelope.data || {}; // create data nested object if doesn't exist already'
+        return (envelope: any) => {
+            try {
+                envelope.data = envelope.data || {}; // create data nested object if doesn't exist already'
 
-                    envelope.data.clientSessionId = vscode.env.sessionId;
-                    envelope.data.vscodeSurface = getExtensionType();
-                    envelope.data.vscodeExtensionName = EXTENSION_ID;
-                    envelope.data.vscodeExtensionVersion = getExtensionVersion();
-                    envelope.data.vscodeVersion = vscode.version;
-                    envelope.data.domain = vscode.env.appHost;
-                    envelope.data.measurements = envelope.data.measurement;
-                    // Adding below attributes so they get populated in Geneva.
-                    // TODO: It needs implementation for populating the actual value
-                    envelope.data.eventSubType = "";
-                    envelope.data.scenarioId = "";
-                    envelope.data.eventModifier = "";
-                    envelope.data.country = "";
-                    envelope.data.userLocale = "";
-                    envelope.data.userDataBoundary = "";
-                    envelope.data.appLocale = "";
-                    envelope.data.userLocale = "";
-                    envelope.data.webBrowser = "";
-                    envelope.data.browserVersion = "";
-                    envelope.data.browserLanguage = "";
-                    envelope.data.screenResolution = "";
-                    envelope.data.osName = "";
-                    envelope.data.osVersion = "";
-                    envelope.data.timestamp = new Date();
-                    if (getExtensionType() == 'Web'){
-                        this.populateVscodeWebAttributes(envelope);
-                    }else{
-                        this.populateVscodeDesktopAttributes(envelope);
-                    }
-                    envelope.data.tenantId = OneDSLogger.userInfo?.tid;
-                    envelope.data.principalObjectId = OneDSLogger.userInfo?.oid;
-                    envelope.data.puid = OneDSLogger.userInfo?.puid;
-                    envelope.data.context = JSON.stringify(OneDSLogger.contextInfo);
-                    envelope.data.userRegion = OneDSLogger.userRegion;
-                    // At the end of event enrichment, redact the sensitive data for all the applicable fields
-                  //  envelope = this.redactSensitiveDataFromEvent(envelope);
+                envelope.data.clientSessionId = vscode.env.sessionId;
+                envelope.data.vscodeSurface = getExtensionType();
+                envelope.data.vscodeExtensionName = EXTENSION_ID;
+                envelope.data.vscodeExtensionVersion = getExtensionVersion();
+                envelope.data.vscodeVersion = vscode.version;
+                envelope.data.domain = vscode.env.appHost;
+                envelope.data.measurements = envelope.data.measurement;
+                // Adding below attributes so they get populated in Geneva.
+                // TODO: It needs implementation for populating the actual value
+                envelope.data.eventSubType = "";
+                envelope.data.scenarioId = "";
+                envelope.data.eventModifier = "";
+                envelope.data.country = "";
+                envelope.data.userLocale = "";
+                envelope.data.userDataBoundary = "";
+                envelope.data.appLocale = "";
+                envelope.data.userLocale = "";
+                envelope.data.webBrowser = "";
+                envelope.data.browserVersion = "";
+                envelope.data.browserLanguage = "";
+                envelope.data.screenResolution = "";
+                envelope.data.osName = "";
+                envelope.data.osVersion = "";
+                envelope.data.timestamp = new Date();
+                if (getExtensionType() == 'Web') {
+                    this.populateVscodeWebAttributes(envelope);
+                } else {
+                    this.populateVscodeDesktopAttributes(envelope);
+                }
+                envelope.data.tenantId = OneDSLogger.userInfo?.tid;
+                envelope.data.principalObjectId = OneDSLogger.userInfo?.oid;
+                envelope.data.puid = OneDSLogger.userInfo?.puid;
+                envelope.data.context = JSON.stringify(OneDSLogger.contextInfo);
+                envelope.data.userRegion = OneDSLogger.userRegion;
+                // At the end of event enrichment, redact the sensitive data for all the applicable fields
+                //  envelope = this.redactSensitiveDataFromEvent(envelope);
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            catch (exception:any)
-			{
-				// Such exceptions are likely if we are trying to process event attributes which don't exist
-				// In such cases, only add common attributes and current exception details, and avoid processing the event attributes further
-				// However, do log the baseData of the event along with its name in the exception event that gets sent out in this scenario
-				console.warn("Caught exception processing the telemetry event: " + envelope.name);
-				console.warn(exception.message);
+            catch (exception: any) {
+                // Such exceptions are likely if we are trying to process event attributes which don't exist
+                // In such cases, only add common attributes and current exception details, and avoid processing the event attributes further
+                // However, do log the baseData of the event along with its name in the exception event that gets sent out in this scenario
+                console.warn("Caught exception processing the telemetry event: " + envelope.name);
+                console.warn(exception.message);
 
-				this.traceExceptionInEventProcessing();
-				return false;
-			}
+                this.traceExceptionInEventProcessing();
+                return false;
+            }
         }
-	}
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private populateVscodeWebAttributes(envelope: any) {
@@ -347,7 +346,7 @@ export class OneDSLogger implements ITelemetryLogger{
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private populateVscodeDesktopAttributes(envelope: any){
+    private populateVscodeDesktopAttributes(envelope: any) {
         if (envelope.data.eventName == desktopExtTelemetryEventNames.DESKTOP_EXTENSION_INIT_CONTEXT) {
             OneDSLogger.contextInfo.orgId = JSON.parse(envelope.data.eventInfo).OrgId;
             OneDSLogger.contextInfo.envId = JSON.parse(envelope.data.eventInfo).EnvironmentId;
@@ -357,54 +356,54 @@ export class OneDSLogger implements ITelemetryLogger{
     }
 
     //// Redact Sensitive data for the fields susceptible to contain codes/tokens/keys/secrets etc.
-	//// This is done post event enrichment is complete to not impact the dependencies (if any) on actual values like Uri etc.
+    //// This is done post event enrichment is complete to not impact the dependencies (if any) on actual values like Uri etc.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private redactSensitiveDataFromEvent(envelope:any) {
-		//Redact sensitive information from suseptible fields
-		envelope.data.errorStack = this.getAllSensitiveRedactedFromField(envelope.data.errorStack);
-		return envelope;
-	}
+    private redactSensitiveDataFromEvent(envelope: any) {
+        //Redact sensitive information from suseptible fields
+        envelope.data.errorStack = this.getAllSensitiveRedactedFromField(envelope.data.errorStack);
+        return envelope;
+    }
 
     //// Get redacted value after all sensitive information is redacted
-	getAllSensitiveRedactedFromField(value:string) {
-		try {
-			// Ensure the  value is of type string
-			if (value && typeof value === 'string') {
-				this.regexPatternsToRedact.forEach((pattern: RegExp) => {
-					value = this.getRedactedValueViaRegexMatch(value, pattern);
-				});
-			}
-         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} catch (exception:any) {
-			console.warn("Caught exception while processing telemetry data for redaction (if any): " + value);
-			console.warn(exception.message);
-		}
-		return value;
-	}
+    getAllSensitiveRedactedFromField(value: string) {
+        try {
+            // Ensure the  value is of type string
+            if (value && typeof value === 'string') {
+                this.regexPatternsToRedact.forEach((pattern: RegExp) => {
+                    value = this.getRedactedValueViaRegexMatch(value, pattern);
+                });
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (exception: any) {
+            console.warn("Caught exception while processing telemetry data for redaction (if any): " + value);
+            console.warn(exception.message);
+        }
+        return value;
+    }
 
-	//// Get redacted value
-	getRedactedValueViaRegexMatch(value:string, regexPattern:RegExp) {
-		let matches;
+    //// Get redacted value
+    getRedactedValueViaRegexMatch(value: string, regexPattern: RegExp) {
+        let matches;
 
-		while ((matches = regexPattern.exec(value)) !== null) {
-			// This is necessary to avoid infinite loops with zero-width matches
-			if (matches.index === regexPattern.lastIndex) {
-				regexPattern.lastIndex++;
-			}
+        while ((matches = regexPattern.exec(value)) !== null) {
+            // This is necessary to avoid infinite loops with zero-width matches
+            if (matches.index === regexPattern.lastIndex) {
+                regexPattern.lastIndex++;
+            }
 
-			matches.forEach((match, groupIndex) => {
-				if (groupIndex == 0) { // Redact the entire matched string
-					value = value.replace(match, OneDSCollectorEventName.REDACTED); //Replace with string REDACTED
-				}
-			});
-		}
-		return value;
-	}
+            matches.forEach((match, groupIndex) => {
+                if (groupIndex == 0) { // Redact the entire matched string
+                    value = value.replace(match, OneDSCollectorEventName.REDACTED); //Replace with string REDACTED
+                }
+            });
+        }
+        return value;
+    }
 
     /// Trace exceptions in processing event attributes
-	private traceExceptionInEventProcessing() {
-		// TODO : Add exception handling
-	}
+    private traceExceptionInEventProcessing() {
+        // TODO : Add exception handling
+    }
 
     public flushAndTeardown(): void {
         this.appInsightsCore.flush();

--- a/src/common/OneDSLoggerTelemetry/oneDSLoggerWrapper.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLoggerWrapper.ts
@@ -7,65 +7,65 @@ import { isCustomTelemetryEnabled } from "../Utils";
 import { OneDSLogger } from "./oneDSLogger";
 
 //// Wrapper class of oneDSLogger for below purposes
-//// 1. Abstracting code from manual trace log APIs. 
+//// 1. Abstracting code from manual trace log APIs.
 //// 2. Constrolling instantiation of 1ds SDK framework code in oneDSLogger.ts
 
 export class oneDSLoggerWrapper {
     private static instance: oneDSLoggerWrapper;
-    private static oneDSLoggerIntance : OneDSLogger;
+    private static oneDSLoggerIntance: OneDSLogger;
 
     private constructor(geo?: string) {
         oneDSLoggerWrapper.oneDSLoggerIntance = new OneDSLogger(geo);
     }
 
 
-    static getLogger(){
+    static getLogger() {
         return this.instance;
     }
 
-    static instantiate(geo?:string){
+    static instantiate(geo?: string) {
         oneDSLoggerWrapper.instance = new oneDSLoggerWrapper(geo);
     }
 
-	/// Trace info log
-	public traceInfo(eventName:string, eventInfo?: object, measurement?: object) {
-        try{
+    /// Trace info log
+    public traceInfo(eventName: string, eventInfo?: object, measurement?: object) {
+        try {
             if (!isCustomTelemetryEnabled()) return;
             oneDSLoggerWrapper.oneDSLoggerIntance.traceInfo(eventName, eventInfo, measurement);
-        }catch (exception) {
-			console.warn(exception);
-		}
-	}
+        } catch (exception) {
+            console.warn(exception);
+        }
+    }
 
     /// Trace warning log
-	public traceWarning(eventName:string, eventInfo?: object, measurement?: object) {
-        try{
+    public traceWarning(eventName: string, eventInfo?: object, measurement?: object) {
+        try {
             if (!isCustomTelemetryEnabled()) return;
             oneDSLoggerWrapper.oneDSLoggerIntance.traceWarning(eventName, eventInfo, measurement);
-        }catch (exception) {
-			console.warn(exception);
-		}
-	}
+        } catch (exception) {
+            console.warn(exception);
+        }
+    }
 
     /// Trace exception log
-	public traceError(eventName: string, errorMessage: string, exception: Error, eventInfo?:object, measurement?: object) {
-        try{
+    public traceError(eventName: string, errorMessage: string, exception: Error, eventInfo?: object, measurement?: object) {
+        try {
             if (!isCustomTelemetryEnabled()) return;
             oneDSLoggerWrapper.oneDSLoggerIntance.traceError(eventName, errorMessage, exception, eventInfo, measurement);
-        }catch (exception) {
+        } catch (exception) {
             console.warn("Caught exception processing the telemetry event: " + exception);
             console.warn(exception);
-		}
-	}
+        }
+    }
 
     /// Trace featureName
-	public featureUsage( featureName: string,eventName: string,customDimensions?: object) {
-        try{
+    public featureUsage(featureName: string, eventName: string, customDimensions?: object) {
+        try {
             if (!isCustomTelemetryEnabled()) return;
             oneDSLoggerWrapper.oneDSLoggerIntance.featureUsage(featureName, eventName, customDimensions);
-        }catch (exception) {
-			console.warn(exception);
-		}
-	}
-    
-}   
+        } catch (exception) {
+            console.warn(exception);
+        }
+    }
+
+}

--- a/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
+++ b/src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts
@@ -16,7 +16,7 @@ export const azureRegions = {
     CanadaCentral: 'canadacentral',
     CanadaEast: 'canadaeast',
     BrazilSouth: 'brazilsouth',
-  
+
     // Europe
     EuropeNorth: 'northeurope',
     EuropeWest: 'westeurope',
@@ -30,7 +30,7 @@ export const azureRegions = {
     GermanyWestCentral: 'germanywestcentral',
     NorwayWest: 'norwaywest',
     NorwayEast: 'norwayeast',
-  
+
     // Asia
     AsiaEast: 'eastasia',
     AsiaSouthEast: 'southeastasia',
@@ -45,44 +45,44 @@ export const azureRegions = {
     IndiaWest: 'westindia',
     KoreaSouth: 'koreasouth',
     KoreaCentral: 'koreacentral',
-  
+
     // UAE
     UAECentral: 'uaecentral',
     UAENorth: 'uaenorth',
     SouthAfricaNorth: 'southafricanorth',
     SouthAfricaWest: 'southafricawest',
-  
+
     // Germany
     GermanyCentral: 'germanycentral',
     GermanyNorthEast: 'germanynortheast',
-  
+
     // Singapore
     SingaporeSouthEast: 'southeastasia',
-  
+
     /// <summary>
     /// U.S. government cloud in Virginia.
     /// </summary>
-  
+
     GovernmentUSVirginia: 'usgovvirginia',
-  
+
     /// <summary>
     /// U.S. government cloud in Iowa.
     /// </summary>
     GovernmentUSIowa: 'usgoviowa',
-  
+
     /// <summary>
     /// U.S. government cloud in Arizona.
     /// </summary>
     GovernmentUSArizona: 'usgovarizona',
-  
+
     /// <summary>
     /// U.S. government cloud in Texas.
     /// </summary>
     GovernmentUSTexas: 'usgovtexas',
-  
+
     GovernmentUSDodEast: 'usdodeast',
     GovernmentUSDodCentral: 'usdodcentral',
-  
+
     /// <summary>
     /// China Environment
     /// <summary>
@@ -92,9 +92,9 @@ export const azureRegions = {
     ChinaEast: 'chinaeast',
     ChinaEast2: 'chinaeast2',
     ChinaEast3: 'chinaeast3',
-  };
-  
-  export const regionShortName = {
+};
+
+export const regionShortName = {
     wus: 'wus',
     cus: 'cus',
     eus: 'eus',
@@ -141,8 +141,8 @@ export const azureRegions = {
     cnn: 'cnn',
     cnn2: 'cnn2',
     cnn3: 'cnn3'
-  };
-  
+};
+
 export const geoMappingsToAzureRegion = {
     // Public
     [regionShortName.wus]: { geoName: 'us', azureRegion: azureRegions.USWest },
@@ -178,7 +178,7 @@ export const geoMappingsToAzureRegion = {
     [regionShortName.nch]: { geoName: 'ch', azureRegion: azureRegions.SwitzerlandNorth },
     [regionShortName.wch]: { geoName: 'ch', azureRegion: azureRegions.SwitzerlandWest },
     [regionShortName.eno]: { geoName: 'no', azureRegion: azureRegions.NorwayEast },
-    [regionShortName.wno]: { geoName: 'no', azureRegion: azureRegions.NorwayWest },     
+    [regionShortName.wno]: { geoName: 'no', azureRegion: azureRegions.NorwayWest },
     [regionShortName.ckr]: { geoName: 'kr', azureRegion: azureRegions.KoreaCentral },
     [regionShortName.skr]: { geoName: 'kr', azureRegion: azureRegions.KoreaSouth },
     // Government US.
@@ -193,5 +193,4 @@ export const geoMappingsToAzureRegion = {
     [regionShortName.cnn]: { geoName: 'cn', azureRegion: azureRegions.ChinaNorth },
     [regionShortName.cnn2]: { geoName: 'cn', azureRegion: azureRegions.ChinaNorth2 },
     [regionShortName.cnn3]: { geoName: 'cn', azureRegion: azureRegions.ChinaNorth3 },
-  };
-  
+};


### PR DESCRIPTION
This pull request includes two changes in the `src/common/OneDSLoggerTelemetry` directory. The changes involve code formatting and removal of extra white space.

* [`src/common/OneDSLoggerTelemetry/oneDSLogger.ts`](diffhunk://#diff-1c7a0bcddd4688b6e489876d4ab1a031b03f1dcf43f9b9725f460df8758606dfL312-R312): The formatting of the `catch` block in the `OneDSLogger` class has been improved for better readability. The curly brace that opens the block has been moved to the same line as the `catch` statement.
* [`src/common/OneDSLoggerTelemetry/shortNameMappingToAzureRegion.ts`](diffhunk://#diff-30b15e3495e5d89dc31bbdedce35971fa1dec6250d90cfc0d44e8a47e279b8e1L197): An extra line of white space at the end of the `geoMappingsToAzureRegion` constant has been removed.Fixed Indentation for couple of files