### PR TITLE
Loading Copilot Notification Panel Ext. Version Update

### DIFF
--- a/src/common/chat-participants/powerpages/PowerPagesChatParticipantConstants.ts
+++ b/src/common/chat-participants/powerpages/PowerPagesChatParticipantConstants.ts
@@ -34,7 +34,7 @@ export const LIST_PROMPT = vscode.l10n.t('Write JavaScript code to highlight the
 export const WELCOME_MESSAGE = vscode.l10n.t('Hi! @powerpages can help you write, edit, and even summarize your website code.')
 export const RESPONSE_AWAITED_MSG = vscode.l10n.t('Working on it...');
 export const AUTHENTICATION_FAILED_MSG = vscode.l10n.t('Authentication failed. Please try again.');
-export const COPILOT_NOT_AVAILABLE_MSG = vscode.l10n.t('Copilot is not available. Please contact your administrator.');
+export const COPILOT_NOT_AVAILABLE_MSG = vscode.l10n.t('AI features have been disabled by your organization. Contact your admin for details. [Learn more](https://go.microsoft.com/fwlink/?linkid=2285848)');
 export const PAC_AUTH_NOT_FOUND = vscode.l10n.t('Active auth profile is not found or has expired. Please try again.');
 export const INVALID_RESPONSE = vscode.l10n.t('Something went wrong. Don’t worry, you can try again.');
 export const DISCLAIMER_MESSAGE = vscode.l10n.t('Make sure AI-generated content is accurate and appropriate before using. [Learn more](https://go.microsoft.com/fwlink/?linkid=2240145) | [View terms](https://go.microsoft.com/fwlink/?linkid=2189520)');

--- a/src/common/copilot/constants.ts
+++ b/src/common/copilot/constants.ts
@@ -36,6 +36,7 @@ export const ATTRIBUTE_DATAFIELD_NAME = 'datafieldname';
 export const ATTRIBUTE_CLASSID = 'classid';
 export const SYSTEFORMS_API_PATH = 'api/data/v9.2/systemforms';
 export const COPILOT_IN_POWERPAGES = 'Copilot In Power Pages'
+export const EXTENSION_VERSION_KEY = 'extensionVersion';
 
 export type WebViewMessage = {
     type: string;


### PR DESCRIPTION
This pull request includes several changes to the `extension.ts` and `constants.ts` files to introduce version-based notifications for the Copilot feature. The main changes involve adding new constants, updating imports, and implementing logic to show notifications based on the extension version.

### Notification Logic Updates:
* Added logic to show the Copilot notification panel on the first load or after an update by comparing the stored version with the current version in `function showNotificationForCopilot` in `src/client/extension.ts`.
* Added similar version-based notification logic in `function showNotificationForCopilot` in `src/web/client/extension.ts`.

### Constants and Imports:
* Added `EXTENSION_VERSION_KEY` and `EXTENSION_ID` constants to `src/common/copilot/constants.ts`.
* Updated imports to include `EXTENSION_VERSION_KEY` and `EXTENSION_ID` in `src/client/extension.ts` and `src/web/client/extension.ts`. [[1]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL36-R44) [[2]](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360L36-R36) [[3]](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360R47)