### PR TITLE
ECS Initialization fix for desktop on Org Switch

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -185,10 +185,6 @@ export async function activate(
     const pacTerminal = new PacTerminal(_context, _telemetry, cliPath);
     _context.subscriptions.push(cli);
     _context.subscriptions.push(pacTerminal);
-    const workspaceFolders =
-        vscode.workspace.workspaceFolders?.map(
-            (fl) => ({ ...fl, uri: fl.uri.fsPath } as WorkspaceFolder)
-        ) || [];
 
     _context.subscriptions.push(
         orgChangeEvent(async (orgDetails: ActiveOrgOutput) => {
@@ -213,7 +209,7 @@ export async function activate(
                             TenantID: TenantID[0].Value,
                             Region: artemisResponse.stamp
                         },
-                        PowerPagesClientName);
+                        PowerPagesClientName, true);
                 }
 
                 oneDSLoggerWrapper.instantiate(geoName, geoLongName);
@@ -226,6 +222,11 @@ export async function activate(
         })
     );
 
+
+    const workspaceFolders =
+        vscode.workspace.workspaceFolders?.map(
+            (fl) => ({ ...fl, uri: fl.uri.fsPath } as WorkspaceFolder)
+        ) || [];
     // TODO: Handle for VSCode.dev also
     if (workspaceContainsPortalConfigFolder(workspaceFolders)) {
         let telemetryData = '';

--- a/src/common/ecs-features/ecsFeatureClient.ts
+++ b/src/common/ecs-features/ecsFeatureClient.ts
@@ -16,8 +16,8 @@ export abstract class ECSFeaturesClient {
 
     // Initialize ECSFeatureClient - any client config can be fetched with utility function like below
     // EnableMultifileVscodeWeb.getConfig().enableMultifileVscodeWeb
-    public static async init(telemetry: ITelemetry | TelemetryReporter, filters: ECSAPIFeatureFlagFilters, clientName: string) {
-        if (this._ecsConfig) return;
+    public static async init(telemetry: ITelemetry | TelemetryReporter, filters: ECSAPIFeatureFlagFilters, clientName: string, force = false) {
+        if (this._ecsConfig && !force) return
 
         const requestURL = createECSRequestURL(filters, clientName);
         try {


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and maintainability of the codebase. The key modifications involve reordering code for better readability, adding a new parameter to a function call, and updating method signatures to include an optional `force` parameter.

Code reordering and readability improvements:

* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL188-L191): Moved the `workspaceFolders` initialization to a more appropriate location for better readability. [[1]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL188-L191) [[2]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaR225-R229)

Function call updates:

* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL216-R212): Added a `true` parameter to the `PowerPagesClientName` function call to enable a new feature.

Method signature updates:

* [`src/common/ecs-features/ecsFeatureClient.ts`](diffhunk://#diff-98e08ba3296c95ebe1634a863e99f6b980b26f407301e1ca1bb137a33bff75dcL19-R20): Updated the `init` method in `ECSFeaturesClient` to include an optional `force` parameter, allowing forced reinitialization.