### PR TITLE
Refactor npm command in GeneratorAcquisition to support nodeJs Security Update

### DIFF
--- a/src/client/lib/GeneratorAcquisition.ts
+++ b/src/client/lib/GeneratorAcquisition.ts
@@ -69,7 +69,7 @@ export class GeneratorAcquisition implements IDisposable {
     }
 
     private npm(args: string[]) {
-        return spawnSync(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', args, { cwd: this._ppagesGlobalPath });
+        return spawnSync(this.npmCommand, args, { cwd: this._ppagesGlobalPath, shell: true });
     }
 
     public ensureInstalled(): string | null {
@@ -141,4 +141,3 @@ export class GeneratorAcquisition implements IDisposable {
         }
     }
 }
-


### PR DESCRIPTION
https://github.com/microsoft/powerplatform-vscode/issues/1018

The error was caused by a security update in Node.js.

From that blog:

_It is important to note that there has been a breaking change for Windows users who utilize child_process.spawn and child_process.spawnSync. Node.js will now error with EINVAL if a .bat or .cmd file is passed to child_process.spawn and child_process.spawnSync without the shell option set. If the input to spawn/spawnSync is sanitized, users can now pass { shell: true } as an option to prevent the occurrence of EINVALs errors._