### PR TITLE
Web Extension: Fix file opening for media files

### DIFF
--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -619,7 +619,7 @@ export class PortalsFS implements vscode.FileSystemProvider {
             );
 
             // Fire and forget
-            vscode.window.showTextDocument(WebExtensionContext.defaultFileUri, { preview: false, preserveFocus: true, viewColumn: vscode.ViewColumn.Active });
+            vscode.commands.executeCommand('vscode.open', WebExtensionContext.defaultFileUri, { preview: false, preserveFocus: true, viewColumn: vscode.ViewColumn.Active });
 
             WebExtensionContext.telemetry.sendInfoTelemetry(
                 webExtensionTelemetryEventNames.WEB_EXTENSION_VSCODE_START_COMMAND,


### PR DESCRIPTION
Using `vscode.open` API to open the default file instead of `window.showTextDocument` because `showTextDocument` doesn't open binary files to it was failing to open non-text files.