### PR TITLE
Pac-cli bump up, envId changes and telemetry update

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -355,7 +355,7 @@ async function snapshot() {
     }
 }
 
-const cliVersion = '1.34.4';
+const cliVersion = '1.35.1';
 
 const recompile = gulp.series(
     clean,

--- a/src/web/client/WebExtensionContext.ts
+++ b/src/web/client/WebExtensionContext.ts
@@ -28,7 +28,7 @@ import { EntityDataMap } from "./context/entityDataMap";
 import { FileDataMap } from "./context/fileDataMap";
 import { IAttributePath, IEntityInfo } from "./common/interfaces";
 import { ConcurrencyHandler } from "./dal/concurrencyHandler";
-import { getMailToPath, getTeamChatURL, isMultifileEnabled } from "./utilities/commonUtil";
+import { getEnvironmentIdFromUrl, getMailToPath, getTeamChatURL, isMultifileEnabled } from "./utilities/commonUtil";
 import { IConnectionData, UserDataMap } from "./context/userDataMap";
 import { EntityForeignKeyDataMap } from "./context/entityForeignKeyDataMap";
 import { QuickPickProvider } from "./webViews/QuickPickProvider";
@@ -73,6 +73,8 @@ export interface IWebExtensionContext {
     geoName: string;
     geoLongName: string;
     serviceEndpointCategory: ServiceEndpointCategory;
+    organizationId: string;
+    environmentId: string;
 
     // Telemetry and survey
     telemetry: WebExtensionTelemetry;
@@ -111,6 +113,8 @@ class WebExtensionContext implements IWebExtensionContext {
     private _geoLongName: string;
     private _clusterLocation: string;
     private _serviceEndpointCategory: ServiceEndpointCategory;
+    private _organizationId: string;
+    private _environmentId: string;
     private _telemetry: WebExtensionTelemetry;
     private _npsEligibility: boolean;
     private _userId: string;
@@ -219,6 +223,18 @@ class WebExtensionContext implements IWebExtensionContext {
     public set serviceEndpointCategory(name: ServiceEndpointCategory) {
         this._serviceEndpointCategory = name;
     }
+    public get organizationId() {
+        return this._organizationId;
+    }
+    public set organizationId(name: string) {
+        this._organizationId = name;
+    }
+    public get environmentId() {
+        return this._environmentId;
+    }
+    public set environmentId(name: string) {
+        this._environmentId = name;
+    }
     public get telemetry() {
         return this._telemetry;
     }
@@ -290,6 +306,8 @@ class WebExtensionContext implements IWebExtensionContext {
         this._geoLongName = "";
         this._clusterLocation = "";
         this._serviceEndpointCategory = ServiceEndpointCategory.NONE;
+        this._organizationId = "";
+        this._environmentId = "";
         this._telemetry = new WebExtensionTelemetry();
         this._npsEligibility = false;
         this._userId = "";
@@ -343,6 +361,10 @@ class WebExtensionContext implements IWebExtensionContext {
             this.schemaEntitiesMap
         );
         this._isContextSet = true;
+
+        // Initialize org details
+        this._organizationId = queryParamsMap.get(Constants.queryParameters.ORG_ID) as string ?? "";
+        this._environmentId = getEnvironmentIdFromUrl();
     }
 
     public setVscodeWorkspaceState(workspaceState: vscode.Memento) {

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -40,7 +40,6 @@ import { GeoNames } from "../../common/OneDSLoggerTelemetry/telemetryConstants";
 import { sendingMessageToWebWorkerForCoPresence } from "./utilities/collaborationUtils";
 import { ECSFeaturesClient } from "../../common/ecs-features/ecsFeatureClient";
 import { PowerPagesAppName, PowerPagesClientName } from "../../common/ecs-features/constants";
-import { IPortalWebExtensionInitQueryParametersTelemetryData } from "../../common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryInterface";
 import { ArtemisService } from "../../common/services/ArtemisService";
 import { showErrorDialog } from "../../common/utilities/errorHandlerUtil";
 import { EXTENSION_ID } from "../../common/constants";
@@ -115,11 +114,11 @@ export function activate(context: vscode.ExtensionContext): void {
                     queryParamsMap,
                     context.extensionUri
                 );
-                logOneDSLogger(queryParamsMap);
+
                 const orgId = queryParamsMap.get(queryParameters.ORG_ID) as string;
                 await fetchArtemisData(orgId);
                 WebExtensionContext.telemetry.sendInfoTelemetry(webExtensionTelemetryEventNames.WEB_EXTENSION_ORG_GEO, { orgId: orgId, orgGeo: WebExtensionContext.geoName });
-                oneDSLoggerWrapper.instantiate(WebExtensionContext.geoLongName, WebExtensionContext.geoLongName);
+                oneDSLoggerWrapper.instantiate(WebExtensionContext.geoName, WebExtensionContext.geoLongName);
 
                 WebExtensionContext.telemetry.sendExtensionInitPathParametersTelemetry(
                     appName,
@@ -153,7 +152,7 @@ export function activate(context: vscode.ExtensionContext): void {
                                         await ECSFeaturesClient.init(WebExtensionContext.telemetry.getTelemetryReporter(),
                                             {
                                                 AppName: PowerPagesAppName,
-                                                EnvID: queryParamsMap.get(queryParameters.ENV_ID) as string,
+                                                EnvID: WebExtensionContext.environmentId,
                                                 UserID: WebExtensionContext.userId,
                                                 TenantID: queryParamsMap.get(queryParameters.TENANT_ID) as string,
                                                 Region: queryParamsMap.get(queryParameters.REGION) as string,
@@ -680,32 +679,4 @@ async function fetchArtemisData(orgId: string) {
     WebExtensionContext.geoLongName = artemisResponse.response.geoLongName;
     WebExtensionContext.serviceEndpointCategory = artemisResponse.stamp;
     WebExtensionContext.clusterLocation = getECSOrgLocationValue(artemisResponse.response.clusterName, artemisResponse.response.clusterNumber);
-}
-
-function logOneDSLogger(queryParamsMap: Map<string, string>) {
-    const telemetryData: IPortalWebExtensionInitQueryParametersTelemetryData = {
-        eventName: webExtensionTelemetryEventNames.WEB_EXTENSION_INIT_QUERY_PARAMETERS,
-        properties: {
-            orgId: queryParamsMap.get(queryParameters.ORG_ID),
-            tenantId: queryParamsMap.get(queryParameters.TENANT_ID),
-            portalId: queryParamsMap.get(queryParameters.PORTAL_ID),
-            websiteId: queryParamsMap.get(queryParameters.WEBSITE_ID),
-            dataSource: queryParamsMap.get(queryParameters.DATA_SOURCE),
-            schema: queryParamsMap.get(queryParameters.SCHEMA),
-            referrerSessionId: queryParamsMap.get(queryParameters.REFERRER_SESSION_ID),
-            referrer: queryParamsMap.get(queryParameters.REFERRER),
-            siteVisibility: queryParamsMap.get(queryParameters.SITE_VISIBILITY),
-            region: queryParamsMap.get(queryParameters.REGION),
-            geo: queryParamsMap.get(queryParameters.GEO),
-            envId: queryParamsMap.get(queryParameters.ENV_ID),
-            referrerSource: queryParamsMap.get(queryParameters.REFERRER_SOURCE),
-            sku: queryParamsMap.get(queryParameters.SKU)
-        }
-    }
-
-    if (queryParamsMap.has(queryParameters.ENTITY) && queryParamsMap.has(queryParameters.ENTITY_ID)) {
-        telemetryData.properties.entity = queryParamsMap.get(queryParameters.ENTITY);
-        telemetryData.properties.entityId = queryParamsMap.get(queryParameters.ENTITY_ID);
-    }
-    oneDSLoggerWrapper.getLogger().traceInfo(telemetryData.eventName, telemetryData.properties);
 }

--- a/src/web/client/telemetry/webExtensionTelemetry.ts
+++ b/src/web/client/telemetry/webExtensionTelemetry.ts
@@ -9,7 +9,7 @@ import { queryParameters } from "../common/constants";
 import { sanitizeURL } from "../utilities/urlBuilderUtil";
 import { webExtensionTelemetryEventNames } from "../../../common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents";
 import { IPortalWebExtensionInitQueryParametersTelemetryData, IWebExtensionAPITelemetryData, IWebExtensionExceptionTelemetryData, IWebExtensionInitPathTelemetryData, IWebExtensionPerfTelemetryData } from "../../../common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryInterface";
-import { isNullOrUndefined } from '../utilities/commonUtil';
+import { getEnvironmentIdFromUrl, isNullOrUndefined } from '../utilities/commonUtil';
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
 export class WebExtensionTelemetry {
@@ -56,7 +56,7 @@ export class WebExtensionTelemetry {
                 siteVisibility: queryParamsMap.get(queryParameters.SITE_VISIBILITY),
                 region: queryParamsMap.get(queryParameters.REGION),
                 geo: queryParamsMap.get(queryParameters.GEO),
-                envId: queryParamsMap.get(queryParameters.ENV_ID),
+                envId: getEnvironmentIdFromUrl(),
                 referrerSource: queryParamsMap.get(queryParameters.REFERRER_SOURCE),
                 sku: queryParamsMap.get(queryParameters.SKU)
             }

--- a/src/web/client/test/integration/webExtensionTelemetry.test.ts
+++ b/src/web/client/test/integration/webExtensionTelemetry.test.ts
@@ -9,6 +9,7 @@ import { sanitizeURL } from "../../utilities/urlBuilderUtil";
 import { webExtensionTelemetryEventNames } from "../../../../common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents";
 import { WebExtensionTelemetry } from "../../telemetry/webExtensionTelemetry";
 import { vscodeExtAppInsightsResourceProvider } from "../../../../common/telemetry-generated/telemetryConfiguration";
+import * as commonUtil from "../../utilities/commonUtil";
 import { expect } from "chai";
 
 describe("webExtensionTelemetry", () => {
@@ -128,6 +129,10 @@ describe("webExtensionTelemetry", () => {
             sku: queryParamsMap.get(queryParameters.SKU),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any;
+
+        stub(commonUtil, "getEnvironmentIdFromUrl").returns(
+            "c4dc3686-1e6b-e428-b886-16cd0b9f4918"
+        );
 
         //Action
         webExtensionTelemetry.sendExtensionInitQueryParametersTelemetry(

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -219,7 +219,7 @@ export function getWorkSpaceName(websiteId: string): string {
 
 // ENV_ID is the last part of the parameter value sent in the vscode URL from studio
 export function getEnvironmentIdFromUrl() {
-    return (WebExtensionContext.urlParametersMap.get(queryParameters.ENV_ID) as string).split("/")?.pop() as string;
+    return (WebExtensionContext.urlParametersMap.get(queryParameters.ENV_ID))?.toString().split("/")?.pop() as string;
 }
 
 export function getBackToStudioURL() {

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -225,7 +225,7 @@ export function getEnvironmentIdFromUrl() {
 export function getBackToStudioURL() {
     const region = WebExtensionContext.urlParametersMap.get(queryParameters.REGION) as string;
 
-    if (isStringUndefinedOrEmpty(WebExtensionContext.urlParametersMap.get(queryParameters.ENV_ID)) ||
+    if (isStringUndefinedOrEmpty(getEnvironmentIdFromUrl()) ||
         isStringUndefinedOrEmpty(WebExtensionContext.urlParametersMap.get(queryParameters.REGION)) ||
         isStringUndefinedOrEmpty(WebExtensionContext.urlParametersMap.get(queryParameters.WEBSITE_ID))) {
         return undefined;
@@ -307,7 +307,7 @@ export function getRangeForMultilineMatch(text: string, pattern: string, index: 
 }
 
 export async function validateWebsitePreviewURL(): Promise<boolean> {
-    const envId = WebExtensionContext.urlParametersMap?.get(queryParameters.ENV_ID);
+    const envId = getEnvironmentIdFromUrl();
     const serviceEndpointStamp = WebExtensionContext.serviceEndpointCategory;
     const websitePreviewId = WebExtensionContext.urlParametersMap?.get(queryParameters.PORTAL_ID);
 


### PR DESCRIPTION
This pull request includes updates to the `WebExtensionContext` class to support new organizational and environment identifiers, as well as some refactoring and minor version updates. The most important changes include adding new properties for `organizationId` and `environmentId`, updating the `gulpfile.mjs` with a new CLI version, and refactoring telemetry logging.

### Enhancements to `WebExtensionContext`:

* Added `organizationId` and `environmentId` properties to the `IWebExtensionContext` interface and the `WebExtensionContext` class. (`src/web/client/WebExtensionContext.ts`) [[1]](diffhunk://#diff-e1e4b1cfb30bca61f70c080e4150842da2a4f1837346604bc23ac58a820ad1caR76-R77) [[2]](diffhunk://#diff-e1e4b1cfb30bca61f70c080e4150842da2a4f1837346604bc23ac58a820ad1caR116-R117) [[3]](diffhunk://#diff-e1e4b1cfb30bca61f70c080e4150842da2a4f1837346604bc23ac58a820ad1caR226-R237) [[4]](diffhunk://#diff-e1e4b1cfb30bca61f70c080e4150842da2a4f1837346604bc23ac58a820ad1caR309-R310) [[5]](diffhunk://#diff-e1e4b1cfb30bca61f70c080e4150842da2a4f1837346604bc23ac58a820ad1caR364-R367)
* Updated the initialization logic to set `organizationId` and `environmentId` from query parameters and utility functions. (`src/web/client/WebExtensionContext.ts`)

### Refactoring:

* Removed the `logOneDSLogger` function and replaced direct calls to it with updated telemetry instantiation. (`src/web/client/extension.ts`) [[1]](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360L118-R121) [[2]](diffhunk://#diff-1429bea43439e067ae9056ff3f9f71203533f7d3ca168f0d5469aa1b9a6e0360L684-L711)
* Updated the `getEnvironmentIdFromUrl` function to handle potential undefined values more gracefully. (`src/web/client/utilities/commonUtil.ts`) [[1]](diffhunk://#diff-0571fa597154eb22907e2fbbd10adc9ccc04cba979a11f3c571f94a54abcf179L222-R228) [[2]](diffhunk://#diff-0571fa597154eb22907e2fbbd10adc9ccc04cba979a11f3c571f94a54abcf179L310-R310)

### Telemetry Updates:

* Updated telemetry data collection to use the new `getEnvironmentIdFromUrl` function. (`src/web/client/telemetry/webExtensionTelemetry.ts`)
* Added a stub for `getEnvironmentIdFromUrl` in the telemetry integration tests. (`src/web/client/test/integration/webExtensionTelemetry.test.ts`)

### Version Update:

* Updated the CLI version from `1.34.4` to `1.35.1` in the `gulpfile.mjs`. (`gulpfile.mjs`)

These changes enhance the functionality and maintainability of the `WebExtensionContext` class and improve the robustness of telemetry logging.