### PR TITLE
Fetching logical and display name for attributes

### DIFF
--- a/src/common/copilot/dataverseMetadata.ts
+++ b/src/common/copilot/dataverseMetadata.ts
@@ -15,15 +15,11 @@ import { DOMParser } from "@xmldom/xmldom";
 import { ATTRIBUTE_CLASSID, ATTRIBUTE_DATAFIELD_NAME, ATTRIBUTE_DESCRIPTION, ControlClassIdMap, SYSTEFORMS_API_PATH } from "./constants";
 
 
-interface Attribute {
-    LogicalName: string;
-}
-
 declare const IS_DESKTOP: string | undefined;
 
 export async function getEntityColumns(entityName: string, orgUrl: string, apiToken: string, telemetry: ITelemetry, sessionID: string): Promise<string[]> {
     try {
-        const dataverseURL = `${orgUrl.endsWith('/') ? orgUrl : orgUrl.concat('/')}api/data/v9.2/EntityDefinitions(LogicalName='${entityName}')?$expand=Attributes($select=LogicalName)`;
+        const dataverseURL = `${orgUrl.endsWith('/') ? orgUrl : orgUrl.concat('/')}api/data/v9.2/EntityDefinitions(LogicalName='${entityName}')?$expand=Attributes`;
         const requestInit: RequestInit = {
             method: "GET",
             headers: {
@@ -36,10 +32,10 @@ export async function getEntityColumns(entityName: string, orgUrl: string, apiTo
         const jsonResponse = await fetchJsonResponse(dataverseURL, requestInit);
         const endTime = performance.now();
         const responseTime = endTime - startTime || 0;
-        const attributes = getAttributesFromResponse(jsonResponse);
+        const attributes = getAttributesFromResponse(jsonResponse); //Display name and logical name fetching from response
 
         sendTelemetryEvent(telemetry, { eventName: CopilotDataverseMetadataSuccessEvent, copilotSessionId: sessionID, durationInMills: responseTime, orgUrl: orgUrl })
-        return attributes.map((attribute: Attribute) => attribute.LogicalName);
+        return attributes
 
     } catch (error) {
         sendTelemetryEvent(telemetry, { eventName: CopilotDataverseMetadataFailureEvent, copilotSessionId: sessionID, error: error as Error, orgUrl: orgUrl })
@@ -92,9 +88,20 @@ async function fetchJsonResponse(url: string, requestInit: RequestInit): Promise
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getAttributesFromResponse(jsonResponse: any): Attribute[] {
+function getAttributesFromResponse(jsonResponse: any): string[] {
     if (jsonResponse.Attributes && Array.isArray(jsonResponse.Attributes) && jsonResponse.Attributes.length > 0) {
-        return jsonResponse.Attributes;
+        const attributes =  jsonResponse.Attributes;
+        const logicalNameDisplayName: string[] = [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        attributes.forEach((attr:any) => {
+            const attrDisplayName = attr.DisplayName?.UserLocalizedLabel?.Label; // Optional chaining for handling missing values
+            if (attrDisplayName) {
+                logicalNameDisplayName.push(attrDisplayName)
+                logicalNameDisplayName.push(attr.LogicalName)
+            }
+        })
+
+        return logicalNameDisplayName
     }
 
     return [];


### PR DESCRIPTION
This pull request primarily focuses on the refactoring of the `getEntityColumns` function and related changes in the `src/common/copilot/dataverseMetadata.ts` file. The changes involve the removal of the `Attribute` interface, modification of the `dataverseURL`, and significant changes to the `getAttributesFromResponse` function to return an array of `string` instead of `Attribute` objects.

Here are the key changes:

* [`src/common/copilot/dataverseMetadata.ts`](diffhunk://#diff-f01824da34af02017a75c331f96e8098e03b6d9c20d04bf943d8551fddde621fL18-R22): Removed the `Attribute` interface. This interface was previously used to type the `attributes` variable in the `getEntityColumns` function.
* [`src/common/copilot/dataverseMetadata.ts`](diffhunk://#diff-f01824da34af02017a75c331f96e8098e03b6d9c20d04bf943d8551fddde621fL18-R22): Modified the `dataverseURL` in the `getEntityColumns` function. The change removed the `$select=LogicalName` part of the URL, which was used to specify the `LogicalName` field in the `Attribute` objects.
* [`src/common/copilot/dataverseMetadata.ts`](diffhunk://#diff-f01824da34af02017a75c331f96e8098e03b6d9c20d04bf943d8551fddde621fL39-R38): Updated the `getEntityColumns` function to return `attributes` directly instead of mapping each `Attribute` to its `LogicalName`. This change is related to the removal of the `Attribute` interface and the changes in the `getAttributesFromResponse` function.
* [`src/common/copilot/dataverseMetadata.ts`](diffhunk://#diff-f01824da34af02017a75c331f96e8098e03b6d9c20d04bf943d8551fddde621fL95-R104): Refactored the `getAttributesFromResponse` function to return an array of `string` instead of `Attribute` objects. The function now creates a `logicalNameDisplayName` array and populates it with the `DisplayName` and `LogicalName` of each attribute if the `DisplayName` exists.