### PR TITLE
Log AadObjectId for desktop extension

### DIFF
--- a/src/client/pac/PacTypes.ts
+++ b/src/client/pac/PacTypes.ts
@@ -69,6 +69,7 @@ export type ActiveOrgOutput = {
     OrgUrl: string,
     UserEmail: string,
     UserId : string,
+    AadObjectId: string,
     EnvironmentId: string,
 }
 

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -357,6 +357,7 @@ export class OneDSLogger implements ITelemetryLogger {
             OneDSLogger.contextInfo.orgId = JSON.parse(envelope.data.eventInfo).OrgId;
             OneDSLogger.contextInfo.envId = JSON.parse(envelope.data.eventInfo).EnvironmentId;
             OneDSLogger.contextInfo.orgGeo = JSON.parse(envelope.data.eventInfo).orgGeo;
+            OneDSLogger.userInfo.oid = JSON.parse(envelope.data.eventInfo).AadObjectId ?? '';
             // TODO: Populate website id
             OneDSLogger.contextInfo.websiteId = 'test'
         }


### PR DESCRIPTION
This pull request includes changes to the `ActiveOrgOutput` type and the `OneDSLogger` class in the `PacTypes.ts` and `oneDSLogger.ts` files respectively. The changes primarily involve adding the `AadObjectId` property to these entities.

Here are the key changes:

* [`src/client/pac/PacTypes.ts`](diffhunk://#diff-131f5146fef791bd6c3f9898a5438c2bbde00c9fb4ebeb7b2938207a1f4d0ee4R72): The `ActiveOrgOutput` type has been extended with a new property `AadObjectId`. This new field is expected to hold the Azure Active Directory Object ID associated with the user of active organization.
* [`src/common/OneDSLoggerTelemetry/oneDSLogger.ts`](diffhunk://#diff-1c7a0bcddd4688b6e489876d4ab1a031b03f1dcf43f9b9725f460df8758606dfR360): The `OneDSLogger` class has been updated to include the `AadObjectId` in its `userInfo` object. This is done by parsing the `AadObjectId` from the `envelope.data.eventInfo`. Empty string is used as a fallback value if it's not present in the `eventInfo`.

Please Note: The PAC changes for AADObjectId in pac org who command response are yet to be released. 
They have been checked-in in this PR: https://msazure.visualstudio.com/One/_git/PowerPlatform-ISVEx-ToolsCore/pullrequest/9902211