### PR TITLE
Bump CLI version from 1.37.4 to 1.39.3

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -346,7 +346,7 @@ async function snapshot() {
     }
 }
 
-const cliVersion = '1.37.4';
+const cliVersion = '1.39.3';
 
 const recompile = gulp.series(
     clean,


### PR DESCRIPTION
This pull request includes a small change to the gulpfile.mjs file. The change updates the cliVersion constant to the latest version.

![image](https://github.com/user-attachments/assets/03d54b83-65bc-4b57-9dfe-37376defea65)
