### PR TITLE
Add Instance URL to Environment Details

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -31,12 +31,14 @@ const getEnvironmentDetails = () => {
     detailsArray.push(vscode.l10n.t({ message: "Timestamp: {0}", args: [new Date().toISOString()], comment: "{0} is the timestamp" }));
 
     const authInfo = PacContext.AuthInfo;
+    const orgInfo = PacContext.OrgInfo;
 
     if (authInfo) {
         detailsArray.push(vscode.l10n.t({ message: "Tenant ID: {0}", args: [authInfo.TenantId], comment: "{0} is the Tenant ID" }));
         detailsArray.push(vscode.l10n.t({ message: "Object ID: {0}", args: [authInfo.EntraIdObjectId], comment: "{0} is the Object ID" }));
         detailsArray.push(vscode.l10n.t({ message: "Organization ID: {0}", args: [authInfo.OrganizationId], comment: "{0} is the Organization ID" }));
         detailsArray.push(vscode.l10n.t({ message: "Unique name: {0}", args: [authInfo.OrganizationUniqueName], comment: "{0} is the Unique name" }));
+        detailsArray.push(vscode.l10n.t({ message: "Instance url: {0}", args: [orgInfo?.OrgUrl], comment: "{0} is the Instance Url" }));
         detailsArray.push(vscode.l10n.t({ message: "Environment ID: {0}", args: [authInfo.EnvironmentId], comment: "{0} is the Environment ID" }));
         detailsArray.push(vscode.l10n.t({ message: "Cluster environment: {0}", args: [authInfo.EnvironmentType], comment: "{0} is the Cluster environment" }));
         detailsArray.push(vscode.l10n.t({ message: "Cluster category: {0}", args: [authInfo.Cloud], comment: "{0} is the Cluster category" }));

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -10,7 +10,7 @@ import { showEnvironmentDetails, refreshEnvironment, switchEnvironment } from '.
 import { Constants } from '../../../../power-pages/actions-hub/Constants';
 import { oneDSLoggerWrapper } from '../../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper';
 import * as CommonUtils from '../../../../power-pages/commonUtility';
-import { AuthInfo, CloudInstance, EnvironmentType } from '../../../../pac/PacTypes';
+import { AuthInfo, CloudInstance, EnvironmentType, OrgInfo } from '../../../../pac/PacTypes';
 import { PacTerminal } from '../../../../lib/PacTerminal';
 import PacContext from '../../../../pac/PacContext';
 
@@ -39,6 +39,16 @@ describe('ActionsHubCommandHandlers', () => {
         OrganizationFriendlyName: 'test-org-friendly-name'
     };
 
+    const mockOrgInfo: OrgInfo = {
+        OrgId: 'test-org-id',
+        UniqueName: 'test-org-name',
+        FriendlyName: 'test-org-friendly-name',
+        OrgUrl: 'test-org-url',
+        UserEmail: 'test-user-email',
+        UserId: 'test-user-id',
+        EnvironmentId: 'test-env-id',
+    };
+
     beforeEach(() => {
         sandbox = sinon.createSandbox();
         mockShowInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage');
@@ -59,6 +69,7 @@ describe('ActionsHubCommandHandlers', () => {
     describe('showEnvironmentDetails', () => {
         it('should show environment details when auth info is available', async () => {
             PacContext['_authInfo'] = mockAuthInfo;
+            PacContext['_orgInfo'] = mockOrgInfo;
             mockShowInformationMessage.resolves(Constants.Strings.COPY_TO_CLIPBOARD);
 
             await showEnvironmentDetails();
@@ -66,12 +77,15 @@ describe('ActionsHubCommandHandlers', () => {
             expect(mockShowInformationMessage.calledOnce).to.be.true;
 
             const message = mockShowInformationMessage.firstCall.args[0];
+            console.log(message)
+
             expect(message).to.include("Session Details");
             expect(message).to.include("Timestamp");
             expect(message).to.include("Tenant ID: test-tenant");
             expect(message).to.include("Object ID: test-object-id");
             expect(message).to.include("Organization ID: test-org-id");
             expect(message).to.include("Unique name: test-org-name");
+            expect(message).to.include("Instance url: test-org-url");
             expect(message).to.include("Environment ID: test-env-id");
             expect(message).to.include("Cluster environment: 1");
             expect(message).to.include("Cluster category: 1");


### PR DESCRIPTION
Include the instance URL in the environment details display, enhancing the information available to users.