### PR TITLE
Add telemetry for File Search feature

### DIFF
--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -277,6 +277,9 @@ export class PortalsFS implements vscode.FileSystemProvider {
     }
 
     async searchFiles(pattern: string) {
+        // Record start time for iterating directory and searching files
+        const startTime = Date.now();
+
         // create case sensitive regex
         const regex = new RegExp(pattern, "i");
         const files = await this.iterateDirectory(WebExtensionContext.rootDirectory);
@@ -288,6 +291,14 @@ export class PortalsFS implements vscode.FileSystemProvider {
                 results.push(fileUri);
             }
         });
+
+        WebExtensionContext.telemetry.sendInfoTelemetry(
+            telemetryEventNames.WEB_EXTENSION_SEARCH_FILE,
+            {
+                duration: (Date.now() - startTime).toString(),
+                files: files.length.toString(),
+            }
+        );
 
         return files;
     }

--- a/src/web/client/telemetry/constants.ts
+++ b/src/web/client/telemetry/constants.ts
@@ -120,4 +120,5 @@ export enum telemetryEventNames {
     WEB_EXTENSION_MANDATORY_PATH_PARAMETERS_MISSING_FOR_SINGLE_FILE = "WebExtensionMandatoryPathParametersMissingForSingleFile",
     WEB_EXTENSION_SEARCH_TEXT_RESULTS = "WebExtensionSearchTextResults",
     WEB_EXTENSION_SEARCH_TEXT = "WebExtensionSearchText",
+    WEB_EXTENSION_SEARCH_FILE = "WebExtensionSearchFile",
 }


### PR DESCRIPTION
This pull request primarily focuses on enhancing the telemetry within the `PortalsFS` class in the `fileSystemProvider.ts` file. This is accomplished by recording the start time for the file search operation, and then sending this information, along with the number of files found, to the telemetry service. A new telemetry event named `WEB_EXTENSION_SEARCH_FILE` has also been added to the `telemetryEventNames` enumeration in the `constants.ts` file.

Here are the key changes:

Telemetry enhancements:

* [`src/web/client/dal/fileSystemProvider.ts`](diffhunk://#diff-4ccb3f93d7b25ce5d403b78669157a686dfc23c36f47d684a9bf61c9c92f1385R280-R282): Added code to record the start time before searching for files in the `searchFiles` method of the `PortalsFS` class. This is used to calculate the duration of the operation.

* [`src/web/client/dal/fileSystemProvider.ts`](diffhunk://#diff-4ccb3f93d7b25ce5d403b78669157a686dfc23c36f47d684a9bf61c9c92f1385R295-R302): After the file search operation, the duration of the operation and the number of files found are sent to the telemetry service via the `sendInfoTelemetry` method of the `WebExtensionContext.telemetry` object. The telemetry event used for this is `WEB_EXTENSION_SEARCH_FILE`.

* [`src/web/client/telemetry/constants.ts`](diffhunk://#diff-53efdee85c5ff2b3b01fd6dc8943b4c561f23ad7f08567209c09716e23d028eeR123): Added a new telemetry event named `WEB_EXTENSION_SEARCH_FILE` to the `telemetryEventNames` enumeration. This event is used to send telemetry data about file search operations.