### PR TITLE
[A11y] Fix Screen Reader Issue for Status Messages

### DIFF
--- a/src/common/copilot/assets/scripts/copilot.js
+++ b/src/common/copilot/assets/scripts/copilot.js
@@ -317,13 +317,16 @@
             updateThinking: function (thinkingMessage) {
                 const thinking = document.createElement("div");
                 thinking.classList.add("thinking");
-                thinking.innerText = thinkingMessage;
                 thinking.setAttribute("tabindex", "0"); // Make the element focusable
                 thinking.setAttribute("role", "status"); // Add ARIA role
-                thinking.setAttribute("aria-live", "polite"); // Ensure screen readers announce updates
-
                 messageElement.appendChild(thinking);
                 chatMessages.scrollTop = chatMessages.scrollHeight - chatMessages.clientHeight;
+
+                //This is necessary because
+// screen readers may not immediately detect content updates if they occur synchronously
+                setTimeout(() => {
+                    thinking.innerText = thinkingMessage;
+                }, 0);
             },
             updateResponse: function (apiResponse) {
                 const thinkingDiv = messageElement.querySelector(".thinking");


### PR DESCRIPTION
This PR contains changes that improves the accessibility of the extension:

copilot.js: Right now, we are creating the status message div ('thinking') and adding it to the DOM. The screen reader won't read the status since the DOM node is being initialized with the message during the time of creation. Only future updates to the content will be read. Therefore, we are adding an empty div first and then setting the content in the next event loop so that the screen reader detects the change and reads out loud.

**Note**: Tested on web and desktop versions