### PR TITLE
Fix error type for concurrency handler

### DIFF
--- a/src/web/client/dal/concurrencyHandler.ts
+++ b/src/web/client/dal/concurrencyHandler.ts
@@ -26,7 +26,7 @@ export class ConcurrencyHandler {
                     this.handleRequest.name,
                     this._bulkhead.executionSlots.toString(),
                 );
-                throw new Error(ERROR_CONSTANTS.SUBURI_EMPTY);
+                throw new Error(ERROR_CONSTANTS.BULKHEAD_LIMITS_EXCEEDED);
             } else {
                 throw e;
             }


### PR DESCRIPTION
This PR is correcting the error thrown when the request fails due to `BulkheadRejectedError`. 
The error currently thrown is `SUBURI_EMPTY` which is a typo and should be `BULKHEAD_LIMITS_EXCEEDED`.