### PR TITLE
Copilot user prompt and feedback form UI fix + SubScenario Telemetry

### DIFF
--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -250,11 +250,11 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
 
                     if (feedbackValue === THUMBS_UP) {
 
-                        sendTelemetryEvent(this.telemetry, { eventName: CopilotUserFeedbackThumbsUpEvent, copilotSessionId: sessionID, orgId: orgID });
+                        sendTelemetryEvent(this.telemetry, { eventName: CopilotUserFeedbackThumbsUpEvent, copilotSessionId: sessionID, orgId: orgID, subScenario: String(messageScenario)});
                         CESUserFeedback(this._extensionContext, sessionID, userID, THUMBS_UP, this.telemetry, this.geoName as string, messageScenario, tenantId)
                     } else if (feedbackValue === THUMBS_DOWN) {
 
-                        sendTelemetryEvent(this.telemetry, { eventName: CopilotUserFeedbackThumbsDownEvent, copilotSessionId: sessionID, orgId: orgID });
+                        sendTelemetryEvent(this.telemetry, { eventName: CopilotUserFeedbackThumbsDownEvent, copilotSessionId: sessionID, orgId: orgID, subScenario: String(messageScenario)});
                         CESUserFeedback(this._extensionContext, sessionID, userID, THUMBS_DOWN, this.telemetry, this.geoName as string, messageScenario, tenantId)
                     }
                     break;

--- a/src/common/copilot/assets/scripts/copilot.js
+++ b/src/common/copilot/assets/scripts/copilot.js
@@ -14,8 +14,8 @@
   const chatInput = document.getElementById("chat-input");
   const chatInputComponent = document.getElementById("input-component");
   const skipCodes = ["", null, undefined, "violation", "unclear", "explain"];
-  const THUMBS_UP = "thumbsup";
-  const THUMBS_DOWN = "thumbsdown";
+  const THUMBS_UP = "thumbsUp";
+  const THUMBS_DOWN = "thumbsDown";
 
   let userName;
   let apiResponseHandler;
@@ -74,7 +74,9 @@
     const resultDiv = document.createElement("div");
     let codeLineCount = 0;
 
-    for (let i = 0; i < responseText.length-1; i++) {
+    const responseLength = isUserCode ? responseText.length : responseText.length - 1;
+
+    for (let i = 0; i < responseLength; i++) {
       const textDiv = document.createElement("div");
       textDiv.innerText = responseText[i].displayText;
       resultDiv.appendChild(textDiv);
@@ -575,11 +577,11 @@
   function handleFeedbackClick(event) {
     const target = event.target;
 
-    if (target.classList.contains(THUMBS_UP)) {
+    if (target.classList.contains("thumbsup")) {
       handleThumbsUpClick(target);
     }
 
-    if (target.classList.contains(THUMBS_DOWN)) {
+    if (target.classList.contains("thumbsdown")) {
       handleThumbsDownClick(target);
     }
   }

--- a/src/common/copilot/telemetry/ITelemetry.ts
+++ b/src/common/copilot/telemetry/ITelemetry.ts
@@ -20,4 +20,5 @@ export interface IProDevCopilotTelemetryData {
     orgUrl?: string,
     tokenSize?: string
     isSuggestedPrompt?: string;
+    subScenario?: string;
 }

--- a/src/common/copilot/telemetry/copilotTelemetry.ts
+++ b/src/common/copilot/telemetry/copilotTelemetry.ts
@@ -28,6 +28,7 @@ export function sendTelemetryEvent(telemetry: ITelemetry, telemetryData: IProDev
     telemetryDataProperties.responseStatus = telemetryData.responseStatus ? telemetryData.responseStatus : '';
     telemetryDataProperties.tokenSize = telemetryData.tokenSize ? telemetryData.tokenSize : '';
     telemetryDataProperties.isSuggestedPrompt = telemetryData.isSuggestedPrompt ? telemetryData.isSuggestedPrompt : '';
+    telemetryDataProperties.subScenario = telemetryData.subScenario ? telemetryData.subScenario : '';
 
     if (telemetryData.error) {
         telemetryDataProperties.eventName = telemetryData.eventName;


### PR DESCRIPTION
This pull request primarily involves changes to telemetry events and user feedback handling in the `PowerPagesCopilot` class and `copilot.js` script. The changes include the addition of a `subScenario` field to telemetry events, modification of thumbs up and thumbs down event names, and adjustments to the handling of response text length and feedback click events.

Telemetry events and user feedback:

* [`src/common/copilot/PowerPagesCopilot.ts`](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL253-R257): Added a `subScenario` field to the telemetry data sent when a thumbs up or thumbs down event is triggered. This additional data will provide more context about the user's feedback.
* [`src/common/copilot/assets/scripts/copilot.js`](diffhunk://#diff-2b752bc47b9599a39d91a02dc72fc16cc92edad87ef510294403fdc46306e07dL17-R18): The names for thumbs up and thumbs down events have been changed from "thumbsup" and "thumbsdown" to "thumbsUp" and "thumbsDown" respectively. This change is reflected in the handling of feedback click events. [[1]](diffhunk://#diff-2b752bc47b9599a39d91a02dc72fc16cc92edad87ef510294403fdc46306e07dL17-R18) [[2]](diffhunk://#diff-2b752bc47b9599a39d91a02dc72fc16cc92edad87ef510294403fdc46306e07dL578-R584)
* [`src/common/copilot/assets/scripts/copilot.js`](diffhunk://#diff-2b752bc47b9599a39d91a02dc72fc16cc92edad87ef510294403fdc46306e07dL77-R79): Adjusted the calculation of `responseLength` to account for whether the response text is user code or not. This change affects the loop that creates text elements for each line of the response text.

Telemetry data structure:

* [`src/common/copilot/telemetry/ITelemetry.ts`](diffhunk://#diff-cb9d6c99c020ebd978eea34f2f848b1fa1fd3975e99d1beb09f82cf2a9d1f399R23): Added a `subScenario` field to the `IProDevCopilotTelemetryData` interface. This new field will hold additional context about the user's feedback.
* [`src/common/copilot/telemetry/copilotTelemetry.ts`](diffhunk://#diff-d73b46474d7a1e801babe96986791f338b5804fa29442ea969355996535755d0R31): Updated the `sendTelemetryEvent` function to include the `subScenario` field in the telemetry data properties.