### PR TITLE
copresence package update - remove package version override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1-dev",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@fluidframework/azure-client": "^1.1.1",
+        "@fluidframework/azure-client": "^1.2.0",
         "@microsoft/1ds-core-js": "4.0.5",
         "@microsoft/1ds-post-js": "4.0.5",
         "@microsoft/generator-powerpages": "1.21.19",
@@ -20,7 +20,7 @@
         "cockatiel": "^3.1.1",
         "command-exists": "^1.2.9",
         "find-process": "^1.4.7",
-        "fluid-framework": "^1.3.3",
+        "fluid-framework": "^1.4.0",
         "glob": "^7.1.7",
         "gpt-tokenizer": "^2.1.1",
         "https-browserify": "^1.0.0",
@@ -650,25 +650,25 @@
       }
     },
     "node_modules/@fluidframework/aqueduct": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.3.7.tgz",
-      "integrity": "sha512-eXWGpzXnATNUIta5xJauwW8QDqw7sCjaVsF2yk5me3aeRZ9vi5a6bWeHuheADMARyYPrTWoDVINFR0H3EXFnjg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.4.0.tgz",
+      "integrity": "sha512-b3I3fWGAWuXQbyuEFeeEi3GVVUOYPWJfFaB4httsu5Jn4C0QSkKxftkielDlor9/7rCJYjHc4IEWViaVO+kBbA==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-loader": "^1.3.7",
-        "@fluidframework/container-runtime": "^1.3.7",
-        "@fluidframework/container-runtime-definitions": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore": "^1.3.7",
-        "@fluidframework/datastore-definitions": "^1.3.7",
-        "@fluidframework/map": "^1.3.7",
-        "@fluidframework/request-handler": "^1.3.7",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7",
-        "@fluidframework/synthesize": "^1.3.7",
-        "@fluidframework/view-interfaces": "^1.3.7",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-loader": "^1.4.0",
+        "@fluidframework/container-runtime": "^1.4.0",
+        "@fluidframework/container-runtime-definitions": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore": "^1.4.0",
+        "@fluidframework/datastore-definitions": "^1.4.0",
+        "@fluidframework/map": "^1.4.0",
+        "@fluidframework/request-handler": "^1.4.0",
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0",
+        "@fluidframework/synthesize": "^1.4.0",
+        "@fluidframework/view-interfaces": "^1.4.0",
         "uuid": "^8.3.1"
       }
     },
@@ -710,99 +710,29 @@
       }
     },
     "node_modules/@fluidframework/azure-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-1.1.1.tgz",
-      "integrity": "sha512-2raaGv2nWxdMbcrw9kuDhHd8coqqVloIoM7X19NmcCVP7FLkT7n8Fj2O/7gg8ccqsaMSXNWCRhbtMpca/lcD8g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-1.2.0.tgz",
+      "integrity": "sha512-jpfYF6I1uwwCqOc8X0fOgZz4Lj91QFzKV4S9lM7jSW84GxytlL3nDanj9+EYC+vLn4liRVaOCA3zRwpkDNXRWg==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": "^1.3.3",
-        "@fluidframework/container-loader": "^1.3.3",
-        "@fluidframework/core-interfaces": "^1.3.3",
-        "@fluidframework/driver-definitions": "^1.3.3",
-        "@fluidframework/driver-utils": "^1.3.3",
-        "@fluidframework/fluid-static": "^1.3.3",
-        "@fluidframework/map": "^1.3.3",
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-loader": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
+        "@fluidframework/driver-utils": "^1.4.0",
+        "@fluidframework/fluid-static": "^1.4.0",
+        "@fluidframework/map": "^1.4.0",
         "@fluidframework/protocol-definitions": "^1.0.0",
-        "@fluidframework/routerlicious-driver": "^1.3.3",
-        "@fluidframework/runtime-utils": "^1.3.3",
-        "@fluidframework/server-services-client": "^0.1036.5001",
-        "axios": "^0.21.2",
+        "@fluidframework/routerlicious-driver": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0",
+        "@fluidframework/server-services-client": "^0.1036.5002",
+        "axios": "^0.28.0",
         "uuid": "^8.3.1"
       },
       "peerDependencies": {
-        "fluid-framework": "^1.3.3"
+        "fluid-framework": "^1.4.0"
       }
-    },
-    "node_modules/@fluidframework/azure-client/node_modules/@fluidframework/server-services-client": {
-      "version": "0.1036.5001",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
-      "integrity": "sha512-e+Zk2uPcds9yqlalAZ0PpfEAKPPUIpIoQb3YSm42ZVpAgQmLYIRqTpXrmTC7qdeQnSGFJUAliW4DfHBEwpSXlQ==",
-      "dependencies": {
-        "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/gitresources": "^0.1036.5001",
-        "@fluidframework/protocol-base": "^0.1036.5001",
-        "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "axios": "^0.26.0",
-        "crc-32": "1.2.0",
-        "debug": "^4.1.1",
-        "json-stringify-safe": "^5.0.1",
-        "jsrsasign": "^10.2.0",
-        "jwt-decode": "^3.0.0",
-        "querystring": "^0.2.0",
-        "sillyname": "^0.1.0",
-        "uuid": "^8.3.1"
-      }
-    },
-    "node_modules/@fluidframework/azure-client/node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/common-utils": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.2.tgz",
-      "integrity": "sha512-PoGX7/l0vWKt5JaAxcgFOdGje30Q6qSE06YzFIKh9Ba3oq7B60+TFqu7c2ErQt6sNddmvcAcAiLVNaTGAip3vw==",
-      "dependencies": {
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@types/events": "^3.0.0",
-        "base64-js": "^1.5.1",
-        "buffer": "^6.0.3",
-        "events": "^3.1.0",
-        "lodash": "^4.17.21",
-        "sha.js": "^2.4.11"
-      }
-    },
-    "node_modules/@fluidframework/azure-client/node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/protocol-definitions": {
-      "version": "0.1028.2000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
-      "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
-      "dependencies": {
-        "@fluidframework/common-definitions": "^0.20.1"
-      }
-    },
-    "node_modules/@fluidframework/azure-client/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@fluidframework/azure-client/node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/@fluidframework/common-definitions": {
       "version": "0.20.1",
@@ -847,13 +777,13 @@
       }
     },
     "node_modules/@fluidframework/container-definitions": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.3.7.tgz",
-      "integrity": "sha512-ESO6uI6n6Xy6gk4Yee9BoVh0JjgnG7SIh79JFKIgGLOk9mQ2j3A8glHPtWTwMxgtvfr+NCHdcE6yleWGWnBU7g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.4.0.tgz",
+      "integrity": "sha512-UwyxdX739ltQhQ9Zr2n7mBKN2eYEVnY7GCsV60ZfLUawb021eeL0rVZZgT0t3BiTCCilBMl4Bw4KQ8XyYu2g/w==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
         "events": "^3.1.0"
       }
@@ -867,20 +797,20 @@
       }
     },
     "node_modules/@fluidframework/container-loader": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.3.7.tgz",
-      "integrity": "sha512-BDAW9cCD4VOV8vAHjv7/n6Bl9TOumkvBcvBJQfg9tXBnBDCxwgjvB5Azpg/rKlxZn9LXLArbTUd1oeT5i1B01g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.4.0.tgz",
+      "integrity": "sha512-D54tW/W5EXLb2nRUGCNd8bID9t9KVkQJmtnHfnQ/JggpaBWODaQRp2tCDtidwo8y6bkiqIheMGjIdjgP9SqJzw==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-utils": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
-        "@fluidframework/driver-utils": "^1.3.7",
-        "@fluidframework/protocol-base": "^0.1036.5001",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-utils": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
+        "@fluidframework/driver-utils": "^1.4.0",
+        "@fluidframework/protocol-base": "^0.1036.5002",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/telemetry-utils": "^1.3.7",
+        "@fluidframework/telemetry-utils": "^1.4.0",
         "abort-controller": "^3.0.0",
         "double-ended-queue": "^2.1.0-0",
         "events": "^3.1.0",
@@ -935,41 +865,41 @@
       }
     },
     "node_modules/@fluidframework/container-runtime": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.3.7.tgz",
-      "integrity": "sha512-dqzcvJlcSWfIS8iTWiqFk3uk+LInZK+gOcNUS2QWR+nOwzI70lQV+UqCb1lxErG1zRcQotga1yn+KSzccZlRxg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.4.0.tgz",
+      "integrity": "sha512-KENgBxuPD7GdNmdjmsyVJpPKZwfXoRlzAxaMNhGdMSbi6oXDrd1LSekY5tchhsLWBpB5ucZpuvmSgbU+h9z3HQ==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-runtime-definitions": "^1.3.7",
-        "@fluidframework/container-utils": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
-        "@fluidframework/driver-utils": "^1.3.7",
-        "@fluidframework/garbage-collector": "^1.3.7",
-        "@fluidframework/protocol-base": "^0.1036.5001",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-runtime-definitions": "^1.4.0",
+        "@fluidframework/container-utils": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
+        "@fluidframework/driver-utils": "^1.4.0",
+        "@fluidframework/garbage-collector": "^1.4.0",
+        "@fluidframework/protocol-base": "^0.1036.5002",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7",
-        "@fluidframework/telemetry-utils": "^1.3.7",
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0",
+        "@fluidframework/telemetry-utils": "^1.4.0",
         "double-ended-queue": "^2.1.0-0",
         "events": "^3.1.0",
         "uuid": "^8.3.1"
       }
     },
     "node_modules/@fluidframework/container-runtime-definitions": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.3.7.tgz",
-      "integrity": "sha512-86RzJm/2/j0es+4oKiJTSsC2/zkp2KGFR/2ALccl58Hru+zttnRMn31DIcc2c7YDNHB6IuaZ7V2UKh26AAnkAg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.4.0.tgz",
+      "integrity": "sha512-0rlswYsMVQiD1/btlJ5Ebf3rfTyFd06E2/zRJiKWiaMzgmn9QqF7OoVtiJfAIUsyey+dR8hnI0IFlB1IMfIPOg==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7"
+        "@fluidframework/runtime-definitions": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/container-runtime-definitions/node_modules/@fluidframework/protocol-definitions": {
@@ -1026,15 +956,15 @@
       }
     },
     "node_modules/@fluidframework/container-utils": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.3.7.tgz",
-      "integrity": "sha512-XFt6iSD6RzJ+1dafwwzFgWA9U0yEvda0328zAGNT//c5H6cNSipxDuos7CJrDJWy2goQkBuyTYxpiSzsi7dNWg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.4.0.tgz",
+      "integrity": "sha512-OKYpvuzz5N62gQn8JELMyuKEwJAlToiLNWJP/dn/PS1HCKux5C/Mg7Twdi19DCgXP/hp5qvzAd+EHPqYWxMUGg==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
+        "@fluidframework/container-definitions": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/telemetry-utils": "^1.3.7"
+        "@fluidframework/telemetry-utils": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/container-utils/node_modules/@fluidframework/common-utils": {
@@ -1083,44 +1013,44 @@
       }
     },
     "node_modules/@fluidframework/core-interfaces": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.3.7.tgz",
-      "integrity": "sha512-Rzsb1xK4h5imIddai+BW+XNWnpM1FEZR9UBWSKb+vMr0PCVBJwe4BTi6vxA7+o8OgdzVMOmOZhqnivKNUrGYKw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.4.0.tgz",
+      "integrity": "sha512-PDIglmsa9BgFh7Xhfs32KA3Q34/arTVHF4m3M0IuAByP4z8Oi2lVuNENZnBEk+IJMcrUhUDk5Q9LH8KGfoAw+Q=="
     },
     "node_modules/@fluidframework/datastore": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.3.7.tgz",
-      "integrity": "sha512-RaGLO3VUCIQhbh5D6h2PLnZ79Fw2aUbZSCltiQdKBWbBp4FzUgP+qqrtzSTd62waIzCod50aODUBNoYP+MqqoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.4.0.tgz",
+      "integrity": "sha512-xV8cfmNzGAcpbQMrtEXTe7N6h6IkybrStrguyhZB6zBFzaPw3RNeAsMTiSxEMeVkU4UFcnI/ZU2rMalzVVC3Tg==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-utils": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore-definitions": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
-        "@fluidframework/driver-utils": "^1.3.7",
-        "@fluidframework/garbage-collector": "^1.3.7",
-        "@fluidframework/protocol-base": "^0.1036.5001",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-utils": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore-definitions": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
+        "@fluidframework/driver-utils": "^1.4.0",
+        "@fluidframework/garbage-collector": "^1.4.0",
+        "@fluidframework/protocol-base": "^0.1036.5002",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7",
-        "@fluidframework/telemetry-utils": "^1.3.7",
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0",
+        "@fluidframework/telemetry-utils": "^1.4.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.1"
       }
     },
     "node_modules/@fluidframework/datastore-definitions": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.3.7.tgz",
-      "integrity": "sha512-ucco5cnYvJEVBtzdeB2vYrdnDswjYAyX2H/OnL4+3gffUcJWCIuXQuON+AHv3uw/ESrOP0CUhuYv6ulT1SajNQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.4.0.tgz",
+      "integrity": "sha512-Xmebp+XFyK2K8EIauQx10UdwOXYskuSyQt8pSZ6ggTMMFpUsnx44tSR8I8KacSFoYkrWzG/G64osRu23SPCcjQ==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7"
+        "@fluidframework/runtime-definitions": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/datastore-definitions/node_modules/@fluidframework/common-utils": {
@@ -1214,16 +1144,16 @@
       }
     },
     "node_modules/@fluidframework/driver-base": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.3.7.tgz",
-      "integrity": "sha512-egZTjkAAQXATbIj5K5Ou7mNfthIKpQzogjrU+l//lHVsXyKJhShsowl4mTLs9VvYfNE5NLove7fdSEoh1coyLA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.4.0.tgz",
+      "integrity": "sha512-w3fYGp1Bkdjp9he3W3dSPQb1vU+zsRIcZZV9wGNfPA1ii7z9rnXzSgscn39IdLbZqvS2704endNwOIYHyBT34g==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/driver-definitions": "^1.3.7",
-        "@fluidframework/driver-utils": "^1.3.7",
+        "@fluidframework/driver-definitions": "^1.4.0",
+        "@fluidframework/driver-utils": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/telemetry-utils": "^1.3.7"
+        "@fluidframework/telemetry-utils": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/driver-base/node_modules/@fluidframework/common-utils": {
@@ -1272,12 +1202,12 @@
       }
     },
     "node_modules/@fluidframework/driver-definitions": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.3.7.tgz",
-      "integrity": "sha512-JZfOgfkOA9sdmMDDs1L83UtU1Zoe73E0QFXu3hlL3JUllDEmMvwzZkwJf+H82PdpHTu/gR99lPMz3GVtWoU5hQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.4.0.tgz",
+      "integrity": "sha512-ay6Wwl8zGS64fjDsdh2iOeKiVVxT57Opeqjp6DqSglnnJi6AkSfYVoOVlMZ5+vJTfYJN3N4ptjrP/i3Mao9zPA==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": "^1.3.7",
+        "@fluidframework/core-interfaces": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000"
       }
     },
@@ -1290,19 +1220,19 @@
       }
     },
     "node_modules/@fluidframework/driver-utils": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.3.7.tgz",
-      "integrity": "sha512-N8dHnrgZJrvbC8DSY0MAbcFNhRJeoryQKYz0b7fjO3P/RE1GRQfU5phlBWlkQwJKPo5Zh+I9o2S6kQY1oz6DcQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.4.0.tgz",
+      "integrity": "sha512-NPTFw54a+EnIzop7iwrHTONdt0UAjW59HhMlYVPMH8/aOBodddHl7oi2Ek96nZLc+6qruHImjJ+0OW+NxNS+Gw==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
-        "@fluidframework/gitresources": "^0.1036.5001",
-        "@fluidframework/protocol-base": "^0.1036.5001",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
+        "@fluidframework/gitresources": "^0.1036.5002",
+        "@fluidframework/protocol-base": "^0.1036.5002",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/telemetry-utils": "^1.3.7",
-        "axios": "^0.26.0",
+        "@fluidframework/telemetry-utils": "^1.4.0",
+        "axios": "^0.28.0",
         "uuid": "^8.3.1"
       }
     },
@@ -1352,22 +1282,22 @@
       }
     },
     "node_modules/@fluidframework/fluid-static": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.3.7.tgz",
-      "integrity": "sha512-Rnuvx/xjy6GuA2/VN2J3I2RLkVMLch1QVqlN5UWZqpSFUx3O8+NPTVC9pocTOnTJTvhO3dqgPmGpJgIigZizbQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.4.0.tgz",
+      "integrity": "sha512-YlSX6Ibm3HquB+swxoIJt6QM1Bd6R9rBHp/HYDR9/9JuQwCIqW1xvF2NHmXPN/TGl51DnbhSB0gtm9k6pYd7pg==",
       "dependencies": {
-        "@fluidframework/aqueduct": "^1.3.7",
+        "@fluidframework/aqueduct": "^1.4.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-loader": "^1.3.7",
-        "@fluidframework/container-runtime-definitions": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore-definitions": "^1.3.7",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-loader": "^1.4.0",
+        "@fluidframework/container-runtime-definitions": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore-definitions": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/request-handler": "^1.3.7",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7"
+        "@fluidframework/request-handler": "^1.4.0",
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/fluid-static/node_modules/@fluidframework/common-utils": {
@@ -1416,13 +1346,13 @@
       }
     },
     "node_modules/@fluidframework/garbage-collector": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.3.7.tgz",
-      "integrity": "sha512-w9FRDXN+/vWnL3JHBteGqY4Df1VvUXJ6DVR/PWJLh1pUyVUvpDAXya9ldxhmPw1CRja+TSc1nxwMWennJVAywQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.4.0.tgz",
+      "integrity": "sha512-bwt1mv3B2PcvVN/JqBkm8MwdRydVboBM7MguQkANDGkmUPD56dRzjBYEdOl3yNZJEO/xJ2v15RPrkf1coI78Bg==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/runtime-definitions": "^1.3.7"
+        "@fluidframework/runtime-definitions": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/garbage-collector/node_modules/@fluidframework/common-utils": {
@@ -1463,25 +1393,25 @@
       }
     },
     "node_modules/@fluidframework/gitresources": {
-      "version": "0.1036.5001",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5001.tgz",
-      "integrity": "sha512-Beg1A/eR7wCPYYb5u5iqqc092NkWnSvl4XCn2ImA4FDKtnYggD2/KYd9Hp0feM6Z99aU4FYSBidL2NewWlvF7A=="
+      "version": "0.1036.5002",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5002.tgz",
+      "integrity": "sha512-/xdmCca+arU9x9tDGdIl2CCk0DmpWlFjZdcTdWjLNiexKMVKDrHmSw9vCpUMlGmECq8EOO7fyzBnAGM+nu+i0g=="
     },
     "node_modules/@fluidframework/map": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.3.7.tgz",
-      "integrity": "sha512-O9YYytm3OIkl6BuC3WGQQtwJZnh50BjfkRGECvhJtMSgEvGE1U6STpk1xuOwnjcK7SsnrkNQd9hMCTZgUMe0VQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.4.0.tgz",
+      "integrity": "sha512-KBdHBxCcIvPtsUSqnc5Ztgs2U01FwgnsW8WF3bl+TGt55Xs4esm3+p43WNkET1YU5Q95RVocRVp03dYMN7xelQ==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-utils": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore-definitions": "^1.3.7",
-        "@fluidframework/driver-utils": "^1.3.7",
+        "@fluidframework/container-utils": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore-definitions": "^1.4.0",
+        "@fluidframework/driver-utils": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7",
-        "@fluidframework/shared-object-base": "^1.3.7",
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0",
+        "@fluidframework/shared-object-base": "^1.4.0",
         "path-browserify": "^1.0.1"
       }
     },
@@ -1531,21 +1461,21 @@
       }
     },
     "node_modules/@fluidframework/merge-tree": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.3.7.tgz",
-      "integrity": "sha512-YA9/fRrTN8LkSw2H1/CgjkfWY1hW6PreHRJbBYZVVC469vXzMGOf+A8xBWS33A4U3oDNBj4ymVb9Ijy87vTKIA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.4.0.tgz",
+      "integrity": "sha512-UJq7AfD52bp8ecoJLxArGI8506hTFjkNYLU2TXj08Fn8pi6MYN8WBMrCgAGJ47P7ytP1YfXOOWLzeT2ODuYJYw==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-utils": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore-definitions": "^1.3.7",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-utils": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore-definitions": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7",
-        "@fluidframework/shared-object-base": "^1.3.7",
-        "@fluidframework/telemetry-utils": "^1.3.7"
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0",
+        "@fluidframework/shared-object-base": "^1.4.0",
+        "@fluidframework/telemetry-utils": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/merge-tree/node_modules/@fluidframework/common-utils": {
@@ -1594,12 +1524,12 @@
       }
     },
     "node_modules/@fluidframework/protocol-base": {
-      "version": "0.1036.5001",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5001.tgz",
-      "integrity": "sha512-Btjy2bWVbVsmzNTBxTQZ9l/WXljsjDpGbBgJsn9GLacrTG9aDDtIVMXuwLAcEV1IVkxGcIipXryvfhbPHDYcMg==",
+      "version": "0.1036.5002",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5002.tgz",
+      "integrity": "sha512-mlI9okyLeSusGx7qU32NDJ4GJptSzVo3V6tPDhphPIOPtyOVTBuL4EQRFYdceoSLHlxEdVnQprwhyoRiMNw7Kw==",
       "dependencies": {
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/gitresources": "^0.1036.5001",
+        "@fluidframework/gitresources": "^0.1036.5002",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
         "lodash": "^4.17.21"
       }
@@ -1658,15 +1588,15 @@
       }
     },
     "node_modules/@fluidframework/request-handler": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.3.7.tgz",
-      "integrity": "sha512-bR1VsJ+KISQ+iklRrjy0OGnYYC/fwsDZcTOG9wbfslFGYt7GIIkFZhsaYDlIjYXBIDQhbZzXCeclxmTzrs2hAQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.4.0.tgz",
+      "integrity": "sha512-KDYjQcrdvSuHXBtIG+LkDCcIjiDdw1CKX4iWi/aQrbGOTFVyLzfb2SnEXOBz7sw0YuMhxf+S322KTcX/OWd12w==",
       "dependencies": {
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-runtime-definitions": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7"
+        "@fluidframework/container-runtime-definitions": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/request-handler/node_modules/@fluidframework/common-utils": {
@@ -1707,20 +1637,20 @@
       }
     },
     "node_modules/@fluidframework/routerlicious-driver": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.3.7.tgz",
-      "integrity": "sha512-mYBOCEaKdgrLihlBSzx7FMdRdjmu3MkIU5bWswEIaBiyBmrv+cVoqtKIaH30Myi+a7KQkmToFQ+ZSJ8kFVukJg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.4.0.tgz",
+      "integrity": "sha512-iyLywWEgo7zWYCiJj0GPzsrn4lmLw65GYJLEod57fBCk9eLRRxhQ2GJuu2k9XGV6nCFadEc1ZEKufDUNIiBPow==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/driver-base": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
-        "@fluidframework/driver-utils": "^1.3.7",
-        "@fluidframework/gitresources": "^0.1036.5001",
-        "@fluidframework/protocol-base": "^0.1036.5001",
+        "@fluidframework/driver-base": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
+        "@fluidframework/driver-utils": "^1.4.0",
+        "@fluidframework/gitresources": "^0.1036.5002",
+        "@fluidframework/protocol-base": "^0.1036.5002",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/server-services-client": "^0.1036.5001",
-        "@fluidframework/telemetry-utils": "^1.3.7",
+        "@fluidframework/server-services-client": "^0.1036.5002",
+        "@fluidframework/telemetry-utils": "^1.4.0",
         "cross-fetch": "^3.1.5",
         "json-stringify-safe": "5.0.1",
         "querystring": "^0.2.0",
@@ -1751,26 +1681,6 @@
         "@fluidframework/common-definitions": "^0.20.1"
       }
     },
-    "node_modules/@fluidframework/routerlicious-driver/node_modules/@fluidframework/server-services-client": {
-      "version": "0.1036.5001",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
-      "integrity": "sha512-e+Zk2uPcds9yqlalAZ0PpfEAKPPUIpIoQb3YSm42ZVpAgQmLYIRqTpXrmTC7qdeQnSGFJUAliW4DfHBEwpSXlQ==",
-      "dependencies": {
-        "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/gitresources": "^0.1036.5001",
-        "@fluidframework/protocol-base": "^0.1036.5001",
-        "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "axios": "^0.26.0",
-        "crc-32": "1.2.0",
-        "debug": "^4.1.1",
-        "json-stringify-safe": "^5.0.1",
-        "jsrsasign": "^10.2.0",
-        "jwt-decode": "^3.0.0",
-        "querystring": "^0.2.0",
-        "sillyname": "^0.1.0",
-        "uuid": "^8.3.1"
-      }
-    },
     "node_modules/@fluidframework/routerlicious-driver/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1794,21 +1704,16 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/@fluidframework/routerlicious-driver/node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-    },
     "node_modules/@fluidframework/runtime-definitions": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.3.7.tgz",
-      "integrity": "sha512-AXE1FDgCl9nF5O4RCn7vdMzTIM4y7fXArAx6HpKMbaWZIVy/fsrGBJ+XFiKCblKtMKhcgv3TrbQlM3nUMSa6Iw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.4.0.tgz",
+      "integrity": "sha512-GewpwBxbeMutnHHXzVWsFYbGQJHKh8dFNqTiW0covMfaOOhXVSM0qzuf7RY7qX9n8Vn/bK3zF4WRo6gx/32fmg==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000"
       }
     },
@@ -1858,21 +1763,21 @@
       }
     },
     "node_modules/@fluidframework/runtime-utils": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.3.7.tgz",
-      "integrity": "sha512-CKzkYYaaYYxscU0NazuYu1gF1tiQxvZ5mHbTE5FxxxydGMEHcqKQ92eFwDdFYEpfJ8TyWBWpnYgyrU4g7dp89A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.4.0.tgz",
+      "integrity": "sha512-0drnuEdUja1m2401FXcsB9l66x5oCGjgW43mLjZgZFKcz5v5jYZml8OKWAtLmwfI/UNLJ9bQkb/nHQSM0Tf3Rw==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-runtime-definitions": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore-definitions": "^1.3.7",
-        "@fluidframework/garbage-collector": "^1.3.7",
-        "@fluidframework/protocol-base": "^0.1036.5001",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-runtime-definitions": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore-definitions": "^1.4.0",
+        "@fluidframework/garbage-collector": "^1.4.0",
+        "@fluidframework/protocol-base": "^0.1036.5002",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/telemetry-utils": "^1.3.7"
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/telemetry-utils": "^1.4.0"
       }
     },
     "node_modules/@fluidframework/runtime-utils/node_modules/@fluidframework/common-utils": {
@@ -1921,21 +1826,21 @@
       }
     },
     "node_modules/@fluidframework/sequence": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.3.7.tgz",
-      "integrity": "sha512-ctBdXecq4y+EZnAAtE/bHSj+jkByusqfemqUhA+NMM8pgIzD3oOO1JWpuIE/dZAjQLTamnXOmrOL4UkyB3dnmw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.4.0.tgz",
+      "integrity": "sha512-KV/BNdALIgKhlivGv7U4NRCRrDWLIgWEVB2Q/oSNdKF5kUgoQnl+iIQLQcpC8dGAB7YQyCHFZVi4glanyEPF5Q==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-utils": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore-definitions": "^1.3.7",
-        "@fluidframework/merge-tree": "^1.3.7",
+        "@fluidframework/container-utils": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore-definitions": "^1.4.0",
+        "@fluidframework/merge-tree": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7",
-        "@fluidframework/shared-object-base": "^1.3.7",
-        "@fluidframework/telemetry-utils": "^1.3.7",
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0",
+        "@fluidframework/shared-object-base": "^1.4.0",
+        "@fluidframework/telemetry-utils": "^1.4.0",
         "uuid": "^8.3.1"
       }
     },
@@ -1984,23 +1889,93 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/@fluidframework/server-services-client": {
+      "version": "0.1036.5002",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5002.tgz",
+      "integrity": "sha512-2d0RSUXvfNlFgHVLiehiU4LgJheqGXlspIgug6U6nvPdwFGtQSbButh2SysBDFilIJ9E6Bacdd0P0e+4HRpCaQ==",
+      "dependencies": {
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/gitresources": "^0.1036.5002",
+        "@fluidframework/protocol-base": "^0.1036.5002",
+        "@fluidframework/protocol-definitions": "^0.1028.2000",
+        "axios": "^0.28.0",
+        "crc-32": "1.2.0",
+        "debug": "^4.1.1",
+        "json-stringify-safe": "^5.0.1",
+        "jsrsasign": "^11.1.0",
+        "jwt-decode": "^3.0.0",
+        "querystring": "^0.2.0",
+        "sillyname": "^0.1.0",
+        "uuid": "^8.3.1"
+      }
+    },
+    "node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/common-utils": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.2.tgz",
+      "integrity": "sha512-PoGX7/l0vWKt5JaAxcgFOdGje30Q6qSE06YzFIKh9Ba3oq7B60+TFqu7c2ErQt6sNddmvcAcAiLVNaTGAip3vw==",
+      "dependencies": {
+        "@fluidframework/common-definitions": "^0.20.1",
+        "@types/events": "^3.0.0",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "events": "^3.1.0",
+        "lodash": "^4.17.21",
+        "sha.js": "^2.4.11"
+      }
+    },
+    "node_modules/@fluidframework/server-services-client/node_modules/@fluidframework/protocol-definitions": {
+      "version": "0.1028.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
+      "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
+      "dependencies": {
+        "@fluidframework/common-definitions": "^0.20.1"
+      }
+    },
+    "node_modules/@fluidframework/server-services-client/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@fluidframework/server-services-client/node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "node_modules/@fluidframework/shared-object-base": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.3.7.tgz",
-      "integrity": "sha512-16ShEElTu60ZNxD4Em1PBbh77v//bHPHIaPJ9Tj8iI0zXGVIhhaY3RjhZScjhQFDhHEwJ0+rv/50X/xUzUXJ/w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.4.0.tgz",
+      "integrity": "sha512-NI94dsIyZL7s76UN/UVawd0JqV106cS84MaW1r9Qv91+QGU8aq/KCS3j8R9ZZ8pWFQ46sX9BT4CKa4hy4xZedw==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-runtime": "^1.3.7",
-        "@fluidframework/container-utils": "^1.3.7",
-        "@fluidframework/core-interfaces": "^1.3.7",
-        "@fluidframework/datastore": "^1.3.7",
-        "@fluidframework/datastore-definitions": "^1.3.7",
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-runtime": "^1.4.0",
+        "@fluidframework/container-utils": "^1.4.0",
+        "@fluidframework/core-interfaces": "^1.4.0",
+        "@fluidframework/datastore": "^1.4.0",
+        "@fluidframework/datastore-definitions": "^1.4.0",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.3.7",
-        "@fluidframework/runtime-utils": "^1.3.7",
-        "@fluidframework/telemetry-utils": "^1.3.7",
+        "@fluidframework/runtime-definitions": "^1.4.0",
+        "@fluidframework/runtime-utils": "^1.4.0",
+        "@fluidframework/telemetry-utils": "^1.4.0",
         "uuid": "^8.3.1"
       }
     },
@@ -2050,14 +2025,14 @@
       }
     },
     "node_modules/@fluidframework/synthesize": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.3.7.tgz",
-      "integrity": "sha512-hojZEcVPM6ymDTiJkfYpDxQS28BaCjAA9KOqEa4a9RKljUXkxhVKl/flavofYWry/CgBw441e5KnXAZsAbmyoA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.4.0.tgz",
+      "integrity": "sha512-0pdq28pZ/cA/OVOp7KiUv8/bDxltwQy2ca7UJQGuyRDF9n1QcXoWC98liu2fB3/imahdfDi5pZ6l2vw/nIiFkA=="
     },
     "node_modules/@fluidframework/telemetry-utils": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.3.7.tgz",
-      "integrity": "sha512-zM+GDOhZ2XKjPUm6PcGS9IDq3BvoiltH5X3j0dzODRR12xGtZIO2VBHTWlVtDjELw4n/TL/2Ftw+Kk2q/nIooQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.4.0.tgz",
+      "integrity": "sha512-WXG1ThL+WJLGdBtUGlCPPlIrHxqnc+zy+YHrYtqFnlIp+75W3W+YApR5dyP1uCfvapISoBPo0htK3WNIiyj8Rw==",
       "dependencies": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.2",
@@ -2104,11 +2079,11 @@
       }
     },
     "node_modules/@fluidframework/view-interfaces": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.3.7.tgz",
-      "integrity": "sha512-9GlMGSkOZDLT7q7AHEd72Mjx15sKV43dZ61K91cK8Whx1eKx4vez/FFhXJl81bom37W+Gsl6iTy7ZRh8T1yj8g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.4.0.tgz",
+      "integrity": "sha512-YD0HE6rMpG6h/ELR717flLZ4Th0Ik0UUkECgaouW+Qy+Of+uPbi4KVoKRqTEEKzZqBFSbvSR5x3TlbmcXiEZnw==",
       "dependencies": {
-        "@fluidframework/core-interfaces": "^1.3.7"
+        "@fluidframework/core-interfaces": "^1.4.0"
       }
     },
     "node_modules/@gulp-sourcemaps/identity-map": {
@@ -3113,9 +3088,9 @@
       "dev": true
     },
     "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
@@ -7459,9 +7434,9 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
-      "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
+      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
@@ -7491,9 +7466,9 @@
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
-      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+      "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -8815,16 +8790,16 @@
       "dev": true
     },
     "node_modules/fluid-framework": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.3.7.tgz",
-      "integrity": "sha512-NobiWALl9iz4rZnQT+Z0Kr583+Umaub7Ocp8LnCVEpr97hdlvnwpCrLj03cvwxZgpsuobHHTRTpGxabuZtehDQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.4.0.tgz",
+      "integrity": "sha512-Alq2+bwmIrYBZFh/8IynI4mfHvKExLahD1wQ1/4G0PiFYVtI6k2vpRVBofXijTJYq81y3WHN7ytzycW4g/JJrQ==",
       "dependencies": {
-        "@fluidframework/container-definitions": "^1.3.7",
-        "@fluidframework/container-loader": "^1.3.7",
-        "@fluidframework/driver-definitions": "^1.3.7",
-        "@fluidframework/fluid-static": "^1.3.7",
-        "@fluidframework/map": "^1.3.7",
-        "@fluidframework/sequence": "^1.3.7"
+        "@fluidframework/container-definitions": "^1.4.0",
+        "@fluidframework/container-loader": "^1.4.0",
+        "@fluidframework/driver-definitions": "^1.4.0",
+        "@fluidframework/fluid-static": "^1.4.0",
+        "@fluidframework/map": "^1.4.0",
+        "@fluidframework/sequence": "^1.4.0"
       }
     },
     "node_modules/flush-write-stream": {
@@ -12379,9 +12354,9 @@
       ]
     },
     "node_modules/jsrsasign": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.0.0.tgz",
-      "integrity": "sha512-BtRwVKS+5dsgPpAtzJcpo5OoWjSs1/zllSBG0+8o8/aV0Ki76m6iZwHnwnsqoTdhfFZDN1XIdcaZr5ZkP+H2gg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
+      "integrity": "sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==",
       "funding": {
         "url": "https://github.com/kjur/jsrsasign#donations"
       }
@@ -18742,9 +18717,9 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
-      "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+      "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",

--- a/package.json
+++ b/package.json
@@ -1085,7 +1085,7 @@
     "yargs": "^16.2.0"
   },
   "dependencies": {
-    "@fluidframework/azure-client": "^1.1.1",
+    "@fluidframework/azure-client": "^1.2.0",
     "@microsoft/1ds-core-js": "4.0.5",
     "@microsoft/1ds-post-js": "4.0.5",
     "@microsoft/generator-powerpages": "1.21.19",
@@ -1096,7 +1096,7 @@
     "cockatiel": "^3.1.1",
     "command-exists": "^1.2.9",
     "find-process": "^1.4.7",
-    "fluid-framework": "^1.3.3",
+    "fluid-framework": "^1.4.0",
     "glob": "^7.1.7",
     "gpt-tokenizer": "^2.1.1",
     "https-browserify": "^1.0.0",
@@ -1123,9 +1123,5 @@
   "optionalDependencies": {
     "bufferutil": "^4.0.6",
     "utf-8-validate": "^5.0.9"
-  },
-  "overrides": {
-    "jsrsasign": "^11.0.0",
-    "axios": "^0.28.0"
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `package.json` file. The changes update the versions of two dependencies and remove the `overrides` section.

Here are the most important changes:

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1088-R1088): Upgraded the `@fluidframework/azure-client` dependency from version `^1.1.1` to `^1.2.0`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1099-R1099): Upgraded the `fluid-framework` dependency from version `^1.3.3` to `^1.4.0`.

Removal of overrides:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1126-L1129): Removed the `overrides` section which included `jsrsasign` and `axios`.