### PR TITLE
[Power Pages][Actions Hub] Add revealInOS command for current active site

### DIFF
--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -735,6 +735,9 @@ The second line should be '[TRANSLATION HERE](command:pacCLI.authPanel.newAuthPr
       <note>This is a Markdown formatted string, and the formatting must persist across translations.
 The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.overview-learn-more)', keeping brackets and the text in the parentheses unmodified</note>
     </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux.title">
+      <source xml:lang="en">Open Containing Folder</source>
+    </trans-unit>
     <trans-unit id="pacCLI.openPacLab.title">
       <source xml:lang="en">Open PAC Lab</source>
     </trans-unit>
@@ -774,6 +777,12 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     </trans-unit>
     <trans-unit id="pacCLI.authPanel.refresh.title">
       <source xml:lang="en">Refresh</source>
+    </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows.title">
+      <source xml:lang="en">Reveal in Explorer</source>
+    </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac.title">
+      <source xml:lang="en">Reveal in Finder</source>
     </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.walkthrough.saveConflict.title">
       <source xml:lang="en">Save conflict</source>

--- a/package.json
+++ b/package.json
@@ -419,6 +419,18 @@
       {
         "command": "microsoft.powerplatform.pages.actionsHub.newAuthProfile",
         "title": "%microsoft.powerplatform.pages.actionsHub.login.title%"
+      },
+      {
+        "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows",
+        "title": "%microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows.title%"
+      },
+      {
+        "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac",
+        "title": "%microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac.title%"
+      },
+      {
+        "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux",
+        "title": "%microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux.title%"
       }
     ],
     "configuration": {
@@ -883,6 +895,18 @@
         {
           "command": "microsoft.powerplatform.pages.actionsHub.activeSite.preview",
           "when": "never"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows",
+          "when": "never"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac",
+          "when": "never"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux",
+          "when": "never"
         }
       ],
       "view/title": [
@@ -1010,6 +1034,21 @@
           "command": "microsoft.powerplatform.pages.actionsHub.activeSite.preview",
           "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == nonCurrentActiveSite)",
           "group": "activeSiteContextMenuGroup@1"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isWindows",
+          "group": "activeSiteContextMenuGroup@2"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isMac",
+          "group": "activeSiteContextMenuGroup@2"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isLinux",
+          "group": "activeSiteContextMenuGroup@2"
         }
       ]
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -105,5 +105,8 @@
       "The second line should be '[TRANSLATION HERE](command:powerpages.actionsHub.newAuthProfile).', keeping brackets and the text in the parentheses unmodified"
     ]
   },
-  "microsoft.powerplatform.pages.actionsHub.login.title": "Add New Auth Profile"
+  "microsoft.powerplatform.pages.actionsHub.login.title": "Add New Auth Profile",
+  "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows.title": "Reveal in Explorer",
+  "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac.title": "Reveal in Finder",
+  "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux.title": "Open Containing Folder"
 }

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -21,6 +21,7 @@ import { dataverseAuthentication } from '../../../common/services/Authentication
 import { createAuthProfileExp } from '../../../common/utilities/PacAuthUtil';
 import { IWebsiteDetails } from '../../../common/services/Interfaces';
 import { getActiveWebsites, getAllWebsites } from '../../../common/utilities/WebsiteUtil';
+import CurrentSiteContext from './CurrentSiteContext';
 
 export const refreshEnvironment = async (pacTerminal: PacTerminal) => {
     const pacWrapper = pacTerminal.getWrapper();
@@ -219,4 +220,10 @@ export const fetchWebsites = async (): Promise<{ activeSites: IWebsiteDetails[],
     }
 
     return { activeSites: [], inactiveSites: [] };
+}
+
+export const revealInOS = async () => {
+    if (CurrentSiteContext.currentSiteFolderPath) {
+        await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(CurrentSiteContext.currentSiteFolderPath));
+    }
 }

--- a/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
@@ -11,7 +11,7 @@ import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLo
 import { EnvironmentGroupTreeItem } from "./tree-items/EnvironmentGroupTreeItem";
 import { IEnvironmentInfo } from "./models/IEnvironmentInfo";
 import { PacTerminal } from "../../lib/PacTerminal";
-import { fetchWebsites, openActiveSitesInStudio, openInactiveSitesInStudio, previewSite, createNewAuthProfile, refreshEnvironment, showEnvironmentDetails, switchEnvironment } from "./ActionsHubCommandHandlers";
+import { fetchWebsites, openActiveSitesInStudio, openInactiveSitesInStudio, previewSite, createNewAuthProfile, refreshEnvironment, showEnvironmentDetails, switchEnvironment, revealInOS } from "./ActionsHubCommandHandlers";
 import PacContext from "../../pac/PacContext";
 import CurrentSiteContext from "./CurrentSiteContext";
 import { IWebsiteDetails } from "../../../common/services/Interfaces";
@@ -115,6 +115,10 @@ export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<Actio
             vscode.commands.registerCommand("powerpages.actionsHub.newAuthProfile", async () => {
                 await createNewAuthProfile(pacTerminal.getWrapper());
             }),
+
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows", revealInOS),
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac", revealInOS),
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux", revealInOS)
         ];
     }
 }

--- a/src/client/power-pages/actions-hub/CurrentSiteContext.ts
+++ b/src/client/power-pages/actions-hub/CurrentSiteContext.ts
@@ -9,23 +9,28 @@ import { findWebsiteYmlFolder, getWebsiteRecordId } from '../../../common/utilit
 
 interface ICurrentSiteContext {
     currentSiteId: string | null;
+    currentSiteFolderPath: string | null;
 }
 
 class CurrentSiteContext implements ICurrentSiteContext {
     private _currentSiteId: string | null = null;
+    private _currentSiteFolderPath: string | null = null;
     private _disposables: vscode.Disposable[] = [];
-    private readonly _onChanged = new vscode.EventEmitter<string | null>();
+    private readonly _onChanged = new vscode.EventEmitter<ICurrentSiteContext>();
     public readonly onChanged = this._onChanged.event;
 
     constructor() {
-        this._currentSiteId = this.getCurrentSiteId();
+        const { currentSiteId, currentSiteFolderPath } = this.getCurrentSiteInfo();
+        this._currentSiteId = currentSiteId;
+        this._currentSiteFolderPath = currentSiteFolderPath;
 
         this._disposables.push(
             vscode.window.onDidChangeActiveTextEditor(() => {
-                const newSiteId = this.getCurrentSiteId();
-                if (newSiteId !== this._currentSiteId) {
-                    this._currentSiteId = newSiteId;
-                    this._onChanged.fire(newSiteId);
+                const newSiteInfo = this.getCurrentSiteInfo();
+                if (newSiteInfo.currentSiteId !== this._currentSiteId) {
+                    this._currentSiteId = newSiteInfo.currentSiteId;
+                    this._currentSiteFolderPath = newSiteInfo.currentSiteFolderPath;
+                    this._onChanged.fire(newSiteInfo);
                 }
             })
         );
@@ -35,12 +40,16 @@ class CurrentSiteContext implements ICurrentSiteContext {
         return this._currentSiteId;
     }
 
+    public get currentSiteFolderPath(): string | null {
+        return this._currentSiteFolderPath;
+    }
+
     public dispose() {
         this._onChanged.dispose();
         this._disposables.forEach(d => d.dispose());
     }
 
-    private getCurrentSiteId(): string | null {
+    private getCurrentSiteInfo(): ICurrentSiteContext {
         const activeEditor = vscode.window.activeTextEditor;
         if (activeEditor) {
             const filePath = activeEditor.document.uri.fsPath;
@@ -50,7 +59,7 @@ class CurrentSiteContext implements ICurrentSiteContext {
             if (websiteYmlFolder) {
                 const siteId = getWebsiteRecordId(websiteYmlFolder);
                 if (siteId) {
-                    return siteId;
+                    return { currentSiteId: siteId, currentSiteFolderPath: websiteYmlFolder };
                 }
             }
         }
@@ -58,10 +67,10 @@ class CurrentSiteContext implements ICurrentSiteContext {
         // Fallback: check first workspace folder
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (workspaceFolders && workspaceFolders.length > 0) {
-            return getWebsiteRecordId(workspaceFolders[0].uri.fsPath);
+            return { currentSiteId: getWebsiteRecordId(workspaceFolders[0].uri.fsPath), currentSiteFolderPath: workspaceFolders[0].uri.fsPath };
         }
 
-        return null;
+        return { currentSiteId: null, currentSiteFolderPath: null };
     }
 }
 

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
+import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
 import { Constants } from '../../../../power-pages/actions-hub/Constants';
 import { oneDSLoggerWrapper } from '../../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper';
 import * as CommonUtils from '../../../../power-pages/commonUtility';
@@ -24,6 +24,7 @@ import { SiteTreeItem } from '../../../../power-pages/actions-hub/tree-items/Sit
 import { WebsiteStatus } from '../../../../power-pages/actions-hub/models/WebsiteStatus';
 import { IWebsiteInfo } from '../../../../power-pages/actions-hub/models/IWebsiteInfo';
 import * as WebsiteUtils from '../../../../../common/utilities/WebsiteUtil';
+import CurrentSiteContext from '../../../../power-pages/actions-hub/CurrentSiteContext';
 
 describe('ActionsHubCommandHandlers', () => {
     let sandbox: sinon.SinonSandbox;
@@ -630,6 +631,33 @@ describe('ActionsHubCommandHandlers', () => {
 
             expect(response.activeSites).to.deep.equal(activeSites);
             expect(response.inactiveSites).to.deep.equal(inactiveSites);
+        });
+    });
+
+    describe('revealInOS', () => {
+        let executeCommandStub: sinon.SinonStub;
+
+        beforeEach(() => {
+            executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
+        });
+
+        afterEach(() => {
+            executeCommandStub.restore();
+        });
+
+        it('should not reveal file in OS when file path is not provided', async () => {
+            sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => undefined);
+            await revealInOS();
+
+            expect(executeCommandStub.called).to.be.false;
+        });
+
+        it('should reveal file in OS when file path is provided', async () => {
+            const mockPath = 'test-path';
+            sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => mockPath);
+            await revealInOS();
+
+            expect(executeCommandStub.calledOnceWith('revealFileInOS', vscode.Uri.file(mockPath))).to.be.true;
         });
     });
 });

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -103,6 +103,15 @@ describe("ActionsHubTreeDataProvider", () => {
 
             expect(registerCommandStub.calledWith("powerpages.actionsHub.newAuthProfile")).to.be.true;
         });
+
+        it("should register revealInOS commands", async () => {
+            const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            actionsHubTreeDataProvider["registerPanel"](pacTerminal);
+
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows")).to.be.true;
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac")).to.be.true;
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux")).to.be.true;
+        });
     });
 
     describe('getTreeItem', () => {

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -55,62 +55,104 @@ describe("ActionsHubTreeDataProvider", () => {
     });
 
     describe('initialize', () => {
-        it("should register refresh command", () => {
+        it("should register refresh command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'refreshEnvironment');
+            mockCommandHandler.resolves();
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.refresh")).to.be.true;
+
+            await registerCommandStub.getCall(0).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
         });
 
-        it("should register switchEnvironment command", () => {
+        it("should register switchEnvironment command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'switchEnvironment');
+            mockCommandHandler.resolves();
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.switchEnvironment")).to.be.true;
+
+            await registerCommandStub.getCall(1).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
         });
 
-        it("should register showEnvironmentDetails command", () => {
+        it("should register showEnvironmentDetails command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'showEnvironmentDetails');
+            mockCommandHandler.resolves();
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.showEnvironmentDetails")).to.be.true;
+
+            await registerCommandStub.getCall(2).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
         });
 
-        it("should register openActiveSitesInStudio command", () => {
+        it("should register openActiveSitesInStudio command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'openActiveSitesInStudio');
+            mockCommandHandler.resolves();
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.openActiveSitesInStudio")).to.be.true;
+
+            await registerCommandStub.getCall(3).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
         });
 
-        it("should register openInactiveSitesInStudio command", () => {
+        it("should register openInactiveSitesInStudio command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'openInactiveSitesInStudio');
+            mockCommandHandler.resolves();
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.openInactiveSitesInStudio")).to.be.true;
+
+            await registerCommandStub.getCall(4).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
         });
 
-        it("should register preview command", () => {
+        it("should register preview command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'previewSite');
+            mockCommandHandler.resolves();
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.activeSite.preview")).to.be.true;
+
+            await registerCommandStub.getCall(5).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
         });
 
-        it("should register newAuthProfile command", () => {
+        it("should register newAuthProfile command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'createNewAuthProfile');
+            mockCommandHandler.resolves();
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             expect(registerCommandStub.calledWith("powerpages.actionsHub.newAuthProfile")).to.be.true;
+
+            await registerCommandStub.getCall(6).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
         });
 
         it("should register revealInOS commands", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'revealInOS');
+            mockCommandHandler.resolves();
             const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
             actionsHubTreeDataProvider["registerPanel"](pacTerminal);
 
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows")).to.be.true;
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac")).to.be.true;
             expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux")).to.be.true;
+
+            await registerCommandStub.getCall(7).args[1]();
+            await registerCommandStub.getCall(8).args[1]();
+            await registerCommandStub.getCall(9).args[1]();
+            expect(mockCommandHandler.calledThrice).to.be.true;
         });
     });
 


### PR DESCRIPTION
This pull request introduces several new features and improvements to the Power Platform extension, focusing on enhancing the user interface and functionality for revealing the current active site in the operating system's file explorer. The main changes include adding new commands for different operating systems, updating the context handling for the current site, and adding tests for the new functionality.

New commands and context handling:

* Added new commands for revealing the current active site in Windows Explorer, macOS Finder, and Linux file manager in `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R422-R433) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R898-R909) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1037-R1051)
* Updated `CurrentSiteContext` to include `currentSiteFolderPath` and modified the logic to handle this new property. [[1]](diffhunk://#diff-a0c4768e8cb7751abd7b1a9368a299968c9ad2408b95fccdabae86e242af413cR12-R33) [[2]](diffhunk://#diff-a0c4768e8cb7751abd7b1a9368a299968c9ad2408b95fccdabae86e242af413cR43-R52) [[3]](diffhunk://#diff-a0c4768e8cb7751abd7b1a9368a299968c9ad2408b95fccdabae86e242af413cL53-R73)
* Registered the new commands in `ActionsHubTreeDataProvider.ts`.

Test coverage:

* Added tests for the `revealInOS` command to ensure it works correctly based on the provided file path in `ActionsHubCommandHandlers.test.ts`. [[1]](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772L9-R9) [[2]](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772R27) [[3]](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772R636-R662)
* Added tests to verify the registration of the new commands in `ActionsHubTreeDataProvider.test.ts`.

### Feature in action
![Reveal In Explorer](https://github.com/user-attachments/assets/1021abd0-a395-42ac-aadc-cc1b36415130)
