### PR TITLE
Fix accessibility issue in Pages Copilot pane

### DIFF
--- a/src/common/copilot/PowerPagesCopilot.ts
+++ b/src/common/copilot/PowerPagesCopilot.ts
@@ -505,7 +505,7 @@ export class PowerPagesCopilot implements vscode.WebviewViewProvider {
               <label for="chat-input" class="input-label hide" id="input-label-id"></label>
               <div class="input-container">
               <textarea rows=1 placeholder="${vscode.l10n.t('What do you need help with?')}" id="chat-input" class="input-field"></textarea>
-                <button aria-label="Match Case" id="send-button" class="send-button">
+                <button aria-label="Send" id="send-button" class="send-button">
                   <span>
                     ${sendIconSvg}
                   </span>


### PR DESCRIPTION
Fix accessibility issue in `Send` button in Power Pages Copilot pane. Updated the `aria-label` to `Send` instead of `Match Case`