### PR TITLE
Remove unused command from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,10 +192,6 @@
         "when": "never"
       },
       {
-        "command": "extension.createChatView",
-        "title": "Create Chat View"
-      },
-      {
         "command": "pacCLI.openDocumentation",
         "category": "Power Platform CLI",
         "title": "%pacCLI.openDocumentation.title%"


### PR DESCRIPTION
Removing the command `extension.createChatView` from package.json as it is registered but there is no handler associated with it.