### PR TITLE
Multiline support in input box with scroll

### DIFF
--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -498,7 +498,7 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
             <div class="chat-input" id="input-component">
               <label for="chat-input" class="input-label hide" id="input-label-id"></label>
               <div class="input-container">
-                <input type="text" placeholder="What do you need help with?" id="chat-input" class="input-field">
+              <textarea rows=1 placeholder="What do you need help with?" id="chat-input" class="input-field"></textarea>
                 <button aria-label="Match Case" id="send-button" class="send-button">
                   <span>
                     ${sendIconSvg}

--- a/src/common/copilot/assets/styles/copilot.css
+++ b/src/common/copilot/assets/styles/copilot.css
@@ -63,7 +63,12 @@ body {
   outline: none;
   color: var(--vscode-inputOption-activeForeground);
   background-color: transparent;
-  white-space: pre-wrap;
+  resize: none;
+  font-family: var(--vscode-font-family);
+}
+
+.input-field::-webkit-scrollbar {
+  display: none;
 }
 
 .input-field:focus {


### PR DESCRIPTION
This pull request includes changes to the user interface and styling of the input field in the `PowerPagesCopilot` class. The main changes involve modifying the input field from a single-line text input to a multi-line textarea, and updating the CSS styles to hide the scrollbar and prevent resizing of the textarea.

User interface changes:
* [`src/common/copilot/PowerPagesCopilot.ts`](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL501-R501): Changed the input field from a single-line text input to a multi-line textarea to improve user experience and allow for multi-line input.

Styling updates:
* [`src/common/copilot/assets/styles/copilot.css`](diffhunk://#diff-ec7b77375fce346d1f954661f131d5d22b2ef655615e35652ccd9bf9546466b9L66-R71): Updated the CSS styles for the input field to hide the scrollbar and prevent resizing of the textarea. Also, added a font-family style to the textarea.
![image](https://github.com/microsoft/powerplatform-vscode/assets/54068463/1d2866e2-319e-4c29-9a27-6b46bc0c15a8)
