### PR TITLE
Refactor QuickPickProvider to handle custom tab changes also

### DIFF
--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -308,6 +308,12 @@ export function processWorkspaceStateChanges(context: vscode.ExtensionContext) {
                     if (entityInfo.entityId && entityInfo.entityName) {
                         context.workspaceState.update(document.uri.fsPath, entityInfo);
                         WebExtensionContext.updateVscodeWorkspaceState(document.uri.fsPath, entityInfo);
+
+                        if (isCoPresenceEnabled() && tab.input instanceof vscode.TabInputCustom) {
+                            // sending message to webworker event listener for Co-Presence feature
+                            sendingMessageToWebWorkerForCoPresence(entityInfo);
+                            WebExtensionContext.quickPickProvider.refresh();
+                        }
                     }
                 }
             });

--- a/src/web/client/webViews/QuickPickProvider.ts
+++ b/src/web/client/webViews/QuickPickProvider.ts
@@ -23,14 +23,18 @@ export class QuickPickProvider {
     }
 
     public refresh() {
-        if (vscode.window.activeTextEditor) {
-            const fileFsPath = vscode.window.activeTextEditor.document.uri.fsPath;
-            const entityInfo: IEntityInfo = {
-                entityId: getFileEntityId(fileFsPath),
-                entityName: getFileEntityName(fileFsPath),
-                rootWebPageId: getFileRootWebPageId(fileFsPath),
-            };
-            this.updateQuickPickItems(entityInfo);
+        const tabGroup = vscode.window.tabGroups;
+        if (tabGroup.activeTabGroup && tabGroup.activeTabGroup.activeTab) {
+            const tab = tabGroup.activeTabGroup.activeTab;
+            if (tab.input instanceof vscode.TabInputCustom || tab.input instanceof vscode.TabInputText) {
+                const fileFsPath = tab.input.uri.fsPath;
+                const entityInfo: IEntityInfo = {
+                    entityId: getFileEntityId(fileFsPath),
+                    entityName: getFileEntityName(fileFsPath),
+                    rootWebPageId: getFileRootWebPageId(fileFsPath),
+                };
+                this.updateQuickPickItems(entityInfo);
+            }
         }
     }
 


### PR DESCRIPTION
This pull request refactors the QuickPickProvider class to handle tab input changes. The code changes check if the active tab is an instance of vscode.TabInputCustom or vscode.TabInputText and update the quick pick items based on the file path of the tab input. This improves the functionality of the QuickPickProvider and ensures that the quick pick items are updated correctly when the tab input changes.