### PR TITLE
Hide preview site command from palette when feature is disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,8 +183,7 @@
       },
       {
         "command": "powerpages.powerPagesFileExplorer.powerPagesRuntimePreview",
-        "title": "Preview site",
-        "when": "never"
+        "title": "Preview site"
       },
       {
         "command": "powerpages.powerPagesFileExplorer.backToStudio",
@@ -812,6 +811,14 @@
         {
           "command": "microsoft-powerapps-portals.pagetemplate",
           "when": "config.powerPlatform.generatorInstalled"
+        },
+        {
+          "command": "powerpages.powerPagesFileExplorer.powerPagesRuntimePreview",
+          "when": "never"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.preview-site",
+          "when": "microsoft.powerplatform.pages.siteRuntimePreviewEnabled"
         }
       ],
       "view/title": [

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -199,6 +199,8 @@ export async function activate(
     let websiteURL: string | undefined = "";
     const isSiteRuntimePreviewEnabled = PreviewSite.isSiteRuntimePreviewEnabled();
 
+    vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.siteRuntimePreviewEnabled", isSiteRuntimePreviewEnabled);
+
     _context.subscriptions.push(
         orgChangeEvent(async (orgDetails: ActiveOrgOutput) => {
             const orgID = orgDetails.OrgId;


### PR DESCRIPTION
## Context
Currently there are 2 `Preview Site` commands shown in command palette. However, one of them is only functional in vscode.dev and doesn't work when invoked from command palette so it can be hidden. The other command should only be shown when the feature is enabled.

## Changes
1. Removed `powerpages.powerPagesFileExplorer.powerPagesRuntimePreview` from command palette.
2. Added a `when` clause for `microsoft.powerplatform.pages.preview-site` command to only show when the feature is enabled.