### PR TITLE
Introducing interfaces & class strucuture

### DIFF
--- a/src/common/portal-metadata-context/Interfaces.ts
+++ b/src/common/portal-metadata-context/Interfaces.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+
+import * as vscode from 'vscode';
+
+export interface IPortalMetadata {
+    webpages?: IWebpage[];
+    contentSnippets?: IContentSnippet[];
+    webTemplates?: IWebTemplate[];
+    webFiles?: IWebFile[];
+    entityLists?: IEntityList[];
+    entityForms?: IEntityForm[];
+    webForms?: IWebForm[];
+    website?: IWebsite;
+    pageTemplates?: IPageTemplate[];
+}
+
+export interface IWebsite {
+    adx_name: string;
+    adx_defaultlanguage: string;
+    adx_headerwebtemplateid?: string;
+    adx_websiteid: string;
+    adx_website_language: number;
+    adx_footerwebtemplateid?: string;
+}
+
+export interface IPageTemplate {
+    adx_webtemplateid?: string;
+    adx_name: string;
+    adx_type?: number;
+    adx_pagetemplateid: string;
+}
+
+export interface IWebFile {
+    adx_name: string;
+    adx_parentpageid?: string;
+    adx_webfileid: string;
+}
+
+export interface IContentSnippet {
+    adx_value?: string;
+    adx_name: string;
+    adx_contentsnippetlanguageid?: string;
+    adx_contentsnippetid: string;
+}
+
+export interface IWebTemplate {
+    adx_source?: string;
+    adx_webtemplateid: string;
+    adx_name: string;
+}
+
+export interface IWebpage {
+    adx_customcss?: string;
+    adx_entityform?: string;
+    adx_webpagelanguageid?: string;
+    adx_image?: string;
+    adx_webform?: string;
+    adx_customjavascript?: string;
+    adx_isroot: boolean;
+    adx_summary?: string;
+    adx_parentpageid?: string;
+    adx_entitylist?: string;
+    adx_name: string;
+    adx_pagetemplateid: string;
+    adx_copy?: string;
+    adx_rootwebpageid?: string;
+    adx_webpageid: string;
+}
+
+
+export interface IEntityList {
+    adx_registerstartupscript?: string;
+    adx_entitylistid: string;
+    adx_name: string;
+}
+
+export interface IWebForm {
+    adx_name: string;
+    adx_webformid: string;
+    adx_startstep?: string;
+}
+
+export interface IEntityForm {
+    adx_entityformid: string;
+    adx_name: string;
+    adx_registerstartupscript?: string;
+}
+
+export interface IContextItem {
+    label: string;
+    title: string;
+    id: string;
+    isFile: boolean;
+    content: string;
+    path?: vscode.Uri;
+    component: string;
+    children: IContextItem[];
+    error: string;
+    parentList: IContextItem[];
+}

--- a/src/common/portal-metadata-context/PortalMetadataContext.ts
+++ b/src/common/portal-metadata-context/PortalMetadataContext.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { IContextItem, IPortalMetadata } from "./Interfaces";
+
+export class PortalMetadataContext {
+
+    private portalMetadata: IPortalMetadata;
+    private portalMetadataContext: IContextItem;
+
+
+    public getPortalMetadataContext() {
+        // returns portalMetadataContext
+    }
+
+    public onFileUpdate() {
+        // updates metadatacontext when file updates
+    }
+
+    private updatePortalMetadataContext() {
+        // updates portalMetadataContext
+    }
+
+    private updatePortalMetadata() {
+        // updates portalMetadata
+    }
+
+    private createPortalMetadataContext() {
+        // creates portalMetadataContext
+    }
+
+    private createPortalMetadata() {
+        // creates portalMetadata
+    }
+}


### PR DESCRIPTION
This pull request introduces a new context for handling portal metadata by adding interfaces and a context class. The most important changes include defining interfaces for portal metadata and implementing a class to manage this metadata.

### Portal Metadata Interfaces:

* [`src/common/portal-metadata-context/Interfaces.ts`](diffhunk://#diff-946a01bfc1a2962b63ce8e7b38a0203790a0b2d86fa465c737cf80d47d689defR1-R104): Added interfaces for various portal metadata entities, such as `IPortalMetadata`, `IWebsite`, `IPageTemplate`, `IWebFile`, `IContentSnippet`, `IWebTemplate`, `IWebpage`, `IEntityList`, `IWebForm`, and `IEntityForm`. These interfaces define the structure and types of data used in the portal metadata context.

### Portal Metadata Context Class:

* [`src/common/portal-metadata-context/PortalMetadataContext.ts`](diffhunk://#diff-6545e9f982a35d83a069d649d9aee23315b4550ff3854018545624b040889d1eR1-R37): Introduced the `PortalMetadataContext` class, which includes methods for managing portal metadata and its context. This class provides methods to get, update, and create portal metadata and its context.