### PR TITLE
Update PowerPagesCopilot to initialize EnvId for Desktop extension flow of copilot; Cleanup web extension Artemis calls

### DIFF
--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -34,7 +34,7 @@ let orgID: string;
 let environmentName: string;
 let activeOrgUrl: string;
 let tenantId: string | undefined;
-let environmentId: string | undefined;
+let environmentId: string;
 
 declare const IS_DESKTOP: string | undefined;
 //TODO: Check if it can be converted to singleton
@@ -393,11 +393,12 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
         environmentName = activeOrg.FriendlyName;
         userID = activeOrg.UserId;
         activeOrgUrl = activeOrg.OrgUrl;
+        environmentId = activeOrg.EnvironmentId
 
         sessionID = uuidv4(); // Generate a new session ID on org change
         sendTelemetryEvent(this.telemetry, { eventName: CopilotOrgChangedEvent, copilotSessionId: sessionID, orgId: orgID });
 
-        const intelligenceAPIEndpointInfo = await ArtemisService.getIntelligenceEndpoint(orgID, this.telemetry, sessionID, environmentId ?? '');
+        const intelligenceAPIEndpointInfo = await ArtemisService.getIntelligenceEndpoint(orgID, this.telemetry, sessionID, environmentId);
         this.aibEndpoint = intelligenceAPIEndpointInfo.intelligenceEndpoint;
         this.geoName = intelligenceAPIEndpointInfo.geoName;
         this.crossGeoDataMovementEnabledPPACFlag = intelligenceAPIEndpointInfo.crossGeoDataMovementEnabledPPACFlag;

--- a/src/web/client/telemetry/constants.ts
+++ b/src/web/client/telemetry/constants.ts
@@ -107,7 +107,6 @@ export enum telemetryEventNames {
     WEB_EXTENSION_FETCH_WORKER_SCRIPT_FAILED = 'webExtensionFetchWorkerScriptFailed',
     WEB_EXTENSION_WEB_WORKER_REGISTERED = 'webExtensionWebWorkerRegistered',
     WEB_EXTENSION_WEB_WORKER_REGISTRATION_FAILED = 'webExtensionWebWorkerRegistrationFailed',
-    WEB_EXTENSION_ARTEMIS_RESPONSE = 'webExtensionArtemisResponse',
     WEB_EXTENSION_ARTEMIS_RESPONSE_FAILED = 'webExtensionArtemisResponseFailed',
     WEB_EXTENSION_FAILED_TO_UPDATE_FOREIGN_KEY_DETAILS = 'webExtensionFailedToUpdateForeignKeyDetails',
     WEB_EXTENSION_GRAPH_CLIENT_AUTHENTICATION_FAILED = "WebExtensionGraphClientAuthenticationFailed",


### PR DESCRIPTION
This pull request primarily focuses on refactoring and improving the codebase of `src/common/copilot/PowerPagesCopilot.ts` and `src/web/client/extension.ts`. The changes include making `environmentId` a mandatory string, removing the optional chaining operator for `environmentId`, modifying how `fetchArtemisData` returns data, and removing an unused telemetry event.

Changes to `src/common/copilot/PowerPagesCopilot.ts`:

* [`let orgID: string;`](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL37-R37): Changed `environmentId` from an optional string to a mandatory string. This change implies that `environmentId` will always have a value and cannot be undefined.
* [`export class PowerPagesCopilot implements vscode.WebviewViewProvider {`](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abR396-R401): Removed the optional chaining operator for `environmentId` when calling `ArtemisService.getIntelligenceEndpoint`. This change is in line with the previous change that made `environmentId` mandatory.

Changes to `src/web/client/extension.ts`:

* [`export function activate(context: vscode.ExtensionContext): void {`](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360L119-R121): Modified the `fetchArtemisData` function call to destructure `geoName` and `geoLongName` directly from the returned promise. Also updated the parameters for the `oneDSLoggerWrapper.instantiate` method.
* [`export function activate(context: vscode.ExtensionContext): void {`](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360L175-L176): Removed the call to `logArtemisTelemetry`. This suggests that the telemetry logging for Artemis is no longer needed in this context.
* [`function isActiveDocument(fileFsPath: string): boolean {`](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360L654-R663): Refactored the `fetchArtemisData` function to return an `IArtemisAPIOrgResponse` object instead of a string. Also removed the `logArtemisTelemetry` function and updated the error telemetry call in `fetchArtemisData`.

Changes to `src/web/client/telemetry/constants.ts`:

* [`export enum telemetryEventNames {`](diffhunk://#diff-53efdee85c5ff2b3b01fd6dc8943b4c561f23ad7f08567209c09716e23d028eeL110): Removed the `WEB_EXTENSION_ARTEMIS_RESPONSE` event from the telemetry event names enum. This suggests that this particular telemetry event is no longer being used.