### PR TITLE
[PowerPages][vscode.dev] Showing Content Snippets Not Having Language Record

### DIFF
--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -246,11 +246,16 @@ async function createContentFiles(
             schemaEntityKey.LANGUAGE_FIELD
         );
 
+        let languageCode = WebExtensionContext.websiteLanguageCode;
+
         if (languageCodeAttribute && result[languageCodeAttribute] === null) {
-            throw new Error(ERROR_CONSTANTS.LANGUAGE_CODE_ID_VALUE_NULL);
+            if (entityName !== schemaEntityName.CONTENTSNIPPETS) {
+                throw new Error(ERROR_CONSTANTS.LANGUAGE_CODE_ID_VALUE_NULL);
+            } else {
+                languageCode = Constants.DEFAULT_LANGUAGE_CODE; // Handles the case where language code is null for content snippets
+            }
         }
 
-        let languageCode = WebExtensionContext.websiteLanguageCode;
         if (defaultFileInfo?.fileName === undefined &&
             languageCodeAttribute &&
             result[languageCodeAttribute]) {

--- a/src/web/client/schema/portalSchema.ts
+++ b/src/web/client/schema/portalSchema.ts
@@ -123,7 +123,7 @@ export const portal_schema_V1 = {
                 _fetchQueryParameters:
                     "?$filter=adx_contentsnippetid eq {entityId}&$select=adx_name,adx_value,_adx_contentsnippetlanguageid_value",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_adx_websiteid_value eq {websiteId} and _adx_contentsnippetlanguageid_value ne null &$select=adx_name,adx_value,adx_contentsnippetid,_adx_contentsnippetlanguageid_value&$count=true",
+                    "?$filter=_adx_websiteid_value eq {websiteId} &$select=adx_name,adx_value,adx_contentsnippetid,_adx_contentsnippetlanguageid_value&$count=true",
                 _attributes: "adx_value",
                 _attributesExtension: new Map([["adx_value", "html"]]),
             },
@@ -334,7 +334,7 @@ export const portal_schema_V2 = {
                 _fetchQueryParameters:
                     "?$filter=powerpagecomponentid eq {entityId}&$select=name,content",
                 _multiFileFetchQueryParameters:
-                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 7 and _powerpagesitelanguageid_value ne null &$select=name,content,_powerpagesitelanguageid_value&$count=true",
+                    "?$filter=_powerpagesiteid_value eq {websiteId} and powerpagecomponenttype eq 7 &$select=name,content,_powerpagesitelanguageid_value&$count=true",
                 _attributes: "content.value",
                 _attributesExtension: new Map([["content.value", "html"]]),
             },

--- a/src/web/client/utilities/commonUtil.ts
+++ b/src/web/client/utilities/commonUtil.ts
@@ -24,6 +24,7 @@ import { doesFileExist, getFileAttributePath, getFileEntityName, updateEntityCol
 import { isWebFileV2 } from "./schemaHelperUtil";
 import { ServiceEndpointCategory } from "../../../common/services/Constants";
 import { PPAPIService } from "../../../common/services/PPAPIService";
+import * as Constants from "../common/constants";
 
 // decodes file content to UTF-8
 export function convertContentToUint8Array(content: string, isBase64Encoded: boolean): Uint8Array {
@@ -42,15 +43,18 @@ export function GetFileNameWithExtension(
     languageCode: string,
     extension: string
 ) {
-    fileName = isLanguageCodeNeededInFileName(entity) ? `${fileName}.${languageCode}` : fileName;
+    if (entity === schemaEntityName.CONTENTSNIPPETS) {
+        fileName = languageCode && languageCode != Constants.DEFAULT_LANGUAGE_CODE ? `${fileName}.${languageCode}` : fileName; // Handle the case where language is not provided for content snippets
+    } else {
+        fileName = isLanguageCodeNeededInFileName(entity) ? `${fileName}.${languageCode}` : fileName;
+    }
     fileName = isExtensionNeededInFileName(entity) ? `${fileName}.${extension}` : fileName;
 
     return getSanitizedFileName(fileName);
 }
 
 export function isLanguageCodeNeededInFileName(entity: string) {
-    return entity === schemaEntityName.WEBPAGES ||
-        entity === schemaEntityName.CONTENTSNIPPETS;
+    return entity === schemaEntityName.WEBPAGES ||entity === schemaEntityName.CONTENTSNIPPETS;
 }
 
 export function isExtensionNeededInFileName(entity: string) {


### PR DESCRIPTION
This pull request includes changes to handle cases where language codes are null for content snippets and updates to query parameters in portal schemas. The main changes involve error handling, default language code assignment, and query parameter adjustments.

Error handling and default language code assignment:

* [`src/web/client/dal/remoteFetchProvider.ts`](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feR249-L253): Modified the `createContentFiles` function to handle cases where the language code is null for content snippets by assigning a default language code.
* [`src/web/client/utilities/commonUtil.ts`](diffhunk://#diff-0571fa597154eb22907e2fbbd10adc9ccc04cba979a11f3c571f94a54abcf179R46-R57): Updated the `GetFileNameWithExtension` function to handle cases where the language code is not provided for content snippets by using a default language code.

Query parameter adjustments:

* [`src/web/client/schema/portalSchema.ts`](diffhunk://#diff-d2f0f5db4d90218c70bc6005e26d85bae0d8997de232d1f2fd62d35a4a22863bL126-R126): Updated the `_multiFileFetchQueryParameters` in `portal_schema_V1` to remove the condition checking for non-null language ID values.
* [`src/web/client/schema/portalSchema.ts`](diffhunk://#diff-d2f0f5db4d90218c70bc6005e26d85bae0d8997de232d1f2fd62d35a4a22863bL337-R337): Updated the `_multiFileFetchQueryParameters` in `portal_schema_V2` to remove the condition checking for non-null language ID values.

Additional import:

* [`src/web/client/utilities/commonUtil.ts`](diffhunk://#diff-0571fa597154eb22907e2fbbd10adc9ccc04cba979a11f3c571f94a54abcf179R27): Added an import for `Constants` to use the default language code.

![image](https://github.com/user-attachments/assets/53a21038-8408-4a77-bf64-316548b062e2)
