### PR TITLE
Refactor PowerPagesChatParticipant and add CommandRegistry

### DIFF
--- a/src/common/chat-participants/CommandRegistry.ts
+++ b/src/common/chat-participants/CommandRegistry.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+
+export interface Command {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    execute(request: any, stream: vscode.ChatResponseStream): Promise<any>;
+}
+
+export class CommandRegistry {
+    private commands: { [key: string]: Command } = {};
+
+    register(commandName: string, command: Command) {
+        this.commands[commandName] = command;
+    }
+
+    get(commandName: string): Command {
+        return this.commands[commandName];
+    }
+}


### PR DESCRIPTION
This pull request introduces a new command registry system to handle command executions within the chat participants module. The key changes include the creation of the `CommandRegistry` class, its integration into the `PowerPagesChatParticipant` class, and the implementation of command execution logic.

### Command Registry System:

* [`src/common/chat-participants/CommandRegistry.ts`](diffhunk://#diff-3cdf8a2bd8d5fc3ebb86d65b45f3fb036d8cb83f0628239dd879f99d7c7a202bR1-R23): Added a new `CommandRegistry` class to manage command registrations and retrievals. This includes an interface `Command` for defining command execution.

### Integration with PowerPagesChatParticipant:

* [`src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts`](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29R25-R29): Imported and initialized the `CommandRegistry` class. Registered commands and integrated the command execution logic within the `PowerPagesChatParticipant` class. [[1]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29R25-R29) [[2]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L157-R174)

### Code Cleanup:

* [`src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts`](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L220): Removed redundant return statement in the `PowerPagesChatParticipant` class.