### PR TITLE
[Power Pages][Actions Hub] Add 'isCurrent' property and description to site tree items

### DIFF
--- a/src/client/power-pages/actions-hub/Constants.ts
+++ b/src/client/power-pages/actions-hub/Constants.ts
@@ -30,7 +30,8 @@ export const Constants = {
         SELECT_ENVIRONMENT: vscode.l10n.t("Select an environment"),
         COPY_TO_CLIPBOARD: vscode.l10n.t("Copy to clipboard"),
         SESSION_DETAILS: vscode.l10n.t("Session Details"),
-        CHANGING_ENVIRONMENT: vscode.l10n.t("Changing environment...")
+        CHANGING_ENVIRONMENT: vscode.l10n.t("Changing environment..."),
+        CURRENT: vscode.l10n.t("Current"),
     },
     EventNames: {
         ACTIONS_HUB_INITIALIZED: "actionsHubInitialized",

--- a/src/client/power-pages/actions-hub/models/IWebsiteInfo.ts
+++ b/src/client/power-pages/actions-hub/models/IWebsiteInfo.ts
@@ -10,4 +10,5 @@ export interface IWebsiteInfo {
     dataModelVersion: 1 | 2;
     websiteUrl: string;
     status: WebsiteStatus | undefined;
+    isCurrent: boolean;
 }

--- a/src/client/power-pages/actions-hub/tree-items/ActionsHubTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/ActionsHubTreeItem.ts
@@ -10,7 +10,8 @@ export abstract class ActionsHubTreeItem extends vscode.TreeItem {
         public readonly label: string,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
         public readonly iconPath: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } | vscode.ThemeIcon,
-        public readonly contextValue: string
+        public readonly contextValue: string,
+        public readonly description: string = "",
     ) {
         super(label, collapsibleState);
 

--- a/src/client/power-pages/actions-hub/tree-items/ActiveGroupTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/ActiveGroupTreeItem.ts
@@ -36,7 +36,8 @@ export class ActiveGroupTreeItem extends ActionsHubTreeItem {
                 name: site.Name,
                 dataModelVersion: site.DataModel == WebsiteDataModel.Standard ? 1 : 2,
                 websiteUrl: site.WebsiteUrl,
-                status: WebsiteStatus.Active
+                status: WebsiteStatus.Active,
+                isCurrent: false //TODO: Implement this
             };
             const siteItem = new SiteTreeItem(siteInfo);
             return siteItem;

--- a/src/client/power-pages/actions-hub/tree-items/InactiveGroupTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/InactiveGroupTreeItem.ts
@@ -36,7 +36,8 @@ export class InactiveGroupTreeItem extends ActionsHubTreeItem {
                 name: site.Name,
                 dataModelVersion: site.DataModel == WebsiteDataModel.Standard ? 1 : 2,
                 websiteUrl: site.WebsiteUrl,
-                status: WebsiteStatus.Inactive
+                status: WebsiteStatus.Inactive,
+                isCurrent: false
             };
             const siteItem = new SiteTreeItem(siteInfo);
             return siteItem;

--- a/src/client/power-pages/actions-hub/tree-items/SiteTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/SiteTreeItem.ts
@@ -17,7 +17,8 @@ export class SiteTreeItem extends ActionsHubTreeItem {
             siteInfo.name,
             vscode.TreeItemCollapsibleState.None,
             Constants.Icons.SITE,
-            SiteTreeItem.getContextValue(siteInfo)
+            SiteTreeItem.getContextValue(siteInfo),
+            siteInfo.isCurrent ? Constants.Strings.CURRENT : ""
         )
     }
 

--- a/src/client/test/Integration/power-pages/actions-hub/tree-items/ActionsHubTreeItem.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/tree-items/ActionsHubTreeItem.test.ts
@@ -13,7 +13,8 @@ class MockTreeItem extends ActionsHubTreeItem {
             "Foo",
             vscode.TreeItemCollapsibleState.Collapsed,
             "iconPath",
-            "contextValue"
+            "contextValue",
+            "describe"
         );
     }
 }
@@ -25,9 +26,39 @@ describe('ActionsHubTreeItem', () => {
         expect(treeItem).to.be.instanceOf(vscode.TreeItem);
     });
 
+    it('should have the expected label', () => {
+        const treeItem = new MockTreeItem();
+
+        expect(treeItem.label).to.be.equal("Foo");
+    });
+
+    it('should have the expected collapsible state', () => {
+        const treeItem = new MockTreeItem();
+
+        expect(treeItem.collapsibleState).to.be.equal(vscode.TreeItemCollapsibleState.Collapsed);
+    });
+
+    it('should have the expected icon path', () => {
+        const treeItem = new MockTreeItem();
+
+        expect(treeItem.iconPath).to.be.equal("iconPath");
+    });
+
+    it('should have the expected context value', () => {
+        const treeItem = new MockTreeItem();
+
+        expect(treeItem.contextValue).to.be.equal("contextValue");
+    });
+
     it('should have the expected tooltip', () => {
         const treeItem = new MockTreeItem();
 
         expect(treeItem.tooltip).to.be.equal("Foo");
+    });
+
+    it('should have the expected description', () => {
+        const treeItem = new MockTreeItem();
+
+        expect(treeItem.description).to.be.equal("describe");
     });
 });

--- a/src/client/test/Integration/power-pages/actions-hub/tree-items/SiteTreeItem.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/tree-items/SiteTreeItem.test.ts
@@ -11,44 +11,56 @@ import { WebsiteStatus } from "../../../../../power-pages/actions-hub/models/Web
 
 describe('SiteTreeItem', () => {
     it('should be of type ActionsHubTreeItem', () => {
-        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo" });
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo", isCurrent: false });
 
         expect(treeItem).to.be.instanceOf(ActionsHubTreeItem);
     });
 
     it('should have the expected label', () => {
-        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo" });
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo", isCurrent: false });
 
         expect(treeItem.label).to.be.equal("Test Site");
     });
 
     it('should have the expected collapsibleState', () => {
-        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo" });
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo", isCurrent: false });
 
         expect(treeItem.collapsibleState).to.be.equal(vscode.TreeItemCollapsibleState.None);
     });
 
     it('should have the expected icon', () => {
-        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo" });
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo", isCurrent: false });
 
         expect((treeItem.iconPath as vscode.ThemeIcon).id).to.be.equal('globe');
     });
 
     it('should have the expected contextValue when the site is Active', () => {
-        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo" });
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Active, websiteUrl: "https://foo", isCurrent: false });
 
         expect(treeItem.contextValue).to.be.equal("activeSite");
     });
 
     it('should have the expected contextValue when the site is Inactive', () => {
-        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Inactive, websiteUrl: "https://foo" });
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: WebsiteStatus.Inactive, websiteUrl: "https://foo", isCurrent: false });
 
         expect(treeItem.contextValue).to.be.equal("inactiveSite");
     });
 
     it('should have the expected contextValue when the site is neither Active nor Inactive', () => {
-        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: undefined, websiteUrl: "https://foo" });
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: undefined, websiteUrl: "https://foo", isCurrent: false });
 
         expect(treeItem.contextValue).to.be.equal("otherSite");
+    });
+
+    it('should have the expected description when site is current', () => {
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: undefined, websiteUrl: "https://foo", isCurrent: true });
+
+        expect(treeItem.description).to.be.equal("Current");
+    });
+
+    it('should have the expected description when site is not current', () => {
+        const treeItem = new SiteTreeItem({ name: "Test Site", dataModelVersion: 1, status: undefined, websiteUrl: "https://foo", isCurrent: false });
+
+        expect(treeItem.description).to.be.equal("");
     });
 });


### PR DESCRIPTION
Introduce an 'isCurrent' property to site tree items and update the description accordingly. This change enhances the representation of site items in the tree structure.