### PR TITLE
Log OrgGeo for desktop extension

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -195,7 +195,7 @@ export async function activate(
             if (artemisResponse) {
                 const { geoName } = artemisResponse[0];
                 oneDSLoggerWrapper.instantiate(geoName);
-                oneDSLoggerWrapper.getLogger().traceInfo(telemetryEventNames.DESKTOP_EXTENSION_INIT_CONTEXT, orgDetails);
+                oneDSLoggerWrapper.getLogger().traceInfo(telemetryEventNames.DESKTOP_EXTENSION_INIT_CONTEXT, {...orgDetails, orgGeo: geoName});
             }
         })
     );

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -356,6 +356,7 @@ export class OneDSLogger implements ITelemetryLogger {
         if (envelope.data.eventName == desktopExtTelemetryEventNames.DESKTOP_EXTENSION_INIT_CONTEXT) {
             OneDSLogger.contextInfo.orgId = JSON.parse(envelope.data.eventInfo).OrgId;
             OneDSLogger.contextInfo.envId = JSON.parse(envelope.data.eventInfo).EnvironmentId;
+            OneDSLogger.contextInfo.orgGeo = JSON.parse(envelope.data.eventInfo).orgGeo;
             // TODO: Populate website id
             OneDSLogger.contextInfo.websiteId = 'test'
         }


### PR DESCRIPTION
This pull request includes changes to enhance telemetry logging by including geographical information in the `DESKTOP_EXTENSION_INIT_CONTEXT` event. The changes are primarily in the `src/client/extension.ts` and `src/common/OneDSLoggerTelemetry/oneDSLogger.ts` files.

* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL198-R198): Modified the `activate` function to include `orgGeo` (organization's geographical information) in the `DESKTOP_EXTENSION_INIT_CONTEXT` event. This is achieved by extending the `orgDetails` object with `orgGeo` before passing it to `traceInfo` method.

* [`src/common/OneDSLoggerTelemetry/oneDSLogger.ts`](diffhunk://#diff-1c7a0bcddd4688b6e489876d4ab1a031b03f1dcf43f9b9725f460df8758606dfR359): Updated the `OneDSLogger` class to parse and store the `orgGeo` from the `DESKTOP_EXTENSION_INIT_CONTEXT` event. This is done within the condition that checks if the event name is `DESKTOP_EXTENSION_INIT_CONTEXT`.


Link to query: [Web](https://dataexplorer.azure.com/clusters/powerportalstest/databases/PowerPortalsAnalytics?query=H4sIAAAAAAAAAwtITE8tDsgvTy0KyEksScsvynWtKHEtS80rUeCqUSjPSC1KVXDOyQTyg1OLizPz8zxTFGxtFZQMkwwtLZOS0nSNUgzNdE3MjJJ1LS1SUnQTkyyTTI0SU5KN0pINzQ1NTMxMDS3MTUwslABNR%2Bv2agAAAA%3D%3D): 
PagesPowerPlatformExtEvent 
| where ClientSessionId == "1b199bbf-2d16-462c-98dd-ab9b52adc2fc1714465187448"