### PR TITLE
Invoking Language Server Only for Power Pages Workspace

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -96,9 +96,6 @@ export async function activate(
         );
     }
 
-    vscode.workspace.onDidOpenTextDocument(didOpenTextDocument);
-    vscode.workspace.textDocuments.forEach(didOpenTextDocument);
-
     // portal web view panel
     _context.subscriptions.push(
         vscode.commands.registerCommand(
@@ -217,6 +214,9 @@ export async function activate(
         }
         // Init OrgChangeNotifier instance
         OrgChangeNotifier.createOrgChangeNotifierInstance(pacTerminal.getWrapper());
+
+        vscode.workspace.onDidOpenTextDocument(didOpenTextDocument);
+        vscode.workspace.textDocuments.forEach(didOpenTextDocument);
 
         _telemetry.sendTelemetryEvent("PowerPagesWebsiteYmlExists"); // Capture's PowerPages Users
         oneDSLoggerWrapper.getLogger().traceInfo("PowerPagesWebsiteYmlExists");


### PR DESCRIPTION
This pull request includes changes to the `src/client/extension.ts` file, specifically within the `export async function activate(` function. The changes involve the reordering of the `vscode.workspace.onDidOpenTextDocument(didOpenTextDocument);` and `vscode.workspace.textDocuments.forEach(didOpenTextDocument);` lines. These lines were moved from an earlier part of the function to a later part. 

Here are the key changes:

* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL99-L101): The `vscode.workspace.onDidOpenTextDocument(didOpenTextDocument);` and `vscode.workspace.textDocuments.forEach(didOpenTextDocument);` lines were moved from the top of the `activate` function to a spot further down in the function. This reordering have been done to ensure that certain initializations or operations are completed before these lines are executed. [[1]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL99-L101) [[2]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaR218-R220)