### PR TITLE
Webpack: Ignore warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,11 @@ const nodeConfig = {
         new webpack.DefinePlugin({
             IS_DESKTOP: true,
         }),
+    ],
+    ignoreWarnings: [
+        {
+            message: /dependency is an expression|require function is used in a way in which dependencies cannot be statically extracted/
+        }
     ]
 };
 const webConfig = {
@@ -120,6 +125,11 @@ const webConfig = {
     infrastructureLogging: {
         level: "log", // enables logging required for problem matchers
     },
+    ignoreWarnings: [
+        {
+            message: /dependency is an expression|require function is used in a way in which dependencies cannot be statically extracted/
+        }
+    ]
 };
 
 /** @type fluent container scripts web worker config */
@@ -174,6 +184,11 @@ const webWorkerConfig = {
         hints: false,
     },
     devtool: "source-map",
+    ignoreWarnings: [
+        {
+            message: /dependency is an expression|require function is used in a way in which dependencies cannot be statically extracted/
+        }
+    ]
 };
 
 module.exports = [nodeConfig, webConfig, webWorkerConfig];


### PR DESCRIPTION
This pull request includes changes to the `webpack.config.js` file to handle specific warnings more effectively. The most important changes include adding an `ignoreWarnings` configuration to various webpack configurations.

Changes to handle warnings:

* [`webpack.config.js`](diffhunk://#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR59-R63): Added `ignoreWarnings` configuration to `nodeConfig` to ignore warnings related to dynamic dependencies.
* [`webpack.config.js`](diffhunk://#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR128-R132): Added `ignoreWarnings` configuration to `webConfig` to ignore warnings related to dynamic dependencies.
* [`webpack.config.js`](diffhunk://#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR187-R191): Added `ignoreWarnings` configuration to `webWorkerConfig` to ignore warnings related to dynamic dependencies.