### PR TITLE
Disable power platform co-presence feature.

### DIFF
--- a/package.json
+++ b/package.json
@@ -660,7 +660,7 @@
           "command": "powerPlatform.previewCurrentActiveUsers",
           "alt": "current active users",
           "group": "navigation",
-          "when": "isWeb && virtualWorkspace"
+          "when": "never"
         }
       ],
       "commandPalette": [
@@ -955,7 +955,7 @@
         {
           "id": "powerpages.collaborationView",
           "name": "People On The Site",
-          "when": "isWeb && virtualWorkspace",
+          "when": "never",
           "contextualTitle": "People On The Site",
           "visibility": "visible"
         }

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -151,7 +151,9 @@ export function isCoPresenceEnabled() {
         );
     }
 
-    return isCoPresenceEnabled as boolean;
+    // return isCoPresenceEnabled as boolean;
+    // Co-presence feature is disabled for now
+    return false;
 }
 
 /**


### PR DESCRIPTION
This pull request primarily focuses on disabling certain features in the `package.json` and `commonUtil.ts` files. The changes include modifying the conditions for displaying certain commands and views in `package.json`, and disabling the co-presence feature in `commonUtil.ts`.

* In `package.json`, the visibility conditions for the commands and views have been altered:
  * The "powerPlatform.previewCurrentActiveUsers" command is now never shown, as the condition in the "when" field has been changed from "isWeb && virtualWorkspace" to "never".
  * Similarly, the "powerpages.collaborationView" view is now never shown. The condition in the "when" field has been changed from "isWeb && virtualWorkspace" to "never".

* In `src/web/client/utilities/commonUtil.ts`, the co-presence feature has been disabled. The `isCoPresenceEnabled` function now always returns `false`, effectively disabling the feature.