### PR TITLE
[PowerPages][Actions Hub] Toggle to Change Environment

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -182,6 +182,7 @@
   "Inactive Sites": "Inactive Sites",
   "No sites found": "No sites found",
   "No environments found": "No environments found",
+  "Select an environment to switch to": "Select an environment to switch to",
   "Active Environment is expired or deleted. Please select a new environment.": "Active Environment is expired or deleted. Please select a new environment.",
   "PAC Telemetry enabled": "PAC Telemetry enabled",
   "Failed to enable PAC telemetry.": "Failed to enable PAC telemetry.",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -572,6 +572,9 @@ To learn more, visit [Prevent accidental overwrites](command:powerplatform-walkt
       <note>This is a Markdown formatted string, and the formatting must persist across translations.
 The fifth line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.saveConflict-learn-more).', keeping brackets and the text in the parentheses unmodified</note>
     </trans-unit>
+    <trans-unit id="powerpages.actionsHub.switchEnvironment.title">
+      <source xml:lang="en">Change Environment</source>
+    </trans-unit>
     <trans-unit id="pacCLI.authPanel.clearAuthProfile.title">
       <source xml:lang="en">Clear Auth Profiles</source>
     </trans-unit>
@@ -731,9 +734,6 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     </trans-unit>
     <trans-unit id="pacCLI.pacSolutionHelp.title">
       <source xml:lang="en">Show PAC Solution Help</source>
-    </trans-unit>
-    <trans-unit id="powerpages.actionsHub.switchEnvironment.title">
-      <source xml:lang="en">Switch Environment</source>
     </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.walkthrough.advancedCapabilities.description">
       <source xml:lang="en">Visual Studio Code for Web enables editing and publishing of web pages on your website.

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -424,6 +424,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++a40f78f3a7f5c5ab1b101e95cdf044552542712fdcf45a83dfea3f455b6f638a">
       <source xml:lang="en">Select Type</source>
     </trans-unit>
+    <trans-unit id="++CODE++ced4bf2ba126114717dde651370974e70f3a6ac603e69671be5d4d3e3a303c3c">
+      <source xml:lang="en">Select an environment to switch to</source>
+    </trans-unit>
     <trans-unit id="++CODE++4d6f03fa73020c945e651c34d40c5529f3477ac02df254c1764a68d576575e14">
       <source xml:lang="en">Selection is empty.</source>
     </trans-unit>
@@ -728,6 +731,9 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     </trans-unit>
     <trans-unit id="pacCLI.pacSolutionHelp.title">
       <source xml:lang="en">Show PAC Solution Help</source>
+    </trans-unit>
+    <trans-unit id="powerpages.actionsHub.switchEnvironment.title">
+      <source xml:lang="en">Switch Environment</source>
     </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.walkthrough.advancedCapabilities.description">
       <source xml:lang="en">Visual Studio Code for Web enables editing and publishing of web pages on your website.

--- a/package.json
+++ b/package.json
@@ -380,6 +380,11 @@
         "command": "powerpages.actionsHub.refresh",
         "title": "%powerpages.actionsHub.refresh.title%",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "powerpages.actionsHub.switchEnvironment",
+        "title": "%powerpages.actionsHub.switchEnvironment.title%",
+        "icon": "$(sync)"
       }
     ],
     "configuration": {
@@ -855,11 +860,6 @@
           "command": "powerpages.copilot.clearConversation",
           "when": "view == powerpages.copilot",
           "group": "navigation"
-        },
-        {
-          "command": "powerpages.actionsHub.refresh",
-          "when": "view == powerpages.actionsHub",
-          "group": "navigation"
         }
       ],
       "view/item/context": [
@@ -930,6 +930,16 @@
           "command": "powerpages.collaboration.openMail",
           "group": "inline",
           "when": "viewItem == userNode"
+        },
+        {
+          "command": "powerpages.actionsHub.refresh",
+          "when": "view == powerpages.actionsHub && viewItem == environmentGroup",
+          "group": "inline"
+        },
+        {
+          "command": "powerpages.actionsHub.switchEnvironment",
+          "when": "view == powerpages.actionsHub && viewItem == environmentGroup",
+          "group": "inline"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -384,7 +384,7 @@
       {
         "command": "powerpages.actionsHub.switchEnvironment",
         "title": "%powerpages.actionsHub.switchEnvironment.title%",
-        "icon": "$(sync)"
+        "icon": "$(arrow-swap)"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -377,12 +377,12 @@
         "title": "%powerplatform.pages.previewSite.title%"
       },
       {
-        "command": "powerpages.actionsHub.refresh",
+        "command": "microsoft.powerplatform.pages.actionsHub.refresh",
         "title": "%powerpages.actionsHub.refresh.title%",
         "icon": "$(refresh)"
       },
       {
-        "command": "powerpages.actionsHub.switchEnvironment",
+        "command": "microsoft.powerplatform.pages.actionsHub.switchEnvironment",
         "title": "%powerpages.actionsHub.switchEnvironment.title%",
         "icon": "$(arrow-swap)"
       }
@@ -932,12 +932,12 @@
           "when": "viewItem == userNode"
         },
         {
-          "command": "powerpages.actionsHub.refresh",
+          "command": "microsoft.powerplatform.pages.actionsHub.refresh",
           "when": "view == powerpages.actionsHub && viewItem == environmentGroup",
           "group": "inline"
         },
         {
-          "command": "powerpages.actionsHub.switchEnvironment",
+          "command": "microsoft.powerplatform.pages.actionsHub.switchEnvironment",
           "when": "view == powerpages.actionsHub && viewItem == environmentGroup",
           "group": "inline"
         }

--- a/package.nls.json
+++ b/package.nls.json
@@ -100,5 +100,6 @@
   "microsoft-powerplatform-portals.navigation-loop.powerPagesFileExplorer.title": "POWER PAGES ACTIONS",
   "powerplatform.pages.previewSite.title": "Preview Site",
   "microsoft.powerplatform.pages.actionsHub.title": "POWER PAGES ACTIONS",
-  "powerpages.actionsHub.refresh.title": "Refresh"
+  "powerpages.actionsHub.refresh.title": "Refresh",
+  "powerpages.actionsHub.switchEnvironment.title": "Switch Environment"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -101,5 +101,5 @@
   "powerplatform.pages.previewSite.title": "Preview Site",
   "microsoft.powerplatform.pages.actionsHub.title": "POWER PAGES ACTIONS",
   "powerpages.actionsHub.refresh.title": "Refresh",
-  "powerpages.actionsHub.switchEnvironment.title": "Switch Environment"
+  "powerpages.actionsHub.switchEnvironment.title": "Change Environment"
 }

--- a/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
@@ -80,7 +80,7 @@ export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<Actio
     private registerPanel(pacTerminal: PacTerminal): vscode.Disposable[] {
         const pacWrapper = pacTerminal.getWrapper();
         return [
-            vscode.commands.registerCommand("powerpages.actionsHub.refresh", async () => {
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.refresh", async () => {
                 try {
                     const pacActiveAuth = await pacWrapper.activeAuth();
                     if (pacActiveAuth && pacActiveAuth.Status === SUCCESS) {
@@ -92,7 +92,7 @@ export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<Actio
                 }
             }),
 
-            vscode.commands.registerCommand("powerpages.actionsHub.switchEnvironment", async () => {
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.switchEnvironment", async () => {
                 const authInfo = pacAuthManager.getAuthInfo();
                 if(authInfo) {
                     const envListOutput = await pacWrapper.orgList();

--- a/src/client/power-pages/actions-hub/Constants.ts
+++ b/src/client/power-pages/actions-hub/Constants.ts
@@ -26,7 +26,8 @@ export const Constants = {
         ACTIVE_SITES: vscode.l10n.t("Active Sites"),
         INACTIVE_SITES: vscode.l10n.t("Inactive Sites"),
         NO_SITES_FOUND: vscode.l10n.t("No sites found"),
-        NO_ENVIRONMENTS_FOUND: vscode.l10n.t("No environments found")
+        NO_ENVIRONMENTS_FOUND: vscode.l10n.t("No environments found"),
+        SELECT_ENVIRONMENT: vscode.l10n.t("Select an environment to switch to")
     },
     EventNames: {
         ACTIONS_HUB_INITIALIZED: "actionsHubInitialized",

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -150,48 +150,6 @@ describe("ActionsHubTreeDataProvider", () => {
             expect(registerCommandStub.calledWith("powerpages.actionsHub.switchEnvironment")).to.be.true;
             expect(disposables).to.have.lengthOf(2);
         });
-
-        it("should handle errors during refresh command execution", async () => {
-            const error = new Error("Refresh Error");
-
-            // Check if the method is already stubbed and restore it
-            sinon.stub(pacTerminal.getWrapper(), 'activeAuth').throws(error);
-
-            try {
-                await vscode.commands.executeCommand("powerpages.actionsHub.refresh");
-            } catch (err) {
-                if (err instanceof Error) {
-                    expect(err.message).to.equal("Refresh Error");
-                }
-            }
-
-        });
-
-        it("should handle errors during switch environment command execution", async () => {
-            const error = new Error("Switch Environment Error");
-
-            // Check if the method is already stubbed and restore it
-            const orgListStub = sinon.stub(pacTerminal.getWrapper(), 'orgList').throws(error);
-
-            try {
-                await vscode.commands.executeCommand("powerpages.actionsHub.switchEnvironment");
-            } catch (err) {
-                if (err instanceof Error) {
-                    expect(err.message).to.equal("Switch Environment Error");
-                }
-            }
-
-            orgListStub.restore();
-
-            try {
-                await vscode.commands.executeCommand("powerpages.actionsHub.switchEnvironment");
-            } catch (err) {
-                if (err instanceof Error) {
-                    expect(err.message).to.equal("Switch Environment Error");
-                }
-            }
-
-        });
     });
 
 });

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -52,13 +52,13 @@ describe("ActionsHubTreeDataProvider", () => {
     });
 
     describe('initialize', () => {
-        it("should register refresh command", () => {
+        it("microsoft.powerplatform.pages.actionsHub.refresh", () => {
             // Initialize
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             // Assert that the command was registered
-            expect(registerCommandStub.calledWith("powerpages.actionsHub.refresh")).to.be.true;
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.refresh")).to.be.true;
         });
     });
 

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -143,10 +143,19 @@ describe("ActionsHubTreeDataProvider", () => {
             expect(disposables).to.have.lengthOf(2);
         });
 
+        it("should register the switch environment command", async () => {
+            const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            const disposables = provider["registerPanel"](pacTerminal);
+
+            expect(registerCommandStub.calledWith("powerpages.actionsHub.switchEnvironment")).to.be.true;
+            expect(disposables).to.have.lengthOf(2);
+        });
+
         it("should handle errors during refresh command execution", async () => {
-            //const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             const error = new Error("Refresh Error");
-            const pacWrapperStub = sinon.stub(pacTerminal.getWrapper(), 'activeAuth').throws(error);
+
+            // Check if the method is already stubbed and restore it
+            sinon.stub(pacTerminal.getWrapper(), 'activeAuth').throws(error);
 
             try {
                 await vscode.commands.executeCommand("powerpages.actionsHub.refresh");
@@ -156,21 +165,13 @@ describe("ActionsHubTreeDataProvider", () => {
                 }
             }
 
-            pacWrapperStub.restore();
-        });
-
-        it("should register the switch environment command", async () => {
-            const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
-            const disposables = provider["registerPanel"](pacTerminal);
-
-            expect(registerCommandStub.calledWith("powerpages.actionsHub.switchEnvironment")).to.be.true;
-            expect(disposables).to.have.lengthOf(2);
         });
 
         it("should handle errors during switch environment command execution", async () => {
-            //const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             const error = new Error("Switch Environment Error");
-            const pacWrapperStub = sinon.stub(pacTerminal.getWrapper(), 'orgList').throws(error);
+
+            // Check if the method is already stubbed and restore it
+            const orgListStub = sinon.stub(pacTerminal.getWrapper(), 'orgList').throws(error);
 
             try {
                 await vscode.commands.executeCommand("powerpages.actionsHub.switchEnvironment");
@@ -180,24 +181,16 @@ describe("ActionsHubTreeDataProvider", () => {
                 }
             }
 
-            pacWrapperStub.restore();
-        });
-
-        // New test cases
-        it("should handle errors during refresh command registration", () => {
-            const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
-            const error = new Error("Registration Error");
-            const registerCommandStub = sinon.stub(vscode.commands, 'registerCommand').throws(error);
+            orgListStub.restore();
 
             try {
-                provider["registerPanel"](pacTerminal);
+                await vscode.commands.executeCommand("powerpages.actionsHub.switchEnvironment");
             } catch (err) {
                 if (err instanceof Error) {
-                    expect(err.message).to.equal("Registration Error");
+                    expect(err.message).to.equal("Switch Environment Error");
                 }
             }
 
-            registerCommandStub.restore();
         });
     });
 

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -134,4 +134,71 @@ describe("ActionsHubTreeDataProvider", () => {
         });
     });
 
+    describe('registerPanel', () => {
+        it("should register the refresh command", async () => {
+            const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            const disposables = provider["registerPanel"](pacTerminal);
+
+            expect(registerCommandStub.calledWith("powerpages.actionsHub.refresh")).to.be.true;
+            expect(disposables).to.have.lengthOf(2);
+        });
+
+        it("should handle errors during refresh command execution", async () => {
+            //const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            const error = new Error("Refresh Error");
+            const pacWrapperStub = sinon.stub(pacTerminal.getWrapper(), 'activeAuth').throws(error);
+
+            try {
+                await vscode.commands.executeCommand("powerpages.actionsHub.refresh");
+            } catch (err) {
+                if (err instanceof Error) {
+                    expect(err.message).to.equal("Refresh Error");
+                }
+            }
+
+            pacWrapperStub.restore();
+        });
+
+        it("should register the switch environment command", async () => {
+            const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            const disposables = provider["registerPanel"](pacTerminal);
+
+            expect(registerCommandStub.calledWith("powerpages.actionsHub.switchEnvironment")).to.be.true;
+            expect(disposables).to.have.lengthOf(2);
+        });
+
+        it("should handle errors during switch environment command execution", async () => {
+            //const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            const error = new Error("Switch Environment Error");
+            const pacWrapperStub = sinon.stub(pacTerminal.getWrapper(), 'orgList').throws(error);
+
+            try {
+                await vscode.commands.executeCommand("powerpages.actionsHub.switchEnvironment");
+            } catch (err) {
+                if (err instanceof Error) {
+                    expect(err.message).to.equal("Switch Environment Error");
+                }
+            }
+
+            pacWrapperStub.restore();
+        });
+
+        // New test cases
+        it("should handle errors during refresh command registration", () => {
+            const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            const error = new Error("Registration Error");
+            const registerCommandStub = sinon.stub(vscode.commands, 'registerCommand').throws(error);
+
+            try {
+                provider["registerPanel"](pacTerminal);
+            } catch (err) {
+                if (err instanceof Error) {
+                    expect(err.message).to.equal("Registration Error");
+                }
+            }
+
+            registerCommandStub.restore();
+        });
+    });
+
 });

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -139,7 +139,7 @@ describe("ActionsHubTreeDataProvider", () => {
             const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             const disposables = provider["registerPanel"](pacTerminal);
 
-            expect(registerCommandStub.calledWith("powerpages.actionsHub.refresh")).to.be.true;
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.refresh")).to.be.true;
             expect(disposables).to.have.lengthOf(2);
         });
 
@@ -147,7 +147,7 @@ describe("ActionsHubTreeDataProvider", () => {
             const provider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             const disposables = provider["registerPanel"](pacTerminal);
 
-            expect(registerCommandStub.calledWith("powerpages.actionsHub.switchEnvironment")).to.be.true;
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.switchEnvironment")).to.be.true;
             expect(disposables).to.have.lengthOf(2);
         });
     });


### PR DESCRIPTION
This pull request introduces a new feature that allows users to switch environments within the Power Pages Actions Hub. It includes updates to localization files, command registration, and test cases to support this new functionality.

![image](https://github.com/user-attachments/assets/764cd6d8-3e6f-4e1b-ad9a-5cb41c0a853f)

![image](https://github.com/user-attachments/assets/12ce41ab-74b1-46aa-89b2-ecc3eaaa8f38)


Key changes include:

### New Feature: Switch Environment Command

* **Localization Updates:**
  - Added the string "Select an environment to switch to" to `l10n/bundle.l10n.json` and `loc/translations-export/vscode-powerplatform.xlf`. [[1]](diffhunk://#diff-829b512e02461234524c007941f3260e67a43b109f48bedf257ab8e8033cc527R185) [[2]](diffhunk://#diff-62401b58ce452f2686a1cbf6945a0bf5bb33bf35151df029524ced13ada25794R427-R429)
  - Updated `package.nls.json` to include the title for the new switch environment command.

* **Command Registration:**
  - Added the `powerpages.actionsHub.switchEnvironment` command in `package.json` and registered it in `ActionsHubTreeDataProvider.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R383-R387) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R933-R942) [[3]](diffhunk://#diff-bc0f356a4fefe925124b3b08962cbc16aee0c0dc9c8bb47df60d9a3fbc86f9f9R93-R118)

* **Constants Update:**
  - Added a new constant `SELECT_ENVIRONMENT` in `Constants.ts` to support the new command.

* **Testing:**
  - Added test cases in `ActionsHubTreeDataProvider.test.ts` to cover the new switch environment command and its error handling.