### PR TITLE
Actions Hub: Add toggle based on ECS

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -254,7 +254,7 @@ export async function activate(
 
             await PreviewSite.initialize(artemisResponse, workspaceFolders, orgDetails, pacTerminal, context, _telemetry);
 
-            ActionsHub.initialize(context);
+            ActionsHub.initialize(context, pacTerminal);
         })
     );
 

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -47,7 +47,7 @@ import { ECSFeaturesClient } from "../common/ecs-features/ecsFeatureClient";
 import { getECSOrgLocationValue, getWorkspaceFolders } from "../common/utilities/Utils";
 import { CliAcquisitionContext } from "./lib/CliAcquisitionContext";
 import { PreviewSite, SITE_PREVIEW_COMMAND_ID } from "./power-pages/preview-site/PreviewSite";
-import { ActionsHubTreeDataProvider } from "./power-pages/actions-hub/ActionsHubTreeDataProvider";
+import { ActionsHub } from "./power-pages/actions-hub/ActionsHub";
 
 let client: LanguageClient;
 let _context: vscode.ExtensionContext;
@@ -295,7 +295,7 @@ export async function activate(
     const workspaceFolderWatcher = vscode.workspace.onDidChangeWorkspaceFolders(handleWorkspaceFolderChange);
     _context.subscriptions.push(workspaceFolderWatcher);
 
-    initializeActionsHub(context);
+    ActionsHub.initialize(context);
 
     if (shouldEnableDebugger()) {
         activateDebugger(context, _telemetry);
@@ -303,17 +303,6 @@ export async function activate(
 
     _telemetry.sendTelemetryEvent("activated");
     oneDSLoggerWrapper.getLogger().traceInfo("activated");
-}
-
-function initializeActionsHub(context: vscode.ExtensionContext) {
-    //TODO: Initialize this based on ECS feature flag
-    const actionsHubEnabled = false;
-
-    vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.actionsHubEnabled", actionsHubEnabled);
-
-    if (actionsHubEnabled) {
-        ActionsHubTreeDataProvider.initialize(context, _telemetry);
-    }
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -249,7 +249,9 @@ export async function activate(
 
             }
 
-            await initializeSiteRuntimePreview(artemisResponse, workspaceFolders, orgDetails, pacTerminal);
+            await PreviewSite.initialize(artemisResponse, workspaceFolders, orgDetails, pacTerminal, context, _telemetry);
+
+            ActionsHub.initialize(context);
         })
     );
 
@@ -273,40 +275,12 @@ export async function activate(
     const workspaceFolderWatcher = vscode.workspace.onDidChangeWorkspaceFolders(handleWorkspaceFolderChange);
     _context.subscriptions.push(workspaceFolderWatcher);
 
-    ActionsHub.initialize(context);
-
     if (shouldEnableDebugger()) {
         activateDebugger(context, _telemetry);
     }
 
     _telemetry.sendTelemetryEvent("activated");
     oneDSLoggerWrapper.getLogger().traceInfo("activated");
-}
-
-async function initializeSiteRuntimePreview(
-    artemisResponse: IArtemisServiceResponse | null,
-    workspaceFolders: WorkspaceFolder[],
-    orgDetails: ActiveOrgOutput,
-    pacTerminal: PacTerminal) {
-
-    const isSiteRuntimePreviewEnabled = PreviewSite.isSiteRuntimePreviewEnabled();
-
-    oneDSLoggerWrapper.getLogger().traceInfo("EnableSiteRuntimePreview", {
-        isEnabled: isSiteRuntimePreviewEnabled.toString(),
-        websiteURL: PreviewSite.getSiteUrl() || "undefined"
-    });
-
-    if (artemisResponse !== null && isSiteRuntimePreviewEnabled) {
-        _context.subscriptions.push(
-            vscode.commands.registerCommand(
-                SITE_PREVIEW_COMMAND_ID,
-                async () => await PreviewSite.handlePreviewRequest(_telemetry, pacTerminal)
-            )
-        );
-
-        await PreviewSite.loadSiteUrl(workspaceFolders, artemisResponse?.stamp, orgDetails.EnvironmentId, _telemetry);
-        await vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.siteRuntimePreviewEnabled", true);
-    }
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -46,12 +46,8 @@ import { PowerPagesAppName, PowerPagesClientName } from "../common/ecs-features/
 import { ECSFeaturesClient } from "../common/ecs-features/ecsFeatureClient";
 import { getECSOrgLocationValue, getWorkspaceFolders } from "../common/utilities/Utils";
 import { CliAcquisitionContext } from "./lib/CliAcquisitionContext";
-import { PreviewSite, SITE_PREVIEW_COMMAND_ID } from "./power-pages/preview-site/PreviewSite";
+import { PreviewSite } from "./power-pages/preview-site/PreviewSite";
 import { ActionsHub } from "./power-pages/actions-hub/ActionsHub";
-import { authManager } from "./pac/PacAuthManager";
-import { extractAuthInfo } from "./power-pages/commonUtility";
-import { Constants } from "./power-pages/actions-hub/Constants";
-import { IArtemisServiceResponse } from "../common/services/Interfaces";
 
 let client: LanguageClient;
 let _context: vscode.ExtensionContext;

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -250,7 +250,7 @@ export async function activate(
 
             await PreviewSite.initialize(artemisResponse, workspaceFolders, orgDetails, pacTerminal, context, _telemetry);
 
-            ActionsHub.initialize(context, pacTerminal);
+            await ActionsHub.initialize(context, pacTerminal);
         })
     );
 

--- a/src/client/pac/PacAuthManager.ts
+++ b/src/client/pac/PacAuthManager.ts
@@ -27,4 +27,4 @@ class PacAuthManager {
     }
 }
 
-export const authManager = PacAuthManager.getInstance();
+export const pacAuthManager = PacAuthManager.getInstance();

--- a/src/client/power-pages/actions-hub/ActionsHub.ts
+++ b/src/client/power-pages/actions-hub/ActionsHub.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import { ECSFeaturesClient } from "../../../common/ecs-features/ecsFeatureClient";
 import { EnableActionsHub } from "../../../common/ecs-features/ecsFeatureGates";
 import { ActionsHubTreeDataProvider } from "./ActionsHubTreeDataProvider";
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
 export class ActionsHub {
     static isEnabled(): boolean {
@@ -21,6 +22,11 @@ export class ActionsHub {
 
     static initialize(context: vscode.ExtensionContext): void {
         const isActionsHubEnabled = ActionsHub.isEnabled();
+
+        oneDSLoggerWrapper.getLogger().traceInfo("EnableActionsHub", {
+            isEnabled: isActionsHubEnabled.toString()
+        });
+
         vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.actionsHubEnabled", isActionsHubEnabled);
 
         if (!isActionsHubEnabled) {

--- a/src/client/power-pages/actions-hub/ActionsHub.ts
+++ b/src/client/power-pages/actions-hub/ActionsHub.ts
@@ -8,6 +8,7 @@ import { ECSFeaturesClient } from "../../../common/ecs-features/ecsFeatureClient
 import { EnableActionsHub } from "../../../common/ecs-features/ecsFeatureGates";
 import { ActionsHubTreeDataProvider } from "./ActionsHubTreeDataProvider";
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { PacTerminal } from "../../lib/PacTerminal";
 
 export class ActionsHub {
     static isEnabled(): boolean {
@@ -20,7 +21,7 @@ export class ActionsHub {
         return enableActionsHub;
     }
 
-    static initialize(context: vscode.ExtensionContext): void {
+    static initialize(context: vscode.ExtensionContext, pacTerminal: PacTerminal): void {
         const isActionsHubEnabled = ActionsHub.isEnabled();
 
         oneDSLoggerWrapper.getLogger().traceInfo("EnableActionsHub", {
@@ -33,6 +34,6 @@ export class ActionsHub {
             return;
         }
 
-        ActionsHubTreeDataProvider.initialize(context)
+        ActionsHubTreeDataProvider.initialize(context, pacTerminal);
     }
 }

--- a/src/client/power-pages/actions-hub/ActionsHub.ts
+++ b/src/client/power-pages/actions-hub/ActionsHub.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { ECSFeaturesClient } from "../../../common/ecs-features/ecsFeatureClient";
+import { EnableActionsHub } from "../../../common/ecs-features/ecsFeatureGates";
+import { ActionsHubTreeDataProvider } from "./ActionsHubTreeDataProvider";
+
+export class ActionsHub {
+    static isEnabled(): boolean {
+        const enableActionsHub = ECSFeaturesClient.getConfig(EnableActionsHub).enableActionsHub
+
+        if (enableActionsHub === undefined) {
+            return false;
+        }
+
+        return enableActionsHub;
+    }
+
+    static initialize(context: vscode.ExtensionContext): void {
+        const isActionsHubEnabled = ActionsHub.isEnabled();
+        vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.actionsHubEnabled", isActionsHubEnabled);
+
+        if (!isActionsHubEnabled) {
+            return;
+        }
+
+        ActionsHubTreeDataProvider.initialize(context)
+    }
+}

--- a/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
@@ -8,27 +8,24 @@ import { ActionsHubTreeItem } from "./tree-items/ActionsHubTreeItem";
 import { OtherSitesGroupTreeItem } from "./tree-items/OtherSitesGroupTreeItem";
 import { Constants } from "./Constants";
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
-import { PacTerminal } from "../../lib/PacTerminal";
 import { EnvironmentGroupTreeItem } from "./tree-items/EnvironmentGroupTreeItem";
 import { IEnvironmentInfo } from "./models/IEnvironmentInfo";
-import { authManager } from "../../pac/PacAuthManager";
+import { pacAuthManager } from "../../pac/PacAuthManager";
 
 export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<ActionsHubTreeItem> {
     private readonly _disposables: vscode.Disposable[] = [];
     private readonly _context: vscode.ExtensionContext;
-    private readonly _pacTerminal: PacTerminal;
 
-    private constructor(context: vscode.ExtensionContext, pacTerminal: PacTerminal) {
+    private constructor(context: vscode.ExtensionContext) {
         this._disposables.push(
             vscode.window.registerTreeDataProvider("powerpages.actionsHub", this)
         );
 
         this._context = context;
-        this._pacTerminal = pacTerminal;
     }
 
-    public static initialize(context: vscode.ExtensionContext, pacTerminal: PacTerminal): ActionsHubTreeDataProvider {
-        const actionsHubTreeDataProvider = new ActionsHubTreeDataProvider(context, pacTerminal);
+    public static initialize(context: vscode.ExtensionContext): ActionsHubTreeDataProvider {
+        const actionsHubTreeDataProvider = new ActionsHubTreeDataProvider(context);
         oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_INITIALIZED);
 
         return actionsHubTreeDataProvider;
@@ -44,7 +41,7 @@ export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<Actio
 
                 const orgFriendlyName = Constants.Strings.NO_ENVIRONMENTS_FOUND; // Login experience scenario
                 let currentEnvInfo: IEnvironmentInfo = { currentEnvironmentName: orgFriendlyName };
-                const authInfo = authManager.getAuthInfo();
+                const authInfo = pacAuthManager.getAuthInfo();
                 if (authInfo) {
                     currentEnvInfo = { currentEnvironmentName: authInfo.organizationFriendlyName };
                 }

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHub.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHub.test.ts
@@ -6,23 +6,31 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
+import * as CommonUtils from "../../../../power-pages/commonUtility";
 import { ActionsHub } from "../../../../power-pages/actions-hub/ActionsHub";
 import { PacTerminal } from "../../../../lib/PacTerminal";
 import { ECSFeaturesClient } from "../../../../../common/ecs-features/ecsFeatureClient";
 import { oneDSLoggerWrapper } from "../../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 import { ActionsHubTreeDataProvider } from "../../../../power-pages/actions-hub/ActionsHubTreeDataProvider";
+import { SUCCESS } from "../../../../../common/constants";
+import { AUTH_KEYS } from "../../../../../common/OneDSLoggerTelemetry/telemetryConstants";
+import { PacWrapper } from "../../../../pac/PacWrapper";
+import { AuthInfo, PacAuthWhoOutput } from "../../../../pac/PacTypes";
+import { pacAuthManager } from "../../../../pac/PacAuthManager";
 
 describe("ActionsHub", () => {
     let getConfigStub: sinon.SinonStub;
     let executeCommandStub: sinon.SinonStub;
     let traceInfoStub: sinon.SinonStub;
     let fakeContext: vscode.ExtensionContext;
-    let fakePacTerminal: PacTerminal;
+    let fakePacWrapper: sinon.SinonStubbedInstance<PacWrapper>;
+    let fakePacTerminal: sinon.SinonStubbedInstance<PacTerminal>;
 
     beforeEach(() => {
         getConfigStub = sinon.stub(ECSFeaturesClient, "getConfig");
         fakeContext = {} as vscode.ExtensionContext;
-        fakePacTerminal = {} as PacTerminal;
+        fakePacWrapper = sinon.createStubInstance(PacWrapper, { activeAuth: sinon.stub() });
+        fakePacTerminal = sinon.createStubInstance(PacTerminal, { getWrapper: fakePacWrapper });
         executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
         traceInfoStub = sinon.stub();
         sinon.stub(oneDSLoggerWrapper, "getLogger").returns({
@@ -57,18 +65,31 @@ describe("ActionsHub", () => {
 
     describe("initialize", () => {
         describe("when ActionsHub is enabled", () => {
-            it("should set context to true and return early if isEnabled returns true", () => {
+            it("should set context to true and return early if isEnabled returns true", async () => {
                 getConfigStub.returns({ enableActionsHub: true });
-                ActionsHub.initialize(fakeContext, fakePacTerminal);
+                await ActionsHub.initialize(fakeContext, fakePacTerminal);
                 expect(traceInfoStub.calledWith("EnableActionsHub", { isEnabled: "true" })).to.be.true;
                 expect(executeCommandStub.calledWith("setContext", "microsoft.powerplatform.pages.actionsHubEnabled", true)).to.be.true;
             });
 
-            it("should initialize ActionsHubTreeDataProvider", () => {
+            it("should set Auth Info", async () => {
+                getConfigStub.returns({ enableActionsHub: true });
+                const data = { organizationFriendlyName: 'Foo' } as AuthInfo;
+                sinon.stub(CommonUtils, 'extractAuthInfo').returns(data);
+                const pacAuthSetInfoStub = sinon.stub(pacAuthManager, 'setAuthInfo');
+                fakePacWrapper.activeAuth.returns(Promise.resolve({ Status: SUCCESS, Results: [{ Key: AUTH_KEYS.ORGANIZATION_FRIENDLY_NAME, Value: 'Foo' }] }) as Promise<PacAuthWhoOutput>);
+
+                await ActionsHub.initialize(fakeContext, fakePacTerminal);
+                expect(pacAuthSetInfoStub.calledWith(data)).to.be.true;
+            });
+
+            it("should initialize ActionsHubTreeDataProvider", async () => {
                 getConfigStub.returns({ enableActionsHub: true });
                 const actionsHubTreeDataProviderStub = sinon.stub(ActionsHubTreeDataProvider, 'initialize');
-                ActionsHub.initialize(fakeContext, fakePacTerminal);
-                expect(actionsHubTreeDataProviderStub.calledWith(fakeContext, fakePacTerminal)).to.be.true;
+                fakePacWrapper.activeAuth.returns(Promise.resolve({ Status: SUCCESS, Results: [{ Key: AUTH_KEYS.ORGANIZATION_FRIENDLY_NAME, Value: 'Foo' }] }) as Promise<PacAuthWhoOutput>);
+
+                await ActionsHub.initialize(fakeContext, fakePacTerminal);
+                expect(actionsHubTreeDataProviderStub.calledWith(fakeContext)).to.be.true;
             });
         });
 

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHub.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHub.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { ActionsHub } from "../../../../power-pages/actions-hub/ActionsHub";
+import { PacTerminal } from "../../../../lib/PacTerminal";
+import { ECSFeaturesClient } from "../../../../../common/ecs-features/ecsFeatureClient";
+import { oneDSLoggerWrapper } from "../../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { ActionsHubTreeDataProvider } from "../../../../power-pages/actions-hub/ActionsHubTreeDataProvider";
+
+describe("ActionsHub", () => {
+    let getConfigStub: sinon.SinonStub;
+    let executeCommandStub: sinon.SinonStub;
+    let traceInfoStub: sinon.SinonStub;
+    let fakeContext: vscode.ExtensionContext;
+    let fakePacTerminal: PacTerminal;
+
+    beforeEach(() => {
+        getConfigStub = sinon.stub(ECSFeaturesClient, "getConfig");
+        fakeContext = {} as vscode.ExtensionContext;
+        fakePacTerminal = {} as PacTerminal;
+        executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+        traceInfoStub = sinon.stub();
+        sinon.stub(oneDSLoggerWrapper, "getLogger").returns({
+            traceInfo: traceInfoStub,
+            traceWarning: sinon.stub(),
+            traceError: sinon.stub(),
+            featureUsage: sinon.stub()
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe("isEnabled", () => {
+        it("should return false if enableActionsHub is undefined", () => {
+            getConfigStub.returns({ enableActionsHub: undefined });
+            const result = ActionsHub.isEnabled();
+            expect(result).to.be.false;
+        });
+
+        it("should return the actual boolean if enableActionsHub has a value", () => {
+            getConfigStub.returns({ enableActionsHub: true });
+            let result = ActionsHub.isEnabled();
+            expect(result).to.be.true;
+
+            getConfigStub.returns({ enableActionsHub: false });
+            result = ActionsHub.isEnabled();
+            expect(result).to.be.false;
+        });
+    });
+
+    describe("initialize", () => {
+        describe("when ActionsHub is enabled", () => {
+            it("should set context to true and return early if isEnabled returns true", () => {
+                getConfigStub.returns({ enableActionsHub: true });
+                ActionsHub.initialize(fakeContext, fakePacTerminal);
+                expect(traceInfoStub.calledWith("EnableActionsHub", { isEnabled: "true" })).to.be.true;
+                expect(executeCommandStub.calledWith("setContext", "microsoft.powerplatform.pages.actionsHubEnabled", true)).to.be.true;
+            });
+
+            it("should initialize ActionsHubTreeDataProvider", () => {
+                getConfigStub.returns({ enableActionsHub: true });
+                const actionsHubTreeDataProviderStub = sinon.stub(ActionsHubTreeDataProvider, 'initialize');
+                ActionsHub.initialize(fakeContext, fakePacTerminal);
+                expect(actionsHubTreeDataProviderStub.calledWith(fakeContext, fakePacTerminal)).to.be.true;
+            });
+        });
+
+        describe("when ActionsHub is disabled", () => {
+            it("should set context to false and return early if isEnabled returns false", () => {
+                getConfigStub.returns({ enableActionsHub: false });
+                ActionsHub.initialize(fakeContext, fakePacTerminal);
+                expect(traceInfoStub.calledWith("EnableActionsHub", { isEnabled: "false" })).to.be.true;
+                expect(executeCommandStub.calledWith("setContext", "microsoft.powerplatform.pages.actionsHubEnabled", false)).to.be.true;
+            });
+
+            it("should not initialize ActionsHubTreeDataProvider", () => {
+                getConfigStub.returns({ enableActionsHub: false });
+                const actionsHubTreeDataProviderStub = sinon.stub(ActionsHubTreeDataProvider, 'initialize');
+                ActionsHub.initialize(fakeContext, fakePacTerminal);
+                expect(actionsHubTreeDataProviderStub.called).to.be.false;
+            });
+        });
+    });
+});

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -13,105 +13,122 @@ import { Constants } from "../../../../power-pages/actions-hub/Constants";
 import { EnvironmentGroupTreeItem } from "../../../../power-pages/actions-hub/tree-items/EnvironmentGroupTreeItem";
 import { OtherSitesGroupTreeItem } from "../../../../power-pages/actions-hub/tree-items/OtherSitesGroupTreeItem";
 import { ActionsHubTreeItem } from "../../../../power-pages/actions-hub/tree-items/ActionsHubTreeItem";
-import { PacTerminal } from "../../../../lib/PacTerminal";
-import { authManager } from "../../../../pac/PacAuthManager";
+import { pacAuthManager } from "../../../../pac/PacAuthManager";
 
 describe("ActionsHubTreeDataProvider", () => {
     let context: vscode.ExtensionContext;
-    let pacTerminal: PacTerminal;
-    let actionsHubTreeDataProvider: ActionsHubTreeDataProvider;
+    let traceInfoStub: sinon.SinonStub;
+    let traceErrorStub: sinon.SinonStub;
+    let authInfoStub: sinon.SinonStub;
 
     beforeEach(() => {
-        context = {} as vscode.ExtensionContext;
-        pacTerminal = {} as PacTerminal;
-        actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+        context = {
+            extensionUri: vscode.Uri.parse("https://localhost:3000")
+        } as vscode.ExtensionContext;
+        traceInfoStub = sinon.stub();
+        traceErrorStub = sinon.stub();
+        sinon.stub(oneDSLoggerWrapper, "getLogger").returns({
+            traceInfo: traceInfoStub,
+            traceWarning: sinon.stub(),
+            traceError: traceErrorStub,
+            featureUsage: sinon.stub()
+        });
+        authInfoStub = sinon.stub(pacAuthManager, "getAuthInfo");
     });
 
     afterEach(() => {
         sinon.restore();
     });
 
-    it("should initialize and log initialization event", () => {
-        const traceInfoStub = sinon.stub(oneDSLoggerWrapper.getLogger(), "traceInfo");
-        ActionsHubTreeDataProvider.initialize(context, pacTerminal);
-        expect(traceInfoStub.calledWith(Constants.EventNames.ACTIONS_HUB_INITIALIZED)).to.be.true;
-    });
-
-    it("should return the element in getTreeItem", () => {
-        const element = {} as ActionsHubTreeItem;
-        const result = actionsHubTreeDataProvider.getTreeItem(element);
-        expect(result).to.equal(element);
-    });
-
-    it("should return environment and other sites group tree items in getChildren when no element is passed", async () => {
-        const authInfoStub = sinon.stub(authManager, "getAuthInfo").returns({
-            organizationFriendlyName: "TestOrg",
-            userType: "",
-            cloud: "",
-            tenantId: "",
-            tenantCountry: "",
-            user: "",
-            entraIdObjectId: "",
-            puid: "",
-            userCountryRegion: "",
-            tokenExpires: "",
-            authority: "",
-            environmentGeo: "",
-            environmentId: "",
-            environmentType: "",
-            organizationId: "",
-            organizationUniqueName: ""
+    describe('initialize', () => {
+        it("should initialize and log initialization event", () => {
+            ActionsHubTreeDataProvider.initialize(context);
+            expect(traceInfoStub.calledWith(Constants.EventNames.ACTIONS_HUB_INITIALIZED)).to.be.true;
         });
-        const result = await actionsHubTreeDataProvider.getChildren();
-
-        expect(result).to.not.be.null;
-        expect(result).to.not.be.undefined;
-        expect(result).to.have.lengthOf(2);
-        expect(result![0]).to.be.instanceOf(EnvironmentGroupTreeItem);
-        expect(result![1]).to.be.instanceOf(OtherSitesGroupTreeItem);
-
-        authInfoStub.restore();
     });
 
-    it("should return environment group tree item with default name when no auth info is available", async () => {
-        const authInfoStub = sinon.stub(authManager, "getAuthInfo").returns(null);
-        const result = await actionsHubTreeDataProvider.getChildren();
-
-        expect(result).to.not.be.null;
-        expect(result).to.not.be.undefined;
-        expect(result).to.have.lengthOf(2);
-        expect(result![0]).to.be.instanceOf(EnvironmentGroupTreeItem);
-        expect((result![0] as EnvironmentGroupTreeItem).environmentInfo.currentEnvironmentName).to.equal(Constants.Strings.NO_ENVIRONMENTS_FOUND);
-        expect(result![1]).to.be.instanceOf(OtherSitesGroupTreeItem);
-
-        authInfoStub.restore();
+    describe('getTreeItem', () => {
+        it("should return the element in getTreeItem", () => {
+            const element = {} as ActionsHubTreeItem;
+            const result = ActionsHubTreeDataProvider.initialize(context).getTreeItem(element);
+            expect(result).to.equal(element);
+        });
     });
 
-    it("should return null in getChildren when an error occurs", async () => {
-        const authInfoStub = sinon.stub(authManager, "getAuthInfo").throws(new Error("Test Error"));
-        const traceErrorStub = sinon.stub(oneDSLoggerWrapper.getLogger(), "traceError");
+    describe('getChildren', () => {
+        it("should return environment and other sites group tree items in getChildren when no element is passed", async () => {
+            authInfoStub.returns({
+                organizationFriendlyName: "TestOrg",
+                userType: "",
+                cloud: "",
+                tenantId: "",
+                tenantCountry: "",
+                user: "",
+                entraIdObjectId: "",
+                puid: "",
+                userCountryRegion: "",
+                tokenExpires: "",
+                authority: "",
+                environmentGeo: "",
+                environmentId: "",
+                environmentType: "",
+                organizationId: "",
+                organizationUniqueName: ""
+            });
+            const provider = ActionsHubTreeDataProvider.initialize(context);
+            const result = await provider.getChildren();
 
-        const result = await actionsHubTreeDataProvider.getChildren();
-        expect(result).to.be.null;
-        expect(traceErrorStub.calledWith(Constants.EventNames.ACTIONS_HUB_CURRENT_ENV_FETCH_FAILED)).to.be.true;
+            expect(result).to.not.be.null;
+            expect(result).to.not.be.undefined;
+            expect(result).to.have.lengthOf(2);
+            expect(result![0]).to.be.instanceOf(EnvironmentGroupTreeItem);
+            expect(result![1]).to.be.instanceOf(OtherSitesGroupTreeItem);
+        });
 
-        authInfoStub.restore();
-        traceErrorStub.restore();
+        it("should return environment group tree item with default name when no auth info is available", async () => {
+            authInfoStub.returns(null);
+            const provider = ActionsHubTreeDataProvider.initialize(context);
+            const result = await provider.getChildren();
+
+            expect(result).to.not.be.null;
+            expect(result).to.not.be.undefined;
+            expect(result).to.have.lengthOf(2);
+            expect(result![0]).to.be.instanceOf(EnvironmentGroupTreeItem);
+            expect((result![0] as EnvironmentGroupTreeItem).environmentInfo.currentEnvironmentName).to.equal(Constants.Strings.NO_ENVIRONMENTS_FOUND);
+            expect(result![1]).to.be.instanceOf(OtherSitesGroupTreeItem);
+        });
+
+        it("should return null in getChildren when an error occurs", async () => {
+            authInfoStub.throws(new Error("Test Error"));
+
+            const provider = ActionsHubTreeDataProvider.initialize(context);
+            const result = await provider.getChildren();
+
+            expect(result).to.be.null;
+            expect(traceErrorStub.calledWith(Constants.EventNames.ACTIONS_HUB_CURRENT_ENV_FETCH_FAILED)).to.be.true;
+
+            authInfoStub.restore();
+        });
+
+        it("should return an empty array in getChildren when an element is passed", async () => {
+            const element = {} as ActionsHubTreeItem;
+            const provider = ActionsHubTreeDataProvider.initialize(context);
+            const result = await provider.getChildren(element);
+
+            expect(result).to.be.an("array").that.is.empty;
+        });
     });
 
-    it("should return an empty array in getChildren when an element is passed", async () => {
-        const element = {} as ActionsHubTreeItem;
-        const result = await actionsHubTreeDataProvider.getChildren(element);
-        expect(result).to.be.an("array").that.is.empty;
-    });
+    describe('dispose', () => {
+        it("should dispose all disposables", () => {
+            const disposable1 = { dispose: sinon.spy() };
+            const disposable2 = { dispose: sinon.spy() };
+            const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context);
+            actionsHubTreeDataProvider["_disposables"].push(disposable1 as vscode.Disposable, disposable2 as vscode.Disposable);
 
-    it("should dispose all disposables", () => {
-        const disposable1 = { dispose: sinon.spy() };
-        const disposable2 = { dispose: sinon.spy() };
-        actionsHubTreeDataProvider["_disposables"].push(disposable1 as vscode.Disposable, disposable2 as vscode.Disposable);
-
-        actionsHubTreeDataProvider.dispose();
-        expect(disposable1.dispose.calledOnce).to.be.true;
-        expect(disposable2.dispose.calledOnce).to.be.true;
+            actionsHubTreeDataProvider.dispose();
+            expect(disposable1.dispose.calledOnce).to.be.true;
+            expect(disposable2.dispose.calledOnce).to.be.true;
+        });
     });
 });

--- a/src/common/ecs-features/ecsFeatureGates.ts
+++ b/src/common/ecs-features/ecsFeatureGates.ts
@@ -58,3 +58,13 @@ export const {
         enableSiteRuntimePreview: false,
     },
 });
+
+export const {
+    feature: EnableActionsHub
+} = getFeatureConfigs({
+    teamName: PowerPagesClientName,
+    description: 'Enable Actions Hub Panel in VS Code Desktop',
+    fallback: {
+        enableActionsHub: false,
+    },
+});


### PR DESCRIPTION
This pull request includes several important changes to the `src/client` and `src/common` directories to improve the initialization and feature flag handling for the Actions Hub and Site Runtime Preview functionalities.

### Initialization and Feature Flag Handling Improvements:

* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL255-R257): Moved the initialization logic for the Site Runtime Preview and Actions Hub into their respective classes (`PreviewSite` and `ActionsHub`). This change simplifies the `activate` function and ensures that feature flags are checked within their relevant classes. [[1]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL255-R257) [[2]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL279-L280) [[3]](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL289-L334)

* [`src/client/power-pages/actions-hub/ActionsHub.ts`](diffhunk://#diff-39c1145d2f45c77e507dbfd5864081242bc4e75b53e6ae1539cf2a8cf8e84a1bR1-R39): Added a new `ActionsHub` class with methods to check if the Actions Hub feature is enabled and to initialize the Actions Hub if it is enabled. This centralizes the feature flag logic and initialization code.

* [`src/client/power-pages/preview-site/PreviewSite.ts`](diffhunk://#diff-30c5d95c2f7cf50fb017471e573cf9092cb8081368a289e30cf7dcfd03741684R42-R69): Added a new `initialize` method to the `PreviewSite` class to handle the initialization of the Site Runtime Preview, including checking the feature flag and setting up necessary commands and context.

### Code Simplification:

* [`src/client/extension.ts`](diffhunk://#diff-70fa1444b963acf260ba9443bca34c5f078ec0f23bbc3eb5cb5eaa00dc664baaL289-L334): Removed the old `initializeSiteRuntimePreview` and `initializeActionsHub` functions, as their logic has been moved into the `PreviewSite` and `ActionsHub` classes respectively. This reduces redundancy and simplifies the `activate` function.

### Feature Flag Configuration:

* [`src/common/ecs-features/ecsFeatureGates.ts`](diffhunk://#diff-a9a990370940ab92755b288c99c112a8e03eede0ee01bd4f772073d00e4ae16dR61-R70): Added a new feature flag configuration for enabling the Actions Hub (`EnableActionsHub`). This allows the Actions Hub feature to be toggled based on the configuration.