### PR TITLE
Auth create flow triggered only when copilot WebView is visible

### DIFF
--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -110,9 +110,9 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
             orgChangeEvent((orgDetails: ActiveOrgOutput) => this.handleOrgChangeSuccess(orgDetails))
         );
 
-        this._disposables.push(
-            orgChangeErrorEvent(async () => await createAuthProfileExp(this._pacWrapper))
-        );
+        if(this._view?.visible) {
+            this._disposables.push(orgChangeErrorEvent(async () => await createAuthProfileExp(this._pacWrapper)));
+        }
 
         if (orgInfo) {
             orgID = orgInfo.orgId;

--- a/src/common/utilities/Utils.ts
+++ b/src/common/utilities/Utils.ts
@@ -91,7 +91,8 @@ export function showConnectedOrgMessage(environmentName: string, orgUrl: string)
 export async function showInputBoxAndGetOrgUrl() {
     return vscode.window.showInputBox({
         placeHolder: vscode.l10n.t("Enter the environment URL"),
-        prompt: vscode.l10n.t("Active auth profile is not found or has expired. To create a new auth profile, enter the environment URL.")
+        prompt: vscode.l10n.t("Active auth profile is not found or has expired. To create a new auth profile, enter the environment URL."),
+        ignoreFocusOut: true
     });
 }
 


### PR DESCRIPTION
This pull request includes a change to the `PowerPagesCopilot` class in the `src/common/copilot/PowerPagesCopilot.ts` file. The change modifies the event handling for `orgChangeErrorEvent` to only push the event to the `_disposables` array when the `_view` property is visible. This change is likely intended to prevent unnecessary event handling when the view is not visible, potentially improving performance.