### PR TITLE
BugItem-4312228: changed the reorder of powerpagesNavigation

### DIFF
--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -139,8 +139,6 @@ export function activate(context: vscode.ExtensionContext): void {
 
                                 processWalkthroughFirstRunExperience(context);
 
-                                powerPagesNavigation();
-
                                 await vscode.window.withProgress(
                                     {
                                         location: vscode.ProgressLocation.Notification,
@@ -165,6 +163,8 @@ export function activate(context: vscode.ExtensionContext): void {
                                         processWillStartCollaboration(context);
                                     }
                                 );
+
+                                powerPagesNavigation();
 
                                 await NPSService.setEligibility();
                                 if (WebExtensionContext.npsEligibility) {


### PR DESCRIPTION
Bug: https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4312228

In the web version of VS Code, the authentication prompt currently appears twice during launch. The first prompt is triggered by the powerPagesNavigation function, which internally calls powerPlatformAPIAuthentication with a scope limited to api.powerplatform. The second prompt occurs when readDirectory is invoked, as it uses dataverseAuthentication internally with a broader default scope.

The issue arises because when the user is first authenticated through powerPlatformAPIAuthentication, the session created is not recognized by dataverseAuthentication due to the scope limitations. However, if the user is authenticated with dataverseAuthentication first, the resulting session is recognized by powerPlatformAPIAuthentication as well. So changing the order of powerPagesNavigation function