### PR TITLE
Update release it push parameter to true - needs for version tag publish

### DIFF
--- a/.release-it.yaml
+++ b/.release-it.yaml
@@ -7,7 +7,7 @@ hooks:
 git:
   addUntrackedFiles: false
   commit: false
-  push: false # ADO build pushes the tag when build is complete, and fails if it's already there
+  push: true
   # need to specify pushRepo, since AzDO insists on disconnected refs, breaking upstream
   requireUpstream: false
   pushArgs: [ '--tags' ]


### PR DESCRIPTION
This pull request includes a change to the `.release-it.yaml` configuration file. The `push` setting under `git` has been updated from `false` to `true`. This change alters the behavior of the git operations during the release process, enabling automatic pushing of changes.