### PR TITLE
Update xmldom package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@microsoft/generator-powerpages": "1.21.19",
         "@types/jwt-decode": "2.2.0",
         "@types/node-fetch": "^2.6.2",
-        "@types/xmldom": "^0.1.34",
         "@vscode/extension-telemetry": "^0.6.2",
+        "@xmldom/xmldom": "^0.8.10",
         "cockatiel": "^3.1.1",
         "command-exists": "^1.2.9",
         "find-process": "^1.4.7",
@@ -36,7 +36,6 @@
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "worker-loader": "^3.0.8",
-        "xmldom": "^0.6.0",
         "yaml": "^2.2.2"
       },
       "devDependencies": {
@@ -3442,11 +3441,6 @@
       "integrity": "sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==",
       "dev": true
     },
-    "node_modules/@types/xmldom": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.34.tgz",
-      "integrity": "sha512-7eZFfxI9XHYjJJuugddV6N5YNeXgQE1lArWOcd1eCOKWb/FGs5SIjacSYuEJuwhsGS3gy4RuZ5EUIcqYscuPDA=="
-    },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
@@ -4209,6 +4203,14 @@
         "webpack-dev-server": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -21419,14 +21421,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -1091,8 +1091,8 @@
     "@microsoft/generator-powerpages": "1.21.19",
     "@types/jwt-decode": "2.2.0",
     "@types/node-fetch": "^2.6.2",
-    "@types/xmldom": "^0.1.34",
     "@vscode/extension-telemetry": "^0.6.2",
+    "@xmldom/xmldom": "^0.8.10",
     "cockatiel": "^3.1.1",
     "command-exists": "^1.2.9",
     "find-process": "^1.4.7",
@@ -1112,7 +1112,6 @@
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "worker-loader": "^3.0.8",
-    "xmldom": "^0.6.0",
     "yaml": "^2.2.2"
   },
   "__metadata": {

--- a/src/common/copilot/dataverseMetadata.ts
+++ b/src/common/copilot/dataverseMetadata.ts
@@ -11,7 +11,7 @@ import { ITelemetry } from "../../client/telemetry/ITelemetry";
 import { sendTelemetryEvent } from "./telemetry/copilotTelemetry";
 import { CopilotDataverseMetadataFailureEvent, CopilotDataverseMetadataSuccessEvent, CopilotGetEntityFailureEvent, CopilotYamlParsingFailureEvent } from "./telemetry/telemetryConstants";
 import { getEntityMetadata } from "../../web/client/utilities/fileAndEntityUtil";
-import { DOMParser } from "xmldom";
+import { DOMParser } from "@xmldom/xmldom";
 import { ATTRIBUTE_CLASSID, ATTRIBUTE_DATAFIELD_NAME, ATTRIBUTE_DESCRIPTION, ControlClassIdMap, SYSTEFORMS_API_PATH } from "./constants";
 
 


### PR DESCRIPTION
This pull request primarily involves changes related to the XML DOM package used in the project. The package has been updated from `xmldom` to `@xmldom/xmldom`. This change has been reflected in the `package.json` file and in the import statement in `src/common/copilot/dataverseMetadata.ts`.

FIX for: https://github.com/microsoft/powerplatform-vscode/security/dependabot/41

Package updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1094-R1095): Removed `@types/xmldom` and `xmldom` from the list of dependencies and added `@xmldom/xmldom` instead. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1094-R1095) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1115)

Codebase update:

* [`src/common/copilot/dataverseMetadata.ts`](diffhunk://#diff-f01824da34af02017a75c331f96e8098e03b6d9c20d04bf943d8551fddde621fL14-R14): Updated the import statement for `DOMParser` to use `@xmldom/xmldom` instead of `xmldom`.