### PR TITLE
Corrected scope of PPAPI access token for preprod env

### DIFF
--- a/src/common/services/AuthenticationProvider.ts
+++ b/src/common/services/AuthenticationProvider.ts
@@ -23,7 +23,7 @@ import {
     VSCODE_EXTENSION_PPAPI_WEBSITES_AUTHENTICATION_FAILED
 } from "./TelemetryConstants";
 import { ERROR_CONSTANTS } from "../ErrorConstants";
-import { BAP_SERVICE_SCOPE_DEFAULT, INTELLIGENCE_SCOPE_DEFAULT, PPAPI_WEBSITES_SERVICE_SCOPE_DEFAULT, PROVIDER_ID, SCOPE_OPTION_CONTACTS_READ, SCOPE_OPTION_DEFAULT, SCOPE_OPTION_OFFLINE_ACCESS, SCOPE_OPTION_USERS_READ_BASIC_ALL } from "./Constants";
+import { BAP_SERVICE_SCOPE_DEFAULT, INTELLIGENCE_SCOPE_DEFAULT, PPAPI_PREPROD_WEBSITES_SERVICE_SCOPE_DEFAULT, PPAPI_WEBSITES_SERVICE_SCOPE_DEFAULT, PROVIDER_ID, SCOPE_OPTION_CONTACTS_READ, SCOPE_OPTION_DEFAULT, SCOPE_OPTION_OFFLINE_ACCESS, SCOPE_OPTION_USERS_READ_BASIC_ALL, ServiceEndpointCategory } from "./Constants";
 import jwt_decode from 'jwt-decode';
 import { showErrorDialog } from "../utilities/errorHandlerUtil";
 
@@ -296,20 +296,22 @@ export function getOIDFromToken(token: string, telemetry: ITelemetry) {
 
 export async function powerPlatformAPIAuthentication(
     telemetry: ITelemetry,
+    serviceEndpointStamp: ServiceEndpointCategory,
     firstTimeAuth = false
 ): Promise<string> {
     let accessToken = "";
+    const PPAPI_WEBSITES_ENDPOINT = [ServiceEndpointCategory.TEST, ServiceEndpointCategory.PREPROD].includes(serviceEndpointStamp) ? PPAPI_PREPROD_WEBSITES_SERVICE_SCOPE_DEFAULT : PPAPI_WEBSITES_SERVICE_SCOPE_DEFAULT;
     try {
         let session = await vscode.authentication.getSession(
             PROVIDER_ID,
-            [PPAPI_WEBSITES_SERVICE_SCOPE_DEFAULT],
+            [PPAPI_WEBSITES_ENDPOINT],
             { silent: true }
         );
 
         if (!session) {
             session = await vscode.authentication.getSession(
                 PROVIDER_ID,
-                [PPAPI_WEBSITES_SERVICE_SCOPE_DEFAULT],
+                [PPAPI_WEBSITES_ENDPOINT],
                 { createIfNone: true }
             );
         }

--- a/src/common/services/Constants.ts
+++ b/src/common/services/Constants.ts
@@ -21,6 +21,7 @@ export const BAP_SERVICE_COPILOT_CROSS_GEO_FLAG_RELATIVE_URL = `scopes/admin/env
 // PPAPI constants
 export const PPAPI_WEBSITES_API_VERSION = '2022-03-01-preview';
 export const PPAPI_WEBSITES_SERVICE_SCOPE_DEFAULT = "https://api.powerplatform.com/.default";
+export const PPAPI_PREPROD_WEBSITES_SERVICE_SCOPE_DEFAULT = "https://api.preprod.powerplatform.com/.default";
 export const PPAPI_WEBSITES_ENDPOINT = `{rootURL}/powerpages/environments/{environmentId}/websites`;
 
 export enum ServiceEndpointCategory {

--- a/src/common/services/PPAPIService.ts
+++ b/src/common/services/PPAPIService.ts
@@ -14,7 +14,7 @@ export class PPAPIService {
     public static async getWebsiteDetailsById(serviceEndpointStamp: ServiceEndpointCategory, environmentId: string, websitePreviewId: string, telemetry: ITelemetry): Promise<IWebsiteDetails | null> { // websitePreviewId aka portalId
 
         try {
-            const accessToken = await powerPlatformAPIAuthentication(telemetry, true);
+            const accessToken = await powerPlatformAPIAuthentication(telemetry, serviceEndpointStamp, true);
             const response = await fetch(await PPAPIService.getPPAPIServiceEndpoint(serviceEndpointStamp, telemetry, environmentId, websitePreviewId), {
                 method: 'GET',
                 headers: getCommonHeaders(accessToken)


### PR DESCRIPTION
Bug: https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4457220

Access token retrieval for the PPAPI service was incorrect in the pre-production environment. To resolve this, I added the correct endpoint for pre-production, ensuring the right token is fetched.

Testing details & Screenshot added in bug