### PR TITLE
Release notes for April release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log - Power Platform Extension
 
+## 2.0.49
+Web extension updates
+- Copresence support to show editors/viewers currently present on Power Pages Studio and Power Pages VSCode Extension for Web
+
 ## 2.0.41
-  - pac CLI 1.31.6, (February 2024 refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
+- pac CLI 1.31.6, (February 2024 refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
 - Web Extension updates:
   - Copilot available in United Kingdom, Europe and Australia regions
   - Copilot prompt response improved accuracy for Forms scenario

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.49
 Web extension updates
-- Copresence support to show editors/viewers currently present on Power Pages Studio and Power Pages VSCode Extension for Web
+- Copresence support - Find out who's working on a site (Power Pages Studio and Power Pages VS Code for the Web) at the same time as you with copresence
 
 ## 2.0.41
 - pac CLI 1.31.6, (February 2024 refresh, see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))


### PR DESCRIPTION
This pull request includes an update to the `CHANGELOG.md` file. The change adds a new version entry (2.0.49) with details about the updates in the web extension, specifically the support for copresence to show editors/viewers currently present on Power Pages Studio and Power Pages VSCode Extension for Web.