### PR TITLE
After release publish the release version back to be user in ADO pipeline

### DIFF
--- a/.release-it.yaml
+++ b/.release-it.yaml
@@ -1,6 +1,7 @@
 # https://github.com/release-it/release-it/blob/master/config/release-it.json
 
-hooks: {}
+hooks:
+  'after:release': 'echo ##vso[task.setvariable variable=PPVSC_VERSION;]${version}'
 
 # https://github.com/release-it/release-it/blob/master/docs/git.md
 git:


### PR DESCRIPTION
This pull request includes a change to the `.release-it.yaml` configuration file. The change adds a hook that is called after the release process, which sets a task variable `PPVSC_VERSION` to the current version. This can be useful for tracking the version of the software in subsequent tasks.