### PR TITLE
Telemetry for ECS fetch and config read

### DIFF
--- a/src/common/ecs-features/ecsFeatureClient.ts
+++ b/src/common/ecs-features/ecsFeatureClient.ts
@@ -8,6 +8,7 @@ import { ITelemetry } from "../../client/telemetry/ITelemetry";
 import { createECSRequestURL } from "./ecsFeatureUtil";
 import { ECSFeatureDefinition as ECSFeatureProperties } from "./ecsFeatureProperties";
 import { ECSAPIFeatureFlagFilters } from "./ecsFeatureFlagFilters";
+import { ECSConfigFailedInit, ECSConfigSuccessfulInit } from "./ecsTelemetryConstants";
 
 export abstract class ECSFeaturesClient {
     private static _ecsConfig: Record<string, string | boolean>;
@@ -26,14 +27,16 @@ export abstract class ECSFeaturesClient {
                 throw new Error('Request failed');
             }
             const result = await response.json();
-            // Update telemetry in other PR
-            // telemetry.sendTelemetryEvent('ECSConfig', {});
 
             // Initialize ECS config
             this._ecsConfig = result[clientName];
+
+            // capture telemetry
+            telemetry.sendTelemetryEvent(ECSConfigSuccessfulInit, { clientName: clientName, configFlagCount: Object.keys(this._ecsConfig).length.toString() });
         } catch (error) {
+            const message = (error as Error)?.message;
             // Log error
-            // telemetry.sendTelemetryEvent('ECSConfigError', {});
+            telemetry.sendTelemetryErrorEvent(ECSConfigFailedInit, { error: message });
         }
     }
 

--- a/src/common/ecs-features/ecsTelemetryConstants.ts
+++ b/src/common/ecs-features/ecsTelemetryConstants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+// Telemetry Event Names
+export const ECSConfigSuccessfulInit = 'ECSConfigSuccessfulInit';
+export const ECSConfigFailedInit = 'ECSConfigFailedInit';


### PR DESCRIPTION
This pull request primarily focuses on enhancing telemetry in the `ECSFeaturesClient` class within the `src/common/ecs-features/ecsFeatureClient.ts` file. The changes include the addition of specific telemetry event names and the modification of the telemetry event triggering mechanism.

Telemetry improvements:

* [`src/common/ecs-features/ecsFeatureClient.ts`](diffhunk://#diff-98e08ba3296c95ebe1634a863e99f6b980b26f407301e1ca1bb137a33bff75dcR11): Imported new telemetry event names `ECSConfigFailedInit` and `ECSConfigSuccessfulInit` from `ecsTelemetryConstants` and used them to send telemetry events. Previously, the telemetry events were commented out and were to be updated in a future PR. Now, telemetry events are sent when the ECS config initialization is successful, including the client name and config flag count. If the initialization fails, an error event is sent with the error message. [[1]](diffhunk://#diff-98e08ba3296c95ebe1634a863e99f6b980b26f407301e1ca1bb137a33bff75dcR11) [[2]](diffhunk://#diff-98e08ba3296c95ebe1634a863e99f6b980b26f407301e1ca1bb137a33bff75dcL29-R39)

Additions:

* [`src/common/ecs-features/ecsTelemetryConstants.ts`](diffhunk://#diff-7925478014d4f91deb99e33065ab71d0c660f4703580c3bec12dff3562c339f1R1-R8): Added a new file to define telemetry event names. This file includes the `ECSConfigSuccessfulInit` and `ECSConfigFailedInit` event names used in the `ECSFeaturesClient` class.