### PR TITLE
Enhance accessibility by adding ARIA attributes and making thinking message focusable

### DIFF
--- a/src/common/copilot/assets/scripts/copilot.js
+++ b/src/common/copilot/assets/scripts/copilot.js
@@ -317,6 +317,9 @@
                 const thinking = document.createElement("div");
                 thinking.classList.add("thinking");
                 thinking.innerText = thinkingMessage;
+                thinking.setAttribute("tabindex", "0"); // Make the element focusable
+                thinking.setAttribute("role", "status"); // Add ARIA role
+                thinking.setAttribute("aria-live", "polite"); // Ensure screen readers announce updates
 
                 messageElement.appendChild(thinking);
                 chatMessages.scrollTop = chatMessages.scrollHeight - chatMessages.clientHeight;


### PR DESCRIPTION
This pull request includes an accessibility improvement to the `src/common/copilot/assets/scripts/copilot.js` file. The change ensures that the "thinking" element is focusable and properly announced by screen readers.

Accessibility improvements:

* [`src/common/copilot/assets/scripts/copilot.js`](diffhunk://#diff-2b752bc47b9599a39d91a02dc72fc16cc92edad87ef510294403fdc46306e07dR320-R322): Added `tabindex`, `role`, and `aria-live` attributes to the "thinking" element to improve focusability and screen reader support.