### PR TITLE
feat: Move getActiveEditorContent function to utils

### DIFF
--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -8,7 +8,8 @@ import * as vscode from "vscode";
 import { EXTENSION_ID, EXTENSION_NAME, SETTINGS_EXPERIMENTAL_STORE_NAME } from "../client/constants";
 import { CUSTOM_TELEMETRY_FOR_POWER_PAGES_SETTING_NAME } from "./OneDSLoggerTelemetry/telemetryConstants";
 import { PacWrapper } from "../client/pac/PacWrapper";
-import { AUTH_CREATE_FAILED, AUTH_CREATE_MESSAGE, PAC_SUCCESS } from "./copilot/constants";
+import { AUTH_CREATE_FAILED, AUTH_CREATE_MESSAGE, DataverseEntityNameMap, EntityFieldMap, FieldTypeMap, PAC_SUCCESS } from "./copilot/constants";
+import { IActiveFileData, IActiveFileParams } from "./copilot/model";
 
 export function getSelectedCode(editor: vscode.TextEditor): string {
     if (!editor) {
@@ -151,4 +152,30 @@ export async function createAuthProfileExp(pacWrapper: PacWrapper | undefined) {
         vscode.window.showErrorMessage(AUTH_CREATE_FAILED);
         return;
     }
+}
+
+export function getActiveEditorContent(): IActiveFileData {
+    const activeEditor = vscode.window.activeTextEditor;
+    const activeFileData: IActiveFileData = {
+        activeFileContent: '',
+        activeFileParams: {
+            dataverseEntity: '',
+            entityField: '',
+            fieldType: ''
+        } as IActiveFileParams
+    };
+    if (activeEditor) {
+        const document = activeEditor.document;
+        const fileName = document.fileName;
+        const relativeFileName = vscode.workspace.asRelativePath(fileName);
+
+        const activeFileParams: string[] = getLastThreePartsOfFileName(relativeFileName);
+
+        activeFileData.activeFileContent = document.getText();
+        activeFileData.activeFileParams.dataverseEntity = DataverseEntityNameMap.get(activeFileParams[0]) || "";
+        activeFileData.activeFileParams.entityField = EntityFieldMap.get(activeFileParams[1]) || "";
+        activeFileData.activeFileParams.fieldType = FieldTypeMap.get(activeFileParams[2]) || "";
+    }
+
+    return activeFileData;
 }


### PR DESCRIPTION
The code changes add a new function called getActiveEditorContent to the Utils module. This function retrieves the content and parameters of the active editor in Visual Studio Code.
This pull request primarily involves changes to the `src/common/Utils.ts` and `src/common/copilot/PowerPagesCopilot.ts` files. The main changes include the addition of new imports in `Utils.ts`, the creation of a new function `getActiveEditorContent()` in `Utils.ts`, and the removal of the `getActiveEditorContent()` method from `PowerPagesCopilot.ts` to use the newly created function from `Utils.ts`. 

Additions and modifications in `src/common/Utils.ts`:

* Added new imports from `./copilot/constants` and `./copilot/model` to include `DataverseEntityNameMap`, `EntityFieldMap`, `FieldTypeMap`, and `IActiveFileData`, `IActiveFileParams` respectively.
* Created a new function `getActiveEditorContent()`. This function retrieves the content of the active editor and returns an object of type `IActiveFileData`. The object includes the content of the active file and parameters related to the active file such as `dataverseEntity`, `entityField`, and `fieldType`.

Changes in `src/common/copilot/PowerPagesCopilot.ts`:

* Replaced the import of `getLastThreePartsOfFileName` with `getActiveEditorContent` from `../Utils`.
* Replaced the call to `this.getActiveEditorContent()` with `getActiveEditorContent()` in the `PowerPagesCopilot` class. This change reflects the move of the `getActiveEditorContent()` function to `Utils.ts`.
* Removed the `getActiveEditorContent()` method from the `PowerPagesCopilot` class as it is now located in `Utils.ts`.