### PR TITLE
Handle multi step form with bad step data

### DIFF
--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -13,6 +13,7 @@ import {
     isPortalVersionV2,
     isWebfileContentLoadNeeded,
     setFileContent,
+    isNullOrUndefined,
 } from "../utilities/commonUtil";
 import { getCustomRequestURL, getMappingEntityContent, getMetadataInfo, getMappingEntityId, getMimeType, getRequestURL } from "../utilities/urlBuilderUtil";
 import { getCommonHeadersForDataverse } from "../../../common/services/AuthenticationProvider";
@@ -333,7 +334,7 @@ async function processDataAndCreateFile(
         if (fileExtension === undefined) {
             const expandedContent = getAttributeContent(result, attributePath, entityName, entityId);
 
-            if (expandedContent !== Constants.NO_CONTENT) {
+            if (!isNullOrUndefined(expandedContent)) {
                 await processExpandedData(
                     entityName,
                     expandedContent,
@@ -459,7 +460,7 @@ async function createFile(
     await createVirtualFile(
         portalsFS,
         fileUri,
-        convertContentToUint8Array(fileContent, base64Encoded),
+        convertContentToUint8Array(fileContent ?? Constants.NO_CONTENT, base64Encoded),
         entityId,
         attributePath,
         encodeAsBase64(entityName, attribute),
@@ -576,20 +577,28 @@ export async function preprocessData(
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             data?.forEach((dataItem: any) => {
-                const webFormSteps = getAttributeContent(dataItem, attributePath, entityType, fetchedFileId as string) as [];
+                try {
+                    const webFormSteps = getAttributeContent(dataItem, attributePath, entityType, fetchedFileId as string) as [];
 
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const steps: any[] = [];
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const steps: any[] = [];
 
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                webFormSteps?.forEach((step: any) => {
-                    const formStepData = advancedFormStepData.get(step);
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    !isNullOrUndefined(webFormSteps) && webFormSteps?.forEach((step: any) => {
+                        const formStepData = advancedFormStepData.get(step);
 
-                    if (formStepData) {
-                        steps.push(formStepData);
-                    }
-                });
-                setFileContent(dataItem, attributePath, steps);
+                        if (formStepData) {
+                            steps.push(formStepData);
+                        }
+                    });
+                    setFileContent(dataItem, attributePath, steps);
+                }
+                catch (error) {
+                    const errorMsg = (error as Error)?.message;
+                    WebExtensionContext.telemetry.sendErrorTelemetry(telemetryEventNames.WEB_EXTENSION_PREPROCESS_DATA_WEBFORM_STEPS_FAILED,
+                        preprocessData.name,
+                        errorMsg);
+                }
             });
             WebExtensionContext.telemetry.sendInfoTelemetry(telemetryEventNames.WEB_EXTENSION_PREPROCESS_DATA_SUCCESS, { entityType: entityType });
         }

--- a/src/web/client/telemetry/constants.ts
+++ b/src/web/client/telemetry/constants.ts
@@ -49,6 +49,7 @@ export enum telemetryEventNames {
     WEB_EXTENSION_CREATE_ENTITY_FOLDER_FAILED = "webExtensionCreateEntityFolderFailed",
     WEB_EXTENSION_PREPROCESS_DATA_FAILED = "webExtensionPreprocessDataFailed",
     WEB_EXTENSION_PREPROCESS_DATA_SUCCESS = "webExtensionPreprocessDataSuccess",
+    WEB_EXTENSION_PREPROCESS_DATA_WEBFORM_STEPS_FAILED = "webExtensionPreprocessDataWebFormStepsFailed",
     WEB_EXTENSION_ATTRIBUTE_CONTENT_ERROR = "webExtensionAttributeContentError",
     WEB_EXTENSION_SET_FILE_CONTENT_ERROR = "webExtensionSetFileContentError",
     WEB_EXTENSION_FAILED_TO_PREPARE_WORKSPACE = "webExtensionFailedToPrepareWorkspace",

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -10,7 +10,6 @@ import {
     CO_PRESENCE_FEATURE_SETTING_NAME,
     DATA,
     MULTI_FILE_FEATURE_SETTING_NAME,
-    NO_CONTENT,
     STUDIO_PROD_REGION,
     VERSION_CONTROL_FOR_WEB_EXTENSION_SETTING_NAME,
     portalSchemaVersion,
@@ -63,12 +62,12 @@ export function isExtensionNeededInFileName(entity: string) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getAttributeContent(result: any, attributePath: IAttributePath, entityName: string, entityId: string) {
-    let value = result[attributePath.source] ?? NO_CONTENT;
+    let value = result[attributePath.source];
 
     try {
         if (result[attributePath.source] && attributePath.relativePath.length) {
             value =
-                JSON.parse(result[attributePath.source])[attributePath.relativePath] ?? NO_CONTENT;
+                JSON.parse(result[attributePath.source])[attributePath.relativePath];
         }
     }
     catch (error) {
@@ -76,6 +75,7 @@ export function getAttributeContent(result: any, attributePath: IAttributePath, 
         WebExtensionContext.telemetry.sendErrorTelemetry(telemetryEventNames.WEB_EXTENSION_ATTRIBUTE_CONTENT_ERROR,
             getAttributeContent.name,
             `For ${entityName} with entityId ${entityId} and attributePath ${JSON.stringify(attributePath)} error: ${errorMsg}`);
+        return undefined;
     }
 
     return value;


### PR DESCRIPTION
This pull request primarily focuses on the `src/web/client/dal/remoteFetchProvider.ts` and `src/web/client/utilities/commonUtil.ts` files. The changes involve the replacement of the `NO_CONTENT` constant with checks for null or undefined values, the addition of error handling in the `preprocessData` function, and the inclusion of a new telemetry event.

Here are the key changes:

**Refactoring and Error Handling:**

* [`src/web/client/dal/remoteFetchProvider.ts`](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL336-R337): Replaced checks against `NO_CONTENT` with `isNullOrUndefined` checks in the `processDataAndCreateFile` and `preprocessData` functions. This change improves the robustness of the code by handling null or undefined values more explicitly. [[1]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL336-R337) [[2]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feR580-R601)
* [`src/web/client/dal/remoteFetchProvider.ts`](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feR580-R601): Added error handling in the `preprocessData` function. In case of an error, an error telemetry event is sent.

**Code Simplification:**

* [`src/web/client/dal/remoteFetchProvider.ts`](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL462-R463): Simplified the code in the `createFile` function by using the nullish coalescing operator.
* [`src/web/client/utilities/commonUtil.ts`](diffhunk://#diff-0571fa597154eb22907e2fbbd10adc9ccc04cba979a11f3c571f94a54abcf179L13): Removed the `NO_CONTENT` constant from the import statement and replaced it with checks for undefined values in the `getAttributeContent` function. [[1]](diffhunk://#diff-0571fa597154eb22907e2fbbd10adc9ccc04cba979a11f3c571f94a54abcf179L13) [[2]](diffhunk://#diff-0571fa597154eb22907e2fbbd10adc9ccc04cba979a11f3c571f94a54abcf179L66-R78)

**Telemetry Addition:**

* [`src/web/client/telemetry/constants.ts`](diffhunk://#diff-53efdee85c5ff2b3b01fd6dc8943b4c561f23ad7f08567209c09716e23d028eeR52): Added a new telemetry event `WEB_EXTENSION_PREPROCESS_DATA_WEBFORM_STEPS_FAILED` to track failures in preprocessing data.