### PR TITLE
Check Dataverse Org URL for validity

### DIFF
--- a/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts
+++ b/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts
@@ -74,6 +74,8 @@ export enum webExtensionTelemetryEventNames {
     WEB_EXTENSION_MULTI_FILE_FEATURE_FLAG_ENABLED = "WebExtensionMultiFileFeatureFlagEnabled",
     WEB_EXTENSION_MULTI_FILE_FEATURE_FLAG_DISABLED = "WebExtensionMultiFileFeatureFlagDisabled",
     WEB_EXTENSION_MULTI_FILE_MANDATORY_PARAMETERS_MISSING = "WebExtensionMultiFileMandatoryParametersMissing",
+    WEB_EXTENSION_MULTI_FILE_INVALID_DATAVERSE_URL = "WebExtensionMultiFileInvalidDataverseUrl",
+    WEB_EXTENSION_MULTI_FILE_INVALID_WEBSITE_PREVIEW_URL = "WebExtensionMultiFileInvalidWebsitePreviewUrl",
     WEB_EXTENSION_CO_PRESENCE_FEATURE_FLAG_DISABLED = "WebExtensionCoPresenceFeatureFlagDisabled",
     WEB_EXTENSION_CO_PRESENCE_FEATURE_FLAG_ENABLED = "WebExtensionCoPresenceFeatureFlagEnabled",
     WEB_EXTENSION_FILES_LOAD_SUCCESS = "WebExtensionFilesLoadSuccess",

--- a/src/web/client/common/errorHandler.ts
+++ b/src/web/client/common/errorHandler.ts
@@ -68,7 +68,7 @@ export function checkMandatoryQueryParameters(
             const dataSource = queryParamsMap?.get(queryParameters.DATA_SOURCE);
             const schemaName = queryParamsMap?.get(schemaKey.SCHEMA_VERSION);
             const websiteId = queryParamsMap?.get(queryParameters.WEBSITE_ID);
-            if (orgURL && dataSource && schemaName && websiteId) {
+            if (orgURL && dataSource && schemaName && websiteId && isDynamicsCRMUrl(orgURL)) {
                 return true;
             } else {
                 WebExtensionContext.telemetry.sendErrorTelemetry(
@@ -131,4 +131,22 @@ export function checkMandatoryMultifileParameters(
             );
             return false;
     }
+}
+
+// Query Param value checks
+export function isDynamicsCRMUrl(url: string) {
+    // Updated pattern to match both conditions: with and without digits after "crm"
+    // We are in public cloud currently - ignoring the gov cloud for now
+    const pattern = /^https?:\/\/[^.]+\.crm(\d{1,2})?\.dynamics\.com/;
+    const result = pattern.test(url);
+
+    if (!result) {
+        WebExtensionContext.telemetry.sendErrorTelemetry(
+            webExtensionTelemetryEventNames.WEB_EXTENSION_MULTI_FILE_INVALID_DATAVERSE_URL,
+            isDynamicsCRMUrl.name,
+            `orgURL:${url}`
+        );
+    }
+
+    return result;
 }

--- a/src/web/client/common/errorHandler.ts
+++ b/src/web/client/common/errorHandler.ts
@@ -74,7 +74,7 @@ export function checkMandatoryQueryParameters(
                 WebExtensionContext.telemetry.sendErrorTelemetry(
                     webExtensionTelemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
                     checkMandatoryQueryParameters.name,
-                    `${orgURL ? `orgURL, ` : ``}dataSource:${dataSource}, schemaName:${schemaName} ,websiteId:${websiteId}`
+                    `orgURL:${orgURL ? orgURL : ``}, dataSource:${dataSource}, schemaName:${schemaName} ,websiteId:${websiteId}`
                 );
                 showErrorDialog(
                     vscode.l10n.t("There was a problem opening the workspace"),

--- a/src/web/client/test/integration/errorHandler.test.ts
+++ b/src/web/client/test/integration/errorHandler.test.ts
@@ -20,6 +20,7 @@ import {
     checkMandatoryParameters,
     checkMandatoryPathParameters,
     checkMandatoryQueryParameters,
+    isDynamicsCRMUrl,
 } from "../../common/errorHandler";
 import {
     showErrorDialog
@@ -116,7 +117,7 @@ describe("errorHandler", () => {
         //Act
         const appName = "portal";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "url"],
+            [queryParameters.ORG_URL, "https://org.crm4.dynamics.com"],
             [queryParameters.DATA_SOURCE, "SQL"],
             [schemaKey.SCHEMA_VERSION, "1.0.0"],
             [
@@ -140,7 +141,7 @@ describe("errorHandler", () => {
         const _mockShowErrorMessage = stub(vscode.window, "showErrorMessage");
         const appName = "por";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "url"],
+            [queryParameters.ORG_URL, "https://org.crm.dynamics.com"],
             [queryParameters.DATA_SOURCE, "SQL"],
             [schemaKey.SCHEMA_VERSION, "1.0.0"],
             [
@@ -186,7 +187,7 @@ describe("errorHandler", () => {
         //Act
         const appName = "portal";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "orgUrl"],
+            [queryParameters.ORG_URL, "https://org.crm2.dynamics.com"],
             [queryParameters.DATA_SOURCE, ""],
             [schemaKey.SCHEMA_VERSION, "1.0.0"],
             [
@@ -209,7 +210,7 @@ describe("errorHandler", () => {
         //Act
         const appName = "portal";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "orgUrl"],
+            [queryParameters.ORG_URL, "https://org.crm11.dynamics.com"],
             [queryParameters.DATA_SOURCE, "SQL"],
             [schemaKey.SCHEMA_VERSION, ""],
             [
@@ -232,7 +233,7 @@ describe("errorHandler", () => {
         //Act
         const appName = "portal";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "orgUrl"],
+            [queryParameters.ORG_URL, "https://org.crm20.dynamics.com"],
             [queryParameters.DATA_SOURCE, "SQL"],
             [schemaKey.SCHEMA_VERSION, "1.0.0.0"],
             [queryParameters.WEBSITE_ID, ""],
@@ -257,7 +258,7 @@ describe("errorHandler", () => {
         expect(result).true;
     });
 
-    it("checkMandatoryPathParameters_whenPppNameIsDifferentFromPortal_shouldReturnFalse", () => {
+    it("checkMandatoryPathParameters_whenPpNameIsDifferentFromPortal_shouldReturnFalse", () => {
         //Act
         const _mockShowErrorMessage = stub(vscode.window, "showErrorMessage");
         const appName = "por";
@@ -275,7 +276,7 @@ describe("errorHandler", () => {
         //Act
         const appName = "portal";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "orgUrl"],
+            [queryParameters.ORG_URL, "https://org.crm11.dynamics.com"],
             [queryParameters.DATA_SOURCE, "SQL"],
             [schemaKey.SCHEMA_VERSION, "1.0.0.0"],
             [
@@ -325,7 +326,7 @@ describe("errorHandler", () => {
             _mockSendErrorTelemetry,
             webExtensionTelemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
             checkMandatoryQueryParameters.name,
-            `dataSource:SQL, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
+            `orgURL:, dataSource:SQL, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
         );
     });
 
@@ -338,7 +339,7 @@ describe("errorHandler", () => {
         );
         const appName = "portal";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "ORG_URL"],
+            [queryParameters.ORG_URL, "https://org.crm14.dynamics.com"],
             [queryParameters.DATA_SOURCE, ""],
             [schemaKey.SCHEMA_VERSION, "1.0.0.0"],
             [
@@ -364,7 +365,7 @@ describe("errorHandler", () => {
             _mockSendErrorTelemetry,
             webExtensionTelemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
             checkMandatoryQueryParameters.name,
-            `orgURL, dataSource:, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
+            `orgURL:https://org.crm14.dynamics.com, dataSource:, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
         );
     });
 
@@ -377,7 +378,7 @@ describe("errorHandler", () => {
         );
         const appName = "portal";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "ORG_URL"],
+            [queryParameters.ORG_URL, "https://org.crm19.dynamics.com"],
             [queryParameters.DATA_SOURCE, "SQL"],
             [schemaKey.SCHEMA_VERSION, ""],
             [
@@ -403,7 +404,7 @@ describe("errorHandler", () => {
             _mockSendErrorTelemetry,
             webExtensionTelemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
             checkMandatoryQueryParameters.name,
-            `orgURL, dataSource:SQL, schemaName: ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
+            `orgURL:https://org.crm19.dynamics.com, dataSource:SQL, schemaName: ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
         );
     });
 
@@ -416,7 +417,7 @@ describe("errorHandler", () => {
         );
         const appName = "portal";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "ORG_URL"],
+            [queryParameters.ORG_URL, "https://org.crm4.dynamics.com"],
             [queryParameters.DATA_SOURCE, "SQL"],
             [schemaKey.SCHEMA_VERSION, "1.0.0.0"],
             [queryParameters.WEBSITE_ID, ""],
@@ -439,7 +440,7 @@ describe("errorHandler", () => {
             _mockSendErrorTelemetry,
             webExtensionTelemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
             checkMandatoryQueryParameters.name,
-            `orgURL, dataSource:SQL, schemaName:1.0.0.0 ,websiteId:`
+            `orgURL:https://org.crm4.dynamics.com, dataSource:SQL, schemaName:1.0.0.0 ,websiteId:`
         );
     });
 
@@ -448,7 +449,7 @@ describe("errorHandler", () => {
         const _mockShowErrorMessage = spy(vscode.window, "showErrorMessage");
         const appName = "por";
         const queryParamsMap = new Map<string, string>([
-            [queryParameters.ORG_URL, "ORG_URL"],
+            [queryParameters.ORG_URL, "https://org.crm4.dynamics.com"],
             [queryParameters.DATA_SOURCE, "SQL"],
             [schemaKey.SCHEMA_VERSION, "1.0.0.0"],
             [queryParameters.WEBSITE_ID, "12345"],
@@ -464,6 +465,56 @@ describe("errorHandler", () => {
             _mockShowErrorMessage,
             errorString,
             detailMessage
+        );
+    });
+
+    it("checkMandatoryQueryParameters_whenOrgUrlIsInvalid_shouldReturnFalse", () => {
+        //Act
+        const _mockShowErrorMessage = spy(vscode.window, "showErrorMessage");
+        const _mockSendErrorTelemetry = spy(
+            WebExtensionContext.telemetry,
+            "sendErrorTelemetry"
+        );
+
+        const appName = "portal";
+        const queryParamsMap = new Map<string, string>([
+            [queryParameters.ORG_URL, "https://org.dynamics.com"],
+            [queryParameters.DATA_SOURCE, "SQL"],
+            [schemaKey.SCHEMA_VERSION, "1.0.0.0"],
+            [
+                queryParameters.WEBSITE_ID,
+                "ed9a6c19-5ab6-4f67-8c35-2423cff958c4",
+            ],
+        ]);
+        //Action
+        const result = checkMandatoryQueryParameters(appName, queryParamsMap);
+        //Assert
+        expect(result).false;
+        const detailMessage = vscode.l10n.t("Check the URL and verify the parameters are correct");
+
+        const errorString = vscode.l10n.t("There was a problem opening the workspace");
+        const options = { detail: detailMessage, modal: true };
+
+        assert.calledOnceWithExactly(
+            _mockShowErrorMessage,
+            errorString,
+            options
+        );
+
+
+        const sendErrorTelemetryCalls = _mockSendErrorTelemetry.getCalls();
+        assert.callCount(_mockSendErrorTelemetry, 2);
+        assert.calledWithMatch(
+            sendErrorTelemetryCalls[0],
+            webExtensionTelemetryEventNames.WEB_EXTENSION_MULTI_FILE_INVALID_DATAVERSE_URL,
+            isDynamicsCRMUrl.name,
+            `orgURL:https://org.dynamics.com`
+        );
+        assert.calledWithMatch(
+            sendErrorTelemetryCalls[1],
+            webExtensionTelemetryEventNames.WEB_EXTENSION_MANDATORY_QUERY_PARAMETERS_MISSING,
+            checkMandatoryQueryParameters.name,
+            `orgURL:https://org.dynamics.com, dataSource:SQL, schemaName:1.0.0.0 ,websiteId:ed9a6c19-5ab6-4f67-8c35-2423cff958c4`
         );
     });
 });


### PR DESCRIPTION
This pull request primarily focuses on enhancing error handling in the `src/web/client/common/errorHandler.ts` file and adding new telemetry event names in the `src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts` file. 

The key changes include the addition of two new telemetry event names, a new function `isDynamicsCRMUrl()`, and updates to the `checkMandatoryQueryParameters()` function to include a check for a valid Dynamics CRM URL. Here's a breakdown of the changes:

New telemetry event names:

* [`src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts`](diffhunk://#diff-bb82f8809651a816e21902e2dbbd2e27cba15ea568c21a1a7183ceb00cfa70acR77-R78): Two new telemetry event names `WEB_EXTENSION_MULTI_FILE_INVALID_DATAVERSE_URL` and `WEB_EXTENSION_MULTI_FILE_INVALID_WEBSITE_PREVIEW_URL` were added to the `webExtensionTelemetryEventNames` enum. These will be used to log specific error events related to invalid URLs.

Error handling enhancements:

* [`src/web/client/common/errorHandler.ts`](diffhunk://#diff-68cfb6364ab55ffe09e672f0609271de8e625139f73ed9390bc8ea550c574be9R135-R152): A new function `isDynamicsCRMUrl()` was added. This function checks if a URL is a valid Dynamics CRM URL using a regular expression and logs an error telemetry event if it's not.
* [`src/web/client/common/errorHandler.ts`](diffhunk://#diff-68cfb6364ab55ffe09e672f0609271de8e625139f73ed9390bc8ea550c574be9L71-R71): The `checkMandatoryQueryParameters()` function was updated to include a call to `isDynamicsCRMUrl()`. This ensures that the `orgURL` parameter is a valid Dynamics CRM URL before proceeding.