### PR TITLE
Add code coverage output folder in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ telemetry-generated
 # tasks copy them to the correct location, but leave the originals where
 # we do not want them checked in
 l10n/package.nls.*.json
+
+# Code Coverage Output
+.nyc_output/


### PR DESCRIPTION
Adding the code coverage output folder `.nyc_ouput` folder in `.gitignore` so that it doesn't show up in `git diff` after running code coverage command.