### PR TITLE
Site Preview: Initialize after ECS fetch

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -48,6 +48,7 @@ import { getECSOrgLocationValue, getWorkspaceFolders } from "../common/utilities
 import { CliAcquisitionContext } from "./lib/CliAcquisitionContext";
 import { PreviewSite, SITE_PREVIEW_COMMAND_ID } from "./power-pages/preview-site/PreviewSite";
 import { ActionsHubTreeDataProvider } from "./power-pages/actions-hub/ActionsHubTreeDataProvider";
+import { IArtemisServiceResponse } from "../common/services/Interfaces";
 
 let client: LanguageClient;
 let _context: vscode.ExtensionContext;
@@ -193,10 +194,6 @@ export async function activate(
 
     const workspaceFolders = getWorkspaceFolders();
 
-    const isSiteRuntimePreviewEnabled = PreviewSite.isSiteRuntimePreviewEnabled();
-
-    vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.siteRuntimePreviewEnabled", isSiteRuntimePreviewEnabled);
-
     _context.subscriptions.push(
         orgChangeEvent(async (orgDetails: ActiveOrgOutput) => {
             const orgID = orgDetails.OrgId;
@@ -252,10 +249,7 @@ export async function activate(
 
             }
 
-            if (artemisResponse !== null && isSiteRuntimePreviewEnabled) {
-                await PreviewSite.loadSiteUrl(workspaceFolders, artemisResponse?.stamp, orgDetails.EnvironmentId, _telemetry);
-            }
-
+            await initializeSiteRuntimePreview(artemisResponse, workspaceFolders, orgDetails, pacTerminal);
         })
     );
 
@@ -276,22 +270,6 @@ export async function activate(
         vscode.commands.executeCommand('setContext', 'powerpages.websiteYmlExists', false);
     }
 
-    _telemetry.sendTelemetryEvent("EnableSiteRuntimePreview", {
-        isEnabled: isSiteRuntimePreviewEnabled.toString(),
-        websiteURL: PreviewSite.getSiteUrl() || "undefined"
-    });
-    oneDSLoggerWrapper.getLogger().traceInfo("EnableSiteRuntimePreview", {
-        isEnabled: isSiteRuntimePreviewEnabled.toString(),
-        websiteURL: PreviewSite.getSiteUrl() || "undefined"
-    });
-
-    _context.subscriptions.push(
-        vscode.commands.registerCommand(
-            SITE_PREVIEW_COMMAND_ID,
-            async () => await PreviewSite.handlePreviewRequest(isSiteRuntimePreviewEnabled, _telemetry, pacTerminal)
-        )
-    );
-
     const workspaceFolderWatcher = vscode.workspace.onDidChangeWorkspaceFolders(handleWorkspaceFolderChange);
     _context.subscriptions.push(workspaceFolderWatcher);
 
@@ -303,6 +281,32 @@ export async function activate(
 
     _telemetry.sendTelemetryEvent("activated");
     oneDSLoggerWrapper.getLogger().traceInfo("activated");
+}
+
+async function initializeSiteRuntimePreview(
+    artemisResponse: IArtemisServiceResponse | null,
+    workspaceFolders: WorkspaceFolder[],
+    orgDetails: ActiveOrgOutput,
+    pacTerminal: PacTerminal) {
+
+    const isSiteRuntimePreviewEnabled = PreviewSite.isSiteRuntimePreviewEnabled();
+
+    oneDSLoggerWrapper.getLogger().traceInfo("EnableSiteRuntimePreview", {
+        isEnabled: isSiteRuntimePreviewEnabled.toString(),
+        websiteURL: PreviewSite.getSiteUrl() || "undefined"
+    });
+
+    if (artemisResponse !== null && isSiteRuntimePreviewEnabled) {
+        _context.subscriptions.push(
+            vscode.commands.registerCommand(
+                SITE_PREVIEW_COMMAND_ID,
+                async () => await PreviewSite.handlePreviewRequest(_telemetry, pacTerminal)
+            )
+        );
+        
+        await vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.siteRuntimePreviewEnabled", true);
+        await PreviewSite.loadSiteUrl(workspaceFolders, artemisResponse?.stamp, orgDetails.EnvironmentId, _telemetry);
+    }
 }
 
 function initializeActionsHub(context: vscode.ExtensionContext) {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -303,9 +303,9 @@ async function initializeSiteRuntimePreview(
                 async () => await PreviewSite.handlePreviewRequest(_telemetry, pacTerminal)
             )
         );
-        
-        await vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.siteRuntimePreviewEnabled", true);
+
         await PreviewSite.loadSiteUrl(workspaceFolders, artemisResponse?.stamp, orgDetails.EnvironmentId, _telemetry);
+        await vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.siteRuntimePreviewEnabled", true);
     }
 }
 

--- a/src/client/power-pages/preview-site/PreviewSite.ts
+++ b/src/client/power-pages/preview-site/PreviewSite.ts
@@ -102,7 +102,6 @@ export class PreviewSite {
     }
 
     static async handlePreviewRequest(
-        isSiteRuntimePreviewEnabled: boolean,
         telemetry: ITelemetry,
         pacTerminal: PacTerminal) {
 
@@ -113,7 +112,7 @@ export class PreviewSite {
             commandId: SITE_PREVIEW_COMMAND_ID
         });
 
-        if (!isSiteRuntimePreviewEnabled) {
+        if (!PreviewSite.isSiteRuntimePreviewEnabled()) {
             telemetry.sendTelemetryErrorEvent(VSCODE_EXTENSION_SITE_PREVIEW_ERROR, { error: Messages.SITE_PREVIEW_FEATURE_NOT_ENABLED });
             oneDSLoggerWrapper.getLogger().traceInfo(VSCODE_EXTENSION_SITE_PREVIEW_ERROR, { error: Messages.SITE_PREVIEW_FEATURE_NOT_ENABLED });
             await vscode.window.showInformationMessage(Messages.SITE_PREVIEW_FEATURE_NOT_ENABLED);


### PR DESCRIPTION
This pull request includes several changes to the `src/client/extension.ts` and `src/client/power-pages/preview-site/PreviewSite.ts` files to refactor and improve the functionality related to site runtime preview and initialization.

### Refactoring and Improvements:

* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaR51): Added `IArtemisServiceResponse` import to the file.
* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL196-L199): Removed direct calls to `PreviewSite.isSiteRuntimePreviewEnabled` and `PreviewSite.loadSiteUrl`, and instead created a new function `initializeSiteRuntimePreview` to handle these operations. [[1]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL196-L199) [[2]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL255-R252) [[3]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL279-L305)
* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL279-L305): Added workspace folder watcher and debugger activation logic, and moved telemetry event logging to the end of the activation function.
* [`src/client/power-pages/preview-site/PreviewSite.ts`](diffhunk://#diff-30c5d95c2f7cf50fb017471e573cf9092cb8081368a289e30cf7dcfd03741684L105): Removed `isSiteRuntimePreviewEnabled` parameter from `handlePreviewRequest` method and replaced it with a direct call to `PreviewSite.isSiteRuntimePreviewEnabled`. [[1]](diffhunk://#diff-30c5d95c2f7cf50fb017471e573cf9092cb8081368a289e30cf7dcfd03741684L105) [[2]](diffhunk://#diff-30c5d95c2f7cf50fb017471e573cf9092cb8081368a289e30cf7dcfd03741684L116-R115)