### PR TITLE
Move powerPagesNavigationActionsHub to common

### DIFF
--- a/package.json
+++ b/package.json
@@ -947,7 +947,6 @@
         {
           "id": "powerpages.powerPagesFileExplorer",
           "name": "%microsoft-powerplatform-portals.navigation-loop.powerPagesFileExplorer.title%",
-          "when": "isWeb && virtualWorkspace",
           "icon": "./src/web/client/assets/powerPages.svg",
           "contextualTitle": "%microsoft-powerplatform-portals.navigation-loop.powerPagesFileExplorer.title%",
           "visibility": "visible"

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -40,6 +40,7 @@ import { oneDSLoggerWrapper } from "../common/OneDSLoggerTelemetry/oneDSLoggerWr
 import { OrgChangeNotifier, orgChangeEvent } from "../common/OrgChangeNotifier";
 import { ActiveOrgOutput } from "./pac/PacTypes";
 import { telemetryEventNames } from "./telemetry/TelemetryEventNames";
+import { PowerPagesNavigationProvider } from "../common/webViews/powerPagesNavigationProvider";
 
 let client: LanguageClient;
 let _context: vscode.ExtensionContext;
@@ -112,6 +113,18 @@ export async function activate(
                 PortalWebView.createOrShow();
             }
         )
+    );
+
+    // portals action hub
+    const powerPagesNavigationProvider = new PowerPagesNavigationProvider();
+    _context.subscriptions.push(
+        vscode.window.registerTreeDataProvider('powerpages.powerPagesFileExplorer', powerPagesNavigationProvider)
+    );
+    _context.subscriptions.push(
+        vscode.commands.registerCommand('powerpages.powerPagesFileExplorer.powerPagesRuntimePreview', () => powerPagesNavigationProvider.previewPowerPageSite("https://site-zih6k.powerappsportals.com/"))
+    );
+    _context.subscriptions.push(
+        vscode.commands.registerCommand('powerpages.powerPagesFileExplorer.backToStudio', () => powerPagesNavigationProvider.backToStudio("https://make.powerpages.microsoft.com/e/1fdc4473-a512-e14e-8326-a5b8a3fa024f/sites/37de2c85-bdf3-48b1-b262-df1f3a152ac3/pages#webpages/1f653e2b-0768-46b7-8047-2cf373f1fa17"))
     );
 
     // registering bootstrapdiff command

--- a/src/common/TelemetryConstants.ts
+++ b/src/common/TelemetryConstants.ts
@@ -13,3 +13,7 @@ export const VSCODE_EXTENSION_NPS_AUTHENTICATION_COMPLETED = "VSCodeExtensionNPS
 export const VSCODE_EXTENSION_NPS_AUTHENTICATION_FAILED = "VSCodeExtensionNPSAuthenticationFailed";
 export const VSCODE_EXTENSION_GRAPH_CLIENT_AUTHENTICATION_FAILED = "VSCodeExtensionGraphClientAuthenticationFailed";
 export const VSCODE_EXTENSION_GRAPH_CLIENT_AUTHENTICATION_COMPLETED = "VSCodeExtensionGraphClientAuthenticationCompleted";
+
+// Telemetry Event Names for WebViews
+export const WEB_EXTENSION_PREVIEW_SITE_TRIGGERED = "WebExtensionPreviewSiteTriggered";
+export const WEB_EXTENSION_BACK_TO_STUDIO_TRIGGERED = "WebExtensionBackToStudioTriggered";

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -58,7 +58,6 @@ export function getNonce() {
     return text;
 }
 
-
 export function getUserName(user: string) {
     const parts = user.split(" - ");
     return parts[0];
@@ -151,4 +150,8 @@ export async function createAuthProfileExp(pacWrapper: PacWrapper | undefined) {
         vscode.window.showErrorMessage(AUTH_CREATE_FAILED);
         return;
     }
+}
+
+export function isStringUndefinedOrEmpty(value: string | undefined): boolean {
+    return value === undefined || value === '';
 }

--- a/src/common/webViews/constants.ts
+++ b/src/common/webViews/constants.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+export enum httpMethod {
+    PATCH = "PATCH",
+    GET = "GET",
+    POST = "POST",
+    DELETE = "DELETE",
+}

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -19,7 +19,7 @@ import {
     showErrorDialog,
 } from "./common/errorHandler";
 import { WebExtensionTelemetry } from "./telemetry/webExtensionTelemetry";
-import { isCoPresenceEnabled, updateFileContentInFileDataMap } from "./utilities/commonUtil";
+import { getBackToStudioURL, isCoPresenceEnabled, updateFileContentInFileDataMap } from "./utilities/commonUtil";
 import { NPSService } from "./services/NPSService";
 import { vscodeExtAppInsightsResourceProvider } from "../../common/telemetry-generated/telemetryConfiguration";
 import { NPSWebView } from "./webViews/NPSWebView";
@@ -30,7 +30,7 @@ import {
 } from "./utilities/fileAndEntityUtil";
 import { IEntityInfo } from "./common/interfaces";
 import { telemetryEventNames } from "./telemetry/constants";
-import { PowerPagesNavigationProvider } from "./webViews/powerPagesNavigationProvider";
+import { PowerPagesNavigationProvider } from "../../common/webViews/powerPagesNavigationProvider";
 import * as copilot from "../../common/copilot/PowerPagesCopilot";
 import { IOrgInfo } from "../../common/copilot/model";
 import { copilotNotificationPanel, disposeNotificationPanel } from "../../common/copilot/welcome-notification/CopilotNotificationPanel";
@@ -262,8 +262,9 @@ export function registerCollaborationView() {
 export function powerPagesNavigation() {
     const powerPagesNavigationProvider = new PowerPagesNavigationProvider();
     vscode.window.registerTreeDataProvider('powerpages.powerPagesFileExplorer', powerPagesNavigationProvider);
-    vscode.commands.registerCommand('powerpages.powerPagesFileExplorer.powerPagesRuntimePreview', () => powerPagesNavigationProvider.previewPowerPageSite());
-    vscode.commands.registerCommand('powerpages.powerPagesFileExplorer.backToStudio', () => powerPagesNavigationProvider.backToStudio());
+    const websitePreviewUrl = WebExtensionContext.urlParametersMap.get(queryParameters.WEBSITE_PREVIEW_URL) as string;
+    vscode.commands.registerCommand('powerpages.powerPagesFileExplorer.powerPagesRuntimePreview', () => powerPagesNavigationProvider.previewPowerPageSite(websitePreviewUrl));
+    vscode.commands.registerCommand('powerpages.powerPagesFileExplorer.backToStudio', () => powerPagesNavigationProvider.backToStudio(getBackToStudioURL()));
     WebExtensionContext.telemetry.sendInfoTelemetry(telemetryEventNames.WEB_EXTENSION_POWER_PAGES_WEB_VIEW_REGISTERED);
 }
 


### PR DESCRIPTION
This PR moves the powerPagesNavigationActionsHub to the common folder, allowing it to be consumed on desktop as well.