### PR TITLE
chore: Update vscode and @types/vscode dependencies to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@types/sinon": "^10.0.12",
         "@types/unzip-stream": "^0.3.0",
         "@types/uuid": "^8.3.0",
-        "@types/vscode": "^1.89.0",
+        "@types/vscode": "^1.91.0",
         "@types/vscode-webview": "^1.57.1",
         "@types/webpack": "^5.28.0",
         "@types/webpack-env": "^1.17.0",
@@ -104,7 +104,7 @@
       },
       "engines": {
         "npm": ">=8.3.0",
-        "vscode": "^1.89.0"
+        "vscode": "^1.91.0"
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.6",
@@ -3388,9 +3388,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.89.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.89.0.tgz",
-      "integrity": "sha512-TMfGKLSVxfGfoO8JfIE/neZqv7QLwS4nwPwL/NwMvxtAY2230H2I4Z5xx6836pmJvMAzqooRQ4pmLm7RUicP3A==",
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.91.0.tgz",
+      "integrity": "sha512-PgPr+bUODjG3y+ozWUCyzttqR9EHny9sPAfJagddQjDwdtf66y2sDKJMnFZRuzBA2YtBGASqJGPil8VDUPvO6A==",
       "dev": true
     },
     "node_modules/@types/vscode-webview": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "email": "PPTools@microsoft.com"
   },
   "engines": {
-    "vscode": "^1.89.0",
+    "vscode": "^1.91.0",
     "npm": ">=8.3.0"
   },
   "extensionKind": [
@@ -1037,7 +1037,7 @@
     "@types/sinon": "^10.0.12",
     "@types/unzip-stream": "^0.3.0",
     "@types/uuid": "^8.3.0",
-    "@types/vscode": "^1.89.0",
+    "@types/vscode": "^1.91.0",
     "@types/vscode-webview": "^1.57.1",
     "@types/webpack": "^5.28.0",
     "@types/webpack-env": "^1.17.0",


### PR DESCRIPTION
This pull request contains updates to the `package.json` file. The changes are primarily focused on updating the versions of `vscode` and `@types/vscode` from `^1.89.0` to `^1.91.0`. 

Here are the key changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L59-R59): Updated the version of `vscode` from `^1.89.0` to `^1.91.0` in the `engines` section. This change indicates that the extension now requires at least version 1.91.0 of Visual Studio Code to run.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1040-R1040): Updated the version of `@types/vscode` from `^1.89.0` to `^1.91.0` in the `devDependencies` section. This change updates the TypeScript definitions for the Visual Studio Code API to match the new minimum required version of the editor.