### PR TITLE
chore: Update vscode and @types/vscode dependencies to version 1.89.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@types/sinon": "^10.0.12",
         "@types/unzip-stream": "^0.3.0",
         "@types/uuid": "^8.3.0",
-        "@types/vscode": "^1.73.0",
+        "@types/vscode": "^1.89.0",
         "@types/vscode-webview": "^1.57.1",
         "@types/webpack": "^5.28.0",
         "@types/webpack-env": "^1.17.0",
@@ -104,7 +104,7 @@
       },
       "engines": {
         "npm": ">=8.3.0",
-        "vscode": "^1.73.0"
+        "vscode": "^1.89.0"
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.6",
@@ -3388,9 +3388,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-      "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
+      "version": "1.89.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.89.0.tgz",
+      "integrity": "sha512-TMfGKLSVxfGfoO8JfIE/neZqv7QLwS4nwPwL/NwMvxtAY2230H2I4Z5xx6836pmJvMAzqooRQ4pmLm7RUicP3A==",
       "dev": true
     },
     "node_modules/@types/vscode-webview": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "email": "PPTools@microsoft.com"
   },
   "engines": {
-    "vscode": "^1.73.0",
+    "vscode": "^1.89.0",
     "npm": ">=8.3.0"
   },
   "extensionKind": [
@@ -1037,7 +1037,7 @@
     "@types/sinon": "^10.0.12",
     "@types/unzip-stream": "^0.3.0",
     "@types/uuid": "^8.3.0",
-    "@types/vscode": "^1.73.0",
+    "@types/vscode": "^1.89.0",
     "@types/vscode-webview": "^1.57.1",
     "@types/webpack": "^5.28.0",
     "@types/webpack-env": "^1.17.0",

--- a/src/web/client/webViews/QuickPickProvider.ts
+++ b/src/web/client/webViews/QuickPickProvider.ts
@@ -12,7 +12,6 @@ import { getFileEntityId, getFileEntityName, getFileRootWebPageId } from "../uti
 interface IQuickPickItem extends vscode.QuickPickItem {
     label: string;
     id?: string;
-    iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } | vscode.ThemeIcon;
 }
 
 export class QuickPickProvider {


### PR DESCRIPTION
This pull request primarily includes updates to the `package.json` file and a change in the `QuickPickProvider.ts` file. The `package.json` file has been updated to use a newer version of `vscode` and `@types/vscode`. In the `QuickPickProvider.ts` file, the `iconPath` property has been removed from the `IQuickPickItem` interface.

Updates to dependencies:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L59-R59): The `vscode` engine version has been updated from `^1.73.0` to `^1.89.0`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1040-R1040): The `@types/vscode` dependency version has been updated from `^1.73.0` to `^1.89.0`.

Change in `QuickPickProvider.ts`:

* [`src/web/client/webViews/QuickPickProvider.ts`](diffhunk://#diff-8c87e5f3eec6c61061b920113621fd5edb0ad12e511628c798dc63f5b611673dL15): The `iconPath` property has been removed from the `IQuickPickItem` interface.