### PR TITLE
Bump up PAC-CLI version for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log - Power Platform Extension
 
 ## 2.0.31
+  - pac CLI 1.31.6, (February 2024 refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
+- Web Extension updates:
+  - TBD
+
+## 2.0.31
   - pac CLI 1.30.7, (January 2024 refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
   - Moved release notes to *CHANGELOG.md* file, per VS Code's [Marketplace integration](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#marketplace-integration) guidelines.
 - Web Extension updates:

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -347,7 +347,7 @@ async function snapshot() {
 }
 
 const feedName = 'CAP_ISVExp_Tools_Stable';
-const cliVersion = '1.30.7';
+const cliVersion = '1.31.6';
 
 const recompile = gulp.series(
     clean,

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -123,6 +123,12 @@
   "Failed to enable PAC telemetry.": "Failed to enable PAC telemetry.",
   "PAC Telemetry disabled": "PAC Telemetry disabled",
   "Failed to disable PAC telemetry.": "Failed to disable PAC telemetry.",
+  "Cannot install Power Pages generator. Please install npm and try again./Do not translate 'npm'": {
+    "message": "Cannot install Power Pages generator. Please install npm and try again.",
+    "comment": [
+      "Do not translate 'npm'"
+    ]
+  },
   "Cannot install Power Pages generator: {0}/{0} represents the error message returned from the exception": {
     "message": "Cannot install Power Pages generator: {0}",
     "comment": [

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -35,6 +35,10 @@
     <trans-unit id="++CODE++19766ed6ccb2f4a32778eed80d1928d2c87a18d7c275ccb163ec6709d3eb2e27">
       <source xml:lang="en">Cancel</source>
     </trans-unit>
+    <trans-unit id="++CODE++75106b7b8e0c597d51e042edbde3498f813c9cd7bd59759f4dde848abc054e85">
+      <source xml:lang="en">Cannot install Power Pages generator. Please install npm and try again.</source>
+      <note>Do not translate 'npm'</note>
+    </trans-unit>
     <trans-unit id="++CODE++403c4e10526afca006129953a8e31ef13e0205d0a7305427d17838e73396ce48">
       <source xml:lang="en">Cannot install Power Pages generator: {0}</source>
       <note>{0} represents the error message returned from the exception</note>


### PR DESCRIPTION
This pull request primarily updates the Power Platform Extension to a new version and enhances error handling. The most significant changes include updating the `CHANGELOG.md` and `gulpfile.mjs` to reflect the new version, and adding new error messages related to the Power Pages generator in `bundle.l10n.json` and `vscode-powerplatform.xlf`.

Version update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7): A new version entry (2.0.31) has been added, indicating the update to pac CLI 1.31.6. More updates for this version are marked as "TBD".
* [`gulpfile.mjs`](diffhunk://#diff-903dd1850ba0ff2ab89df00417e93e86fb7115642c6c876d75ecca7f97c940b0L350-R350): The `cliVersion` constant has been updated from '1.30.7' to '1.31.6', reflecting the new version of the pac CLI.

Error handling enhancements:

* [`l10n/bundle.l10n.json`](diffhunk://#diff-829b512e02461234524c007941f3260e67a43b109f48bedf257ab8e8033cc527R126-R131): A new error message has been added, indicating that the Power Pages generator cannot be installed without npm.
* [`loc/translations-export/vscode-powerplatform.xlf`](diffhunk://#diff-62401b58ce452f2686a1cbf6945a0bf5bb33bf35151df029524ced13ada25794R38-R41): The same error message has been added here for localization purposes.