### PR TITLE
feat: Add @powerpages feedback telemetry

### DIFF
--- a/src/common/chat-participants/powerpages/PowerPagesChatParticipantConstants.ts
+++ b/src/common/chat-participants/powerpages/PowerPagesChatParticipantConstants.ts
@@ -18,6 +18,8 @@ export const VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_INVOKED = 'GitHubPowerPag
 export const VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_ORG_DETAILS = 'GitHubPowerPagesAgentOrgDetails';
 export const VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_ORG_DETAILS_NOT_FOUND = 'GitHubPowerPagesAgentOrgDetailsNotFound';
 export const VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO = 'GitHubPowerPagesAgentScenario';
+export const VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO_FEEDBACK_THUMBSUP = 'GitHubPowerPagesAgentScenarioFeedbackThumbsUp';
+export const VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO_FEEDBACK_THUMBSDOWN = 'GitHubPowerPagesAgentScenarioFeedbackThumbsDown';
 export const SKIP_CODES = ["", null, undefined, "violation", "unclear", "explain"];
 
 

--- a/src/common/chat-participants/powerpages/PowerPagesChatParticipantTypes.ts
+++ b/src/common/chat-participants/powerpages/PowerPagesChatParticipantTypes.ts
@@ -8,6 +8,8 @@ import * as vscode from 'vscode';
 export interface IPowerPagesChatResult extends vscode.ChatResult {
     metadata: {
         command: string;
+        scenario: string;
+        orgId?: string;
     }
 }
 export interface IOrgDetails {

--- a/src/common/chat-participants/powerpages/PowerPagesChatParticipantUtils.ts
+++ b/src/common/chat-participants/powerpages/PowerPagesChatParticipantUtils.ts
@@ -10,8 +10,9 @@ import { ITelemetry } from "../../OneDSLoggerTelemetry/telemetry/ITelemetry";
 import { ArtemisService } from "../../services/ArtemisService";
 import { dataverseAuthentication } from "../../services/AuthenticationProvider";
 import { IIntelligenceAPIEndpointInformation } from "../../services/Interfaces";
-import { SUPPORTED_ENTITIES } from "./PowerPagesChatParticipantConstants";
+import { SUPPORTED_ENTITIES, VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO_FEEDBACK_THUMBSDOWN, VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO_FEEDBACK_THUMBSUP } from "./PowerPagesChatParticipantConstants";
 import { IComponentInfo } from "./PowerPagesChatParticipantTypes";
+import * as vscode from 'vscode';
 
 export async function getEndpoint(
     orgID: string,
@@ -54,4 +55,14 @@ export async function getComponentInfo(telemetry: ITelemetry, orgUrl: string | u
 
 export function isEntityInSupportedList(entity: string): boolean {
     return SUPPORTED_ENTITIES.includes(entity);
+}
+
+export function handleChatParticipantFeedback (feedback: vscode.ChatResultFeedback, sessionId: string, telemetry: ITelemetry) {
+    const scenario = feedback.result.metadata?.scenario;
+    const orgId = feedback.result.metadata?.orgId;
+    if (feedback.kind === 1) {
+        telemetry.sendTelemetryEvent(VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO_FEEDBACK_THUMBSUP, { feedback: feedback.kind.toString(), scenario: scenario, orgId:orgId, sessionId: sessionId });
+    } else if (feedback.kind === 0) {
+        telemetry.sendTelemetryEvent(VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO_FEEDBACK_THUMBSDOWN, { feedback: feedback.kind.toString(), scenario: scenario, orgId: orgId, sessionId: sessionId});
+    }
 }


### PR DESCRIPTION
This pull request primarily focuses on enhancing the chat participant feedback mechanism in the `PowerPagesChatParticipant.ts` file and associated files. The most significant changes include the addition of a feedback handler, the inclusion of metadata in chat results, and the introduction of new constants for feedback scenarios.

Feedback Handling:

* [`src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts`](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29R45-R49): A feedback handler `handleChatParticipantFeedback` has been added to the class `PowerPagesChatParticipant`. This handler is invoked when the `onDidReceiveFeedback` event is triggered.

Metadata Enhancements:

* [`src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts`](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L94-R100): Metadata has been added to the chat results in multiple places in the `PowerPagesChatParticipant` class. This metadata includes the `command`, `scenario`, and `orgId` fields. [[1]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L94-R100) [[2]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29R114-R115) [[3]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L122-R132) [[4]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L141-R153) [[5]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29R178-R191)
* [`src/common/chat-participants/powerpages/PowerPagesChatParticipantTypes.ts`](diffhunk://#diff-4f01d2df1e8f89d2ca7dc846477ced24118d0a76a97d02470a2721a2934508c6R11-R12): The `IPowerPagesChatResult` interface has been updated to include the new metadata fields.

Constants Addition:

* [`src/common/chat-participants/powerpages/PowerPagesChatParticipantConstants.ts`](diffhunk://#diff-0b8d35efc4455b9b6e562130d5c35e7d2f87c4bf9635332fbfe408f939d414edR21-R22): New constants have been added for feedback scenarios - `VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO_FEEDBACK_THUMBSUP` and `VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_SCENARIO_FEEDBACK_THUMBSDOWN`.

Utility Functions:

* [`src/common/chat-participants/powerpages/PowerPagesChatParticipantUtils.ts`](diffhunk://#diff-b379cc33401ef3e60e20ce6fd0a4fa00a14fd527982f762b7d025a0f576c603fR59-R68): The `handleChatParticipantFeedback` function has been added to handle feedback, sending telemetry events based on the feedback kind.
* [`src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts`](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L16-R16): The `handleChatParticipantFeedback` function has been imported from `PowerPagesChatParticipantUtils`.