### PR TITLE
Fix response Length calculation in copilot.js

### DIFF
--- a/src/common/copilot/assets/scripts/copilot.js
+++ b/src/common/copilot/assets/scripts/copilot.js
@@ -74,7 +74,7 @@
     const resultDiv = document.createElement("div");
     let codeLineCount = 0;
 
-    const responseLength = isUserCode ? responseText.length : responseText.length - 1;
+    const responseLength = responseText.length > 1 ? responseText.length -1 : responseText.length;
 
     for (let i = 0; i < responseLength; i++) {
       const textDiv = document.createElement("div");
@@ -318,11 +318,12 @@
           thinkingDiv.remove();
         }
 
+        const scenario = apiResponse.length > 1 ? apiResponse[apiResponse.length - 1] : apiResponse[0].displayText;
 
         let message = {
           id: messageIndex,
           content: apiResponse,
-          scenario: apiResponse[apiResponse.length - 1],
+          scenario: scenario,
           reaction: null
         }
 


### PR DESCRIPTION
This pull request includes changes to the `src/common/copilot/assets/scripts/copilot.js` file. The changes primarily focus on adjusting how response lengths and scenarios are calculated and assigned. 

Here are the key changes:

* [`src/common/copilot/assets/scripts/copilot.js`](diffhunk://#diff-2b752bc47b9599a39d91a02dc72fc16cc92edad87ef510294403fdc46306e07dL77-R77): Modified the calculation of `responseLength` to accommodate scenarios where `responseText.length` is not greater than 1. This change ensures that the `responseLength` is correctly calculated regardless of the length of `responseText`.
* [`src/common/copilot/assets/scripts/copilot.js`](diffhunk://#diff-2b752bc47b9599a39d91a02dc72fc16cc92edad87ef510294403fdc46306e07dR321-R326): Adjusted the assignment of `scenario` to handle cases where `apiResponse.length` is not greater than 1. This change ensures that the `scenario` is correctly assigned even if there is only one item in `apiResponse`.