### PR TITLE
Refactor telemetry constants and add GitHub Copilot integration and external link event

### DIFF
--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -15,7 +15,7 @@ import { IOrgInfo } from './model';
 import { checkCopilotAvailability, escapeDollarSign, getActiveEditorContent, getNonce, getSelectedCode, getSelectedCodeLineRange, getUserName, openWalkthrough, showConnectedOrgMessage, showInputBoxAndGetOrgUrl, showProgressWithNotification } from "../utilities/Utils";
 import { CESUserFeedback } from "./user-feedback/CESSurvey";
 import { ActiveOrgOutput } from "../../client/pac/PacTypes";
-import { CopilotWalkthroughEvent, CopilotCopyCodeToClipboardEvent, CopilotInsertCodeToEditorEvent, CopilotLoadedEvent, CopilotOrgChangedEvent, CopilotUserFeedbackThumbsDownEvent, CopilotUserFeedbackThumbsUpEvent, CopilotUserPromptedEvent, CopilotCodeLineCountEvent, CopilotClearChatEvent, CopilotExplainCode, CopilotExplainCodeSize, CopilotNotAvailableECSConfig, CopilotPanelTryGitHubCopilotClicked } from "./telemetry/telemetryConstants";
+import { CopilotWalkthroughEvent, CopilotCopyCodeToClipboardEvent, CopilotInsertCodeToEditorEvent, CopilotLoadedEvent, CopilotOrgChangedEvent, CopilotUserFeedbackThumbsDownEvent, CopilotUserFeedbackThumbsUpEvent, CopilotUserPromptedEvent, CopilotCodeLineCountEvent, CopilotClearChatEvent, CopilotExplainCode, CopilotExplainCodeSize, CopilotNotAvailableECSConfig, CopilotPanelTryGitHubCopilotClicked, VSCodeExtensionGitHubChatPanelOpened, VSCodeExtensionGitHubChatNotFound } from "./telemetry/telemetryConstants";
 import { sendTelemetryEvent } from "./telemetry/copilotTelemetry";
 import TelemetryReporter from "@vscode/extension-telemetry";
 import { getEntityColumns, getEntityName, getFormXml } from "./dataverseMetadata";
@@ -297,8 +297,10 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
                     //Open the GitHub Copilot Chat with @powerpages if GitHub Copilot Chat is installed
                     sendTelemetryEvent(this.telemetry, { eventName: CopilotPanelTryGitHubCopilotClicked, copilotSessionId: sessionID, orgId: orgID, userId: userID });
                     if (vscode.extensions.getExtension(GITHUB_COPILOT_CHAT_EXT)) {
+                        sendTelemetryEvent(this.telemetry, { eventName: VSCodeExtensionGitHubChatPanelOpened, copilotSessionId: sessionID, orgId: orgID, userId: userID });
                         vscode.commands.executeCommand('workbench.action.chat.open', PowerPagesParticipantPrompt);
                     } else {
+                        sendTelemetryEvent(this.telemetry, { eventName: VSCodeExtensionGitHubChatNotFound, copilotSessionId: sessionID, orgId: orgID, userId: userID });
                         vscode.env.openExternal(vscode.Uri.parse(PowerPagesParticipantDocLink));
                     }
                 }

--- a/src/common/copilot/telemetry/telemetryConstants.ts
+++ b/src/common/copilot/telemetry/telemetryConstants.ts
@@ -39,4 +39,6 @@ export const CopilotExplainCodeSize = 'CopilotExplainCodeSize';
 export const CopilotNpsAuthenticationCompleted = "CopilotNpsAuthenticationCompleted";
 export const CopilotNotificationTryGitHubCopilotClicked = 'CopilotNotificationTryGitHubCopilotClicked';
 export const CopilotPanelTryGitHubCopilotClicked = 'CopilotPanelTryGitHubCopilotClicked ';
+export const VSCodeExtensionGitHubChatPanelOpened = 'VSCodeExtensionGitHubChatPanelOpened';
+export const VSCodeExtensionGitHubChatNotFound = 'VSCodeExtensionGitHubChatNotFound';
 

--- a/src/common/copilot/welcome-notification/CopilotNotificationPanel.ts
+++ b/src/common/copilot/welcome-notification/CopilotNotificationPanel.ts
@@ -6,7 +6,7 @@
 import * as vscode from "vscode";
 import { getNonce } from "../../utilities/Utils";
 import TelemetryReporter from "@vscode/extension-telemetry";
-import { CopilotNotificationDoNotShowChecked, CopilotTryNotificationClickedEvent, CopilotNotificationDoNotShowUnchecked, CopilotNotificationTryGitHubCopilotClicked } from "../telemetry/telemetryConstants";
+import { CopilotNotificationDoNotShowChecked, CopilotTryNotificationClickedEvent, CopilotNotificationDoNotShowUnchecked, CopilotNotificationTryGitHubCopilotClicked, VSCodeExtensionGitHubChatPanelOpened, VSCodeExtensionGitHubChatNotFound } from "../telemetry/telemetryConstants";
 import { COPILOT_IN_POWERPAGES, COPILOT_NOTIFICATION_DISABLED, PowerPagesParticipantDocLink, PowerPagesParticipantPrompt } from "../constants";
 import { oneDSLoggerWrapper } from "../../OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
@@ -59,8 +59,12 @@ export async function copilotNotificationPanel(context: vscode.ExtensionContext,
                     telemetry.sendTelemetryEvent(CopilotNotificationTryGitHubCopilotClicked, { listOfOrgs: telemetryData, countOfActivePortals: countOfActivePortals as string });
                     oneDSLoggerWrapper.getLogger().traceInfo(CopilotNotificationTryGitHubCopilotClicked, { listOfOrgs: telemetryData, countOfActivePortals: countOfActivePortals as string });
                     if (isGitHubCopilotPresent) {
+                        telemetry.sendTelemetryEvent(VSCodeExtensionGitHubChatPanelOpened, { listOfOrgs: telemetryData, countOfActivePortals: countOfActivePortals as string });
+                        oneDSLoggerWrapper.getLogger().traceInfo(VSCodeExtensionGitHubChatPanelOpened, { listOfOrgs: telemetryData, countOfActivePortals: countOfActivePortals as string });
                         vscode.commands.executeCommand('workbench.action.chat.open', PowerPagesParticipantPrompt);
                     } else {
+                        telemetry.sendTelemetryEvent(VSCodeExtensionGitHubChatNotFound, { listOfOrgs: telemetryData, countOfActivePortals: countOfActivePortals as string });
+                        oneDSLoggerWrapper.getLogger().traceInfo(VSCodeExtensionGitHubChatNotFound, { listOfOrgs: telemetryData, countOfActivePortals: countOfActivePortals as string });
                         vscode.env.openExternal(vscode.Uri.parse(PowerPagesParticipantDocLink));
                     }
             }


### PR DESCRIPTION
This pull request focuses on enhancing telemetry for GitHub Copilot interactions within the PowerPages extension. The main changes include adding new telemetry events to track the opening of the GitHub Copilot Chat panel and handling cases where the extension is not found.

### Telemetry Enhancements:
* [`src/common/copilot/PowerPagesCopilot.ts`](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL18-R18): Added telemetry events `VSCodeExtensionGitHubChatPanelOpened` and `VSCodeExtensionGitHubChatNotFound` to track user interactions when opening the GitHub Copilot Chat panel or when the extension is not found. [[1]](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abL18-R18) [[2]](diffhunk://#diff-98c063ddf20a69c9594332e9f968fe00b2e009c5de85256f9e336c089e6880abR300-R303)
* [`src/common/copilot/telemetry/telemetryConstants.ts`](diffhunk://#diff-8be6094fdbb66269472fff9fba0b0fa6042e180ee442d1d0dc9d2cc9320413b9R42-R43): Introduced new constants `VSCodeExtensionGitHubChatPanelOpened` and `VSCodeExtensionGitHubChatNotFound` for the new telemetry events.
* [`src/common/copilot/welcome-notification/CopilotNotificationPanel.ts`](diffhunk://#diff-65e49faa3d1152985263206facedc615bea8a1e492032f141378741f938f8cf2L9-R9): Integrated the new telemetry events into the notification panel logic to track interactions related to GitHub Copilot Chat. [[1]](diffhunk://#diff-65e49faa3d1152985263206facedc615bea8a1e492032f141378741f938f8cf2L9-R9) [[2]](diffhunk://#diff-65e49faa3d1152985263206facedc615bea8a1e492032f141378741f938f8cf2R62-R67)