### PR TITLE
UserId fix for malformed ID read from auth sessions

### DIFF
--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -341,8 +341,9 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
         if (session) {
             intelligenceApiToken = session.accessToken;
             userName = getUserName(session.account.label);
-            userID = session?.account.id.split("/").pop() ??
-                session?.account.id;
+            userID = session?.account.id.split(/[./]/).shift() ??
+                session?.account.id ??
+                "";
         } else {
             intelligenceApiToken = "";
             userName = "";
@@ -406,7 +407,7 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
 
         const copilotAvailabilityStatus = checkCopilotAvailability(this.aibEndpoint, orgID, this.telemetry, sessionID, tenantId);
 
-        if(!copilotAvailabilityStatus) {
+        if (!copilotAvailabilityStatus) {
             this.sendMessageToWebview({ type: 'Unavailable' });
             return;
         } else {

--- a/src/common/services/AuthenticationProvider.ts
+++ b/src/common/services/AuthenticationProvider.ts
@@ -66,7 +66,7 @@ export async function intelligenceAPIAuthentication(telemetry: ITelemetry, sessi
         }
         accessToken = session?.accessToken ?? '';
         user = session.account.label;
-        userId = session?.account.id.split("/").pop() ??
+        userId = session?.account.id.split(/[./]/).shift() ??
             session?.account.id ??
             "";
         if (!accessToken) {
@@ -112,7 +112,7 @@ export async function dataverseAuthentication(
         }
 
         accessToken = session?.accessToken ?? "";
-        userId = session?.account.id.split("/").pop() ??
+        userId = session?.account.id.split(/[./]/).shift() ??
             session?.account.id ??
             "";
         if (!accessToken) {
@@ -220,7 +220,7 @@ export async function graphClientAuthentication(
             sendTelemetryEvent(telemetry, {
                 eventName: VSCODE_EXTENSION_GRAPH_CLIENT_AUTHENTICATION_COMPLETED,
                 userId:
-                    session?.account.id.split("/").pop() ??
+                    session?.account.id.split(/[./]/).shift() ??
                     session?.account.id ??
                     "",
             });
@@ -269,7 +269,7 @@ export async function bapServiceAuthentication(
             sendTelemetryEvent(telemetry, {
                 eventName: VSCODE_EXTENSION_BAP_SERVICE_AUTHENTICATION_COMPLETED,
                 userId:
-                    session?.account.id.split("/").pop() ??
+                    session?.account.id.split(/[./]/).shift() ??
                     session?.account.id ??
                     "",
             });


### PR DESCRIPTION
NOTE wil consider moving to jsonwebtoken to directly get ID post sync with vscode auth contact point.

This pull request primarily focuses on modifying how user IDs are extracted from account IDs in the `AuthenticationProvider.ts` file. The extraction logic has been changed in four different authentication functions. Instead of using `pop()` to get the last segment of the ID after splitting it by '/', the updated code uses `shift()` to get the first segment after splitting the ID by either '.' or '/'.

Here are the primary changes:

* `src/common/services/AuthenticationProvider.ts` - `intelligenceAPIAuthentication` function: Updated the extraction of `userId` from `session?.account.id` by splitting it with a regular expression and using `shift()` instead of `pop()`.
* `src/common/services/AuthenticationProvider.ts` - `dataverseAuthentication` function: Same change as above for `userId` extraction.
* `src/common/services/AuthenticationProvider.ts` - `graphClientAuthentication` function: Updated the `userId` extraction logic in the telemetry event.
* `src/common/services/AuthenticationProvider.ts` - `bapServiceAuthentication` function: Similar change as above for `userId` extraction in the telemetry event.