### PR TITLE
Moving auth create flow to utils

### DIFF
--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -7,6 +7,8 @@
 import * as vscode from "vscode";
 import { EXTENSION_ID, EXTENSION_NAME, SETTINGS_EXPERIMENTAL_STORE_NAME } from "../client/constants";
 import { CUSTOM_TELEMETRY_FOR_POWER_PAGES_SETTING_NAME } from "./OneDSLoggerTelemetry/telemetryConstants";
+import { PacWrapper } from "../client/pac/PacWrapper";
+import { AUTH_CREATE_FAILED, AUTH_CREATE_MESSAGE, PAC_SUCCESS } from "./copilot/constants";
 
 export function getSelectedCode(editor: vscode.TextEditor): string {
     if (!editor) {
@@ -131,4 +133,22 @@ export function getUserAgent(): string {
         .replace("{product}", EXTENSION_NAME)
         .replace("{product-version}", getExtensionVersion())
         .replace("{comment}", "(" + getExtensionType()+'; )');
+}
+
+export async function createAuthProfileExp(pacWrapper: PacWrapper | undefined) {
+    const userOrgUrl = await showInputBoxAndGetOrgUrl();
+    if (!userOrgUrl) {
+        return;
+    }
+
+    if(!pacWrapper){
+        vscode.window.showErrorMessage(AUTH_CREATE_FAILED);
+        return;
+    }
+
+    const pacAuthCreateOutput = await showProgressWithNotification(vscode.l10n.t(AUTH_CREATE_MESSAGE), async () => { return await pacWrapper?.authCreateNewAuthProfileForOrg(userOrgUrl) });
+    if (pacAuthCreateOutput && pacAuthCreateOutput.Status !== PAC_SUCCESS) {
+        vscode.window.showErrorMessage(AUTH_CREATE_FAILED);
+        return;
+    }
 }

--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -12,7 +12,7 @@ import { PacWrapper } from "../../client/pac/PacWrapper";
 import { ITelemetry } from "../../client/telemetry/ITelemetry";
 import { ADX_ENTITYFORM, ADX_ENTITYLIST, AUTH_CREATE_FAILED, AUTH_CREATE_MESSAGE, AuthProfileNotFound, COPILOT_UNAVAILABLE, CopilotDisclaimer, CopilotStylePathSegments, DataverseEntityNameMap, EXPLAIN_CODE, EntityFieldMap, FieldTypeMap, PAC_SUCCESS, SELECTED_CODE_INFO, SELECTED_CODE_INFO_ENABLED, THUMBS_DOWN, THUMBS_UP, UserPrompt, WebViewMessage, sendIconSvg } from "./constants";
 import { IActiveFileParams, IActiveFileData, IOrgInfo } from './model';
-import { escapeDollarSign, getLastThreePartsOfFileName, getNonce, getSelectedCode, getSelectedCodeLineRange, getUserName, openWalkthrough, showConnectedOrgMessage, showInputBoxAndGetOrgUrl, showProgressWithNotification } from "../Utils";
+import { createAuthProfileExp, escapeDollarSign, getLastThreePartsOfFileName, getNonce, getSelectedCode, getSelectedCodeLineRange, getUserName, openWalkthrough, showConnectedOrgMessage, showInputBoxAndGetOrgUrl, showProgressWithNotification } from "../Utils";
 import { CESUserFeedback } from "./user-feedback/CESSurvey";
 import { ActiveOrgOutput } from "../../client/pac/PacTypes";
 import { CopilotWalkthroughEvent, CopilotCopyCodeToClipboardEvent, CopilotInsertCodeToEditorEvent, CopilotLoadedEvent, CopilotOrgChangedEvent, CopilotUserFeedbackThumbsDownEvent, CopilotUserFeedbackThumbsUpEvent, CopilotUserPromptedEvent, CopilotCodeLineCountEvent, CopilotClearChatEvent, CopilotNotAvailable, CopilotExplainCode, CopilotExplainCodeSize } from "./telemetry/telemetryConstants";
@@ -108,7 +108,7 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
         );
 
         this._disposables.push(
-            orgChangeErrorEvent(async () => await this.createAuthProfileExp())
+            orgChangeErrorEvent(async () => await createAuthProfileExp(this._pacWrapper))
         );
 
         if (orgInfo) {
@@ -130,19 +130,7 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
         if (pacOutput && pacOutput.Status === PAC_SUCCESS) {
             this.handleOrgChangeSuccess(pacOutput.Results);
         } else if (this._view?.visible) {
-            await this.createAuthProfileExp();
-        }
-    }
-
-    private async createAuthProfileExp() {
-        const userOrgUrl = await showInputBoxAndGetOrgUrl();
-        if (!userOrgUrl) {
-            return;
-        }
-        const pacAuthCreateOutput = await showProgressWithNotification(vscode.l10n.t(AUTH_CREATE_MESSAGE), async () => { return await this._pacWrapper?.authCreateNewAuthProfileForOrg(userOrgUrl) });
-        if (pacAuthCreateOutput && pacAuthCreateOutput.Status !== PAC_SUCCESS) {
-            vscode.window.showErrorMessage(AUTH_CREATE_FAILED);
-            return;
+            await createAuthProfileExp(this._pacWrapper)
         }
     }
 


### PR DESCRIPTION
This pull request primarily focuses on refactoring the `createAuthProfileExp` function in the `PowerPagesCopilot` class and moving it to the `Utils.ts` file. The changes aim to improve the modularity and reusability of the code.

Refactoring and code movement:

* [`src/common/Utils.ts`](diffhunk://#diff-ee01043b0ef0997ea30ab1d37c64169402255c0c1318e8b14f0707c7788f01e7R137-R154): The `createAuthProfileExp` function has been added, which handles the creation of an authentication profile. This function was previously a method in the `PowerPagesCopilot` class.

Codebase simplification:

* [`src/common/Utils.ts`](diffhunk://#diff-ee01043b0ef0997ea30ab1d37c64169402255c0c1318e8b14f0707c7788f01e7R10-R11): Added imports for `PacWrapper` and some constants from the `copilot` directory. This was necessary to support the moved `createAuthProfileExp` function.
* [`src/common/copilot/PowerPagesCopilot.ts`](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL15-R15): The `createAuthProfileExp` method has been removed from the `PowerPagesCopilot` class and replaced with a call to the now standalone function in `Utils.ts`. This change is reflected in the import statement and in two places within the class where the method was called. [[1]](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL15-R15) [[2]](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL111-R111) [[3]](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL133-R133)