### PR TITLE
Bump CLI version from 1.35.1 to 1.37.4

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -355,7 +355,7 @@ async function snapshot() {
     }
 }
 
-const cliVersion = '1.35.1';
+const cliVersion = '1.37.4';
 
 const recompile = gulp.series(
     clean,


### PR DESCRIPTION
This pull request includes a version update to the `gulpfile.mjs` file. The `cliVersion` constant has been updated to reflect the latest version.

* [`gulpfile.mjs`](diffhunk://#diff-903dd1850ba0ff2ab89df00417e93e86fb7115642c6c876d75ecca7f97c940b0L358-R358): Updated `cliVersion` from '1.35.1' to '1.37.4' to ensure compatibility with the latest CLI features and fixes.

![image](https://github.com/user-attachments/assets/80c5fe26-06be-459d-8707-356bb85a76ec)
