### PR TITLE
Fix HTML/YML server crash issue

### DIFF
--- a/src/client/PortalWebView.ts
+++ b/src/client/PortalWebView.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from "vscode";
 import * as path from "path";
-import { searchPortalConfigFolder } from "../common/PortalConfigFinder";
+import { searchPortalConfigFolder } from "../common/utilities/PathFinderUtil";
 
 /**
  * Displays Portal html webpage preview
@@ -130,7 +130,7 @@ export class PortalWebView {
         if (uri) {
             // Add bootstrap.min.css
             let url = webview.asWebviewUri(
-                vscode.Uri.joinPath( uri as vscode.Uri, "web-files", "bootstrap.min.css")
+                vscode.Uri.joinPath(uri as vscode.Uri, "web-files", "bootstrap.min.css")
             );
             const bootstrap = `<link href="${url}" rel="stylesheet" />`;
             html += bootstrap;

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -21,7 +21,6 @@ import {
     TransportKind,
     WorkspaceFolder,
 } from "vscode-languageclient/node";
-import { getPortalsOrgURLs, workspaceContainsPortalConfigFolder } from "../common/PortalConfigFinder";
 import {
     activateDebugger,
     deactivateDebugger,
@@ -41,6 +40,8 @@ import { ActiveOrgOutput } from "./pac/PacTypes";
 import { telemetryEventNames } from "./telemetry/TelemetryEventNames";
 import { IArtemisAPIOrgResponse } from "../common/services/Interfaces";
 import { ArtemisService } from "../common/services/ArtemisService";
+import { workspaceContainsPortalConfigFolder } from "../common/utilities/PathFinderUtil";
+import { getPortalsOrgURLs } from "../common/utilities/WorkspaceInfoFinderUtil";
 
 let client: LanguageClient;
 let _context: vscode.ExtensionContext;

--- a/src/common/utilities/PathFinderUtil.ts
+++ b/src/common/utilities/PathFinderUtil.ts
@@ -10,8 +10,6 @@ import { URL } from 'url';
 import * as path from 'path';
 import * as fs from 'fs';
 import { glob } from 'glob';
-import { sendTelemetryEvent} from "../client/power-pages/telemetry";
-import { ITelemetry } from "../client/telemetry/ITelemetry";
 
 const portalConfigFolderName = '.portalconfig';
 
@@ -71,31 +69,4 @@ function isSibling(file: string): URL | null {
         }
     }
     return null;
-}
-
-export function getPortalsOrgURLs(workspaceRootFolders:WorkspaceFolder[] | null, telemetry: ITelemetry ) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let output: any[] = [];
-    try {
-        workspaceRootFolders?.forEach(workspaceRootFolder => {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const manifestFiles  = glob.sync('**/*-manifest.yml', { dot: true, cwd: workspaceRootFolder!.uri });
-            if (manifestFiles.length == 0) {
-                output = [{
-                    orgURL: '',
-                    isManifestExists: false
-                }];
-            }else {
-                manifestFiles?.forEach(manifestFile =>{
-                    output.push({
-                        orgURL: manifestFile.split("-manifest")[0].replace(/.*[portalconfig]\//,''),
-                        isManifestExists: true
-                    });
-                })
-            }
-        });
-    }catch(exception){
-        sendTelemetryEvent(telemetry, { methodName:getPortalsOrgURLs.name,eventName: 'getPortalsOrgURLs', exception: exception as Error });
-    }
-    return output;
 }

--- a/src/common/utilities/WorkspaceInfoFinderUtil.ts
+++ b/src/common/utilities/WorkspaceInfoFinderUtil.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import {
+    WorkspaceFolder
+} from 'vscode-languageserver/node';
+import { glob } from 'glob';
+import { sendTelemetryEvent } from "../../client/power-pages/telemetry";
+import { ITelemetry } from "../../client/telemetry/ITelemetry";
+
+export function getPortalsOrgURLs(workspaceRootFolders: WorkspaceFolder[] | null, telemetry: ITelemetry) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let output: any[] = [];
+    try {
+        workspaceRootFolders?.forEach(workspaceRootFolder => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const manifestFiles = glob.sync('**/*-manifest.yml', { dot: true, cwd: workspaceRootFolder!.uri });
+            if (manifestFiles.length == 0) {
+                output = [{
+                    orgURL: '',
+                    isManifestExists: false
+                }];
+            } else {
+                manifestFiles?.forEach(manifestFile => {
+                    output.push({
+                        orgURL: manifestFile.split("-manifest")[0].replace(/.*[portalconfig]\//, ''),
+                        isManifestExists: true
+                    });
+                })
+            }
+        });
+    } catch (exception) {
+        sendTelemetryEvent(telemetry, { methodName: getPortalsOrgURLs.name, eventName: 'getPortalsOrgURLs', exception: exception as Error });
+    }
+    return output;
+}

--- a/src/server/YamlServer.ts
+++ b/src/server/YamlServer.ts
@@ -41,6 +41,7 @@ let hasDiagnosticRelatedInformationCapability = false;
 
 
 connection.onInitialize((params: InitializeParams) => {
+
     const capabilities = params.capabilities;
     workspaceRootFolders = params.workspaceFolders;
     // Does the client support the `workspace/configuration` request?
@@ -93,7 +94,7 @@ connection.onInitialized(() => {
 // The content of a text document has changed. This event is emitted
 // when the text document first opened or when its content has changed.
 documents.onDidChangeContent(change => {
-	editedTextDocument = (change.document);
+    editedTextDocument = (change.document);
 });
 
 
@@ -135,7 +136,7 @@ function getSuggestions(rowIndex: number, pathOfFileBeingEdited: string) {
         }
     }
     // we send telemetry data only in case of success, otherwise the logs will be bloated with unnecessary data
-    if(completionItems.length > 0) {
+    if (completionItems.length > 0) {
         telemetryData.properties.success = 'true';
         telemetryData.measurements.countOfAutoCompleteResults = completionItems.length;
         sendTelemetryEvent(connection, telemetryData);

--- a/src/server/lib/PortalManifestReader.ts
+++ b/src/server/lib/PortalManifestReader.ts
@@ -10,7 +10,7 @@ import { URL } from 'url';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as YAML from 'yaml';
-import { getPortalConfigFolderUrl } from '../../common/PortalConfigFinder';
+import { getPortalConfigFolderUrl } from '../../common/utilities/PathFinderUtil';
 
 const manifest = '-manifest';
 
@@ -19,7 +19,7 @@ export interface IManifestElement {
     RecordId: string;
 }
 
-export function getMatchedManifestRecords(workspaceRootFolders : WorkspaceFolder[] | null, keyForCompletion: string, pathOfFileBeingEdited?: string) : IManifestElement[] {
+export function getMatchedManifestRecords(workspaceRootFolders: WorkspaceFolder[] | null, keyForCompletion: string, pathOfFileBeingEdited?: string): IManifestElement[] {
     let matchedManifestRecords: IManifestElement[] = [];
     if (pathOfFileBeingEdited) {
         const portalConfigFolderUrl = getPortalConfigFolderUrl(workspaceRootFolders, pathOfFileBeingEdited) as URL | null; //https://github.com/Microsoft/TypeScript/issues/11498


### PR DESCRIPTION
key issue: Language server refers to common module files - which in turn is incorrectly referring to desktop client file which were causing import of "vscode" module in Language server code. Importing vscode module in langugae server is not a supported sceanrio - hence a crash here.

This is related to issue [#893](https://github.com/microsoft/powerplatform-vscode/issues/893)

Under the line copilot generated text:
------------------------------------------

This pull request primarily involves refactoring and reorganizing the codebase. The changes include the renaming of a file and the relocation of functions, with modifications to the corresponding import statements. The most significant changes are:

File renaming and function relocation:

* `src/common/PortalConfigFinder.ts` has been renamed to `src/common/utilities/PathFinderUtil.ts` and the function `searchPortalConfigFolder` has been moved to this file. [[1]](diffhunk://#diff-4d85b2ab3a8cf62e61d109f8f26905163860cdbcf137fee9bf623b0f72b4f40aL8-R8) [[2]](diffhunk://#diff-c1450f38d3e3aa388ad25b58dea24d985819238702857198bc0f87b5d7881dceL13-L14)
* The function `getPortalsOrgURLs` has been moved from `src/common/PortalConfigFinder.ts` to a new file `src/common/utilities/WorkspaceInfoFinderUtil.ts`. [[1]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaR43-R44) [[2]](diffhunk://#diff-1c5d90d8f3b6a10ad4b88e8d8106775e9d85b31c60ec93b91eb39327d296196dR1-R38)

Import statement modifications:

* In `src/client/PortalWebView.ts`, the import statement for `searchPortalConfigFolder` has been updated to reflect the new location of the function.
* In `src/client/extension.ts`, the import statements for `getPortalsOrgURLs` and `workspaceContainsPortalConfigFolder` have been updated to reflect their new locations. [[1]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL24) [[2]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaR43-R44)
* In `src/server/lib/PortalManifestReader.ts`, the import statement for `getPortalConfigFolderUrl` has been updated to reflect its new location.

Minor changes:

* A new line was added in `src/server/YamlServer.ts` for better code readability.