### PR TITLE
[Power Pages][Actions Hub] Add site details command

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -195,6 +195,7 @@
   "Site management URL not found for the selected site. Please try again after refreshing the environment.": "Site management URL not found for the selected site. Please try again after refreshing the environment.",
   "Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?": "Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?",
   "Yes": "Yes",
+  "Site Details": "Site Details",
   "Timestamp: {0}/{0} is the timestamp": {
     "message": "Timestamp: {0}",
     "comment": [
@@ -253,6 +254,24 @@
     "message": "Cluster geo name: {0}",
     "comment": [
       "{0} is the cluster geo name"
+    ]
+  },
+  "Friendly name: {0}/{0} is the website name": {
+    "message": "Friendly name: {0}",
+    "comment": [
+      "{0} is the website name"
+    ]
+  },
+  "Website ID: {0}/{0} is the website ID": {
+    "message": "Website ID: {0}",
+    "comment": [
+      "{0} is the website ID"
+    ]
+  },
+  "Data model version: v{0}/{0} is the data model version": {
+    "message": "Data model version: v{0}",
+    "comment": [
+      "{0} is the data model version"
     ]
   },
   "PAC Telemetry enabled": "PAC Telemetry enabled",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -139,6 +139,10 @@ The second line should be '[TRANSLATION HERE](https://aka.ms/pages-clear-cache).
     <trans-unit id="++CODE++e0d1b68224bf0b31ef16b206c65b5f8f6b89d18161f4a7cdcb8d0ac8d952549a">
       <source xml:lang="en">Current</source>
     </trans-unit>
+    <trans-unit id="++CODE++1da89bd5f5df020ca47c79dfdbc1517a299ca77570df2de4132f53797d5f2412">
+      <source xml:lang="en">Data model version: v{0}</source>
+      <note>{0} is the data model version</note>
+    </trans-unit>
     <trans-unit id="++CODE++5bd78fcb75f98d65ab8f89a8f0b6681c25c13308fa8643c44ab459b7783c06c9">
       <source xml:lang="en">Default Environment: {0}</source>
       <note>The {0} represents profile's resource/environment URL</note>
@@ -225,6 +229,10 @@ The {3} represents Solution's Type (Managed or Unmanaged), but that test is loca
     </trans-unit>
     <trans-unit id="++CODE++1b93e507157d91755f08e1abfe8a33d725b637a32ddadf149420b25907d440a0">
       <source xml:lang="en">File(s) already exist. No new files to add</source>
+    </trans-unit>
+    <trans-unit id="++CODE++56281cd1d0090cc4c7c38634a5738f51769927efda74805ba19e30e35868fd4e">
+      <source xml:lang="en">Friendly name: {0}</source>
+      <note>{0} is the website name</note>
     </trans-unit>
     <trans-unit id="++CODE++7184a5edf42e6fc9ef8f53fc1dd73f10b3f6196a23f6d340c4f434e60c366e45">
       <source xml:lang="en">GETTING STARTED</source>
@@ -475,6 +483,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++899fb203e6c2faac8093e21a2fa8db0d4b13d16ea5492461d8b72dbcee3ecf2a">
       <source xml:lang="en">Show Output Panel</source>
     </trans-unit>
+    <trans-unit id="++CODE++524bca0347e50e3801bebf27374124b3babf072729b4da4bcc45ef5c385ee8f4">
+      <source xml:lang="en">Site Details</source>
+    </trans-unit>
     <trans-unit id="++CODE++a72357d268bce5e1643bfd74563495784179f75ace0d652db8f808f293586b63">
       <source xml:lang="en">Site management URL not found for the selected site. Please try again after refreshing the environment.</source>
     </trans-unit>
@@ -575,6 +586,10 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     </trans-unit>
     <trans-unit id="++CODE++00dc171124ab430bbbaae51ec39dda1c5e7d045f382f56b1767d9e733292731c">
       <source xml:lang="en">Webpage names should contain only letters, numbers, hyphens, or underscores.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++091327257429303159b8580005b5b5a1e05fd028030817edaaa835cfcb0b3293">
+      <source xml:lang="en">Website ID: {0}</source>
+      <note>{0} is the website ID</note>
     </trans-unit>
     <trans-unit id="++CODE++aa64cfbb63d3382bc0530c6e599467b1cc5c1ef8ff3b573d37ad628f9058b2aa">
       <source xml:lang="en">Website not found in the environment. Please check the credentials and login with correct account.</source>
@@ -821,6 +836,9 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     </trans-unit>
     <trans-unit id="pacCLI.pacSolutionHelp.title">
       <source xml:lang="en">Show PAC Solution Help</source>
+    </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.siteDetails.title">
+      <source xml:lang="en">Site Details</source>
     </trans-unit>
     <trans-unit id="microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite.title">
       <source xml:lang="en">Upload Site</source>

--- a/package.json
+++ b/package.json
@@ -439,6 +439,10 @@
       {
         "command": "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite",
         "title": "%microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite.title%"
+      },
+      {
+        "command": "microsoft.powerplatform.pages.actionsHub.siteDetails",
+        "title": "%microsoft.powerplatform.pages.actionsHub.siteDetails.title%"
       }
     ],
     "configuration": {
@@ -923,6 +927,10 @@
         {
           "command": "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite",
           "when": "never"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.siteDetails",
+          "when": "never"
         }
       ],
       "view/title": [
@@ -1075,6 +1083,11 @@
           "command": "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite",
           "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite)",
           "group": "activeSiteContextMenuGroup@1"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.siteDetails",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == nonCurrentActiveSite || viewItem == inactiveSite)",
+          "group": "siteDetailsContextMenuGroup@1"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -1057,37 +1057,37 @@
         {
           "command": "microsoft.powerplatform.pages.actionsHub.activeSite.preview",
           "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == nonCurrentActiveSite)",
-          "group": "activeSiteContextMenuGroup@1"
+          "group": "siteAction@1"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isWindows",
-          "group": "activeSiteContextMenuGroup@2"
+          "group": "siteAction@5"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isMac",
-          "group": "activeSiteContextMenuGroup@2"
+          "group": "siteAction@5"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isLinux",
-          "group": "activeSiteContextMenuGroup@2"
+          "group": "siteAction@5"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.inactiveSite.openSiteManagement",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == inactiveSite",
-          "group": "inactiveSiteContextMenuGroup@1"
+          "group": "siteAction@3"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite",
           "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite)",
-          "group": "activeSiteContextMenuGroup@1"
+          "group": "siteAction@2"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.siteDetails",
           "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == nonCurrentActiveSite || viewItem == inactiveSite)",
-          "group": "siteDetailsContextMenuGroup@1"
+          "group": "siteAction@4"
         }
       ]
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -110,5 +110,6 @@
   "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac.title": "Reveal in Finder",
   "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux.title": "Open Containing Folder",
   "microsoft.powerplatform.pages.actionsHub.inactiveSite.openSiteManagement.title": "Open site management",
-  "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite.title": "Upload Site"
+  "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite.title": "Upload Site",
+  "microsoft.powerplatform.pages.actionsHub.siteDetails.title": "Site Details"
 }

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -66,7 +66,7 @@ export const showEnvironmentDetails = async () => {
 
         const result = await vscode.window.showInformationMessage(message, { detail: details, modal: true }, Constants.Strings.COPY_TO_CLIPBOARD);
 
-        if (result == Constants.Strings.COPY_TO_CLIPBOARD) {
+        if (result === Constants.Strings.COPY_TO_CLIPBOARD) {
             await vscode.env.clipboard.writeText(details);
         }
     } catch (error) {
@@ -258,4 +258,19 @@ export const uploadSite = async (siteTreeItem: SiteTreeItem) => {
     const websitePath = CurrentSiteContext.currentSiteFolderPath;
     const modelVersion = siteTreeItem.siteInfo.dataModelVersion;
     PacTerminal.getTerminal().sendText(`pac pages upload --path "${websitePath}" --modelVersion "${modelVersion}"`);
+}
+
+export const showSiteDetails = async (siteTreeItem: SiteTreeItem) => {
+    const siteInfo = siteTreeItem.siteInfo;
+    const details = [
+        vscode.l10n.t({ message: "Friendly name: {0}", args: [siteInfo.name], comment: "{0} is the website name" }),
+        vscode.l10n.t({ message: "Website ID: {0}", args: [siteInfo.websiteId], comment: "{0} is the website ID" }),
+        vscode.l10n.t({ message: "Data model version: v{0}", args: [siteInfo.dataModelVersion], comment: "{0} is the data model version" })
+    ].join('\n');
+
+    const result = await vscode.window.showInformationMessage(Constants.Strings.SITE_DETAILS, { detail: details, modal: true }, Constants.Strings.COPY_TO_CLIPBOARD);
+
+    if (result === Constants.Strings.COPY_TO_CLIPBOARD) {
+        await vscode.env.clipboard.writeText(details);
+    }
 }

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -233,7 +233,12 @@ export const revealInOS = async () => {
 export const openSiteManagement = async (siteTreeItem: SiteTreeItem) => {
     if (!siteTreeItem.siteInfo.siteManagementUrl) {
         vscode.window.showErrorMessage(vscode.l10n.t(Constants.Strings.SITE_MANAGEMENT_URL_NOT_FOUND));
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND, Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND, new Error(Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND), { method: openSiteManagement.name });
+        oneDSLoggerWrapper.getLogger().traceError(
+            Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND,
+            Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND,
+            new Error(Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND),
+            { method: openSiteManagement.name }
+        );
         return;
     }
     await vscode.env.openExternal(vscode.Uri.parse(siteTreeItem.siteInfo.siteManagementUrl));

--- a/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
@@ -11,7 +11,7 @@ import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLo
 import { EnvironmentGroupTreeItem } from "./tree-items/EnvironmentGroupTreeItem";
 import { IEnvironmentInfo } from "./models/IEnvironmentInfo";
 import { PacTerminal } from "../../lib/PacTerminal";
-import { fetchWebsites, openActiveSitesInStudio, openInactiveSitesInStudio, previewSite, createNewAuthProfile, refreshEnvironment, showEnvironmentDetails, switchEnvironment, revealInOS, openSiteManagement, uploadSite } from "./ActionsHubCommandHandlers";
+import { fetchWebsites, openActiveSitesInStudio, openInactiveSitesInStudio, previewSite, createNewAuthProfile, refreshEnvironment, showEnvironmentDetails, switchEnvironment, revealInOS, openSiteManagement, uploadSite, showSiteDetails } from "./ActionsHubCommandHandlers";
 import PacContext from "../../pac/PacContext";
 import CurrentSiteContext from "./CurrentSiteContext";
 import { IWebsiteDetails } from "../../../common/services/Interfaces";
@@ -122,7 +122,9 @@ export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<Actio
 
             vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.inactiveSite.openSiteManagement", openSiteManagement),
 
-            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite", uploadSite)
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite", uploadSite),
+
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.siteDetails", showSiteDetails)
         ];
     }
 }

--- a/src/client/power-pages/actions-hub/Constants.ts
+++ b/src/client/power-pages/actions-hub/Constants.ts
@@ -36,6 +36,7 @@ export const Constants = {
         SITE_MANAGEMENT_URL_NOT_FOUND: vscode.l10n.t("Site management URL not found for the selected site. Please try again after refreshing the environment."),
         SITE_UPLOAD_CONFIRMATION: vscode.l10n.t(`Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?`),
         YES: vscode.l10n.t("Yes"),
+        SITE_DETAILS: vscode.l10n.t("Site Details")
     },
     EventNames: {
         ACTIONS_HUB_INITIALIZED: "actionsHubInitialized",

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS, uploadSite } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
+import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS, uploadSite, showSiteDetails } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
 import { Constants } from '../../../../power-pages/actions-hub/Constants';
 import { oneDSLoggerWrapper } from '../../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper';
 import * as CommonUtils from '../../../../power-pages/commonUtility';
@@ -735,6 +735,7 @@ describe('ActionsHubCommandHandlers', () => {
             await revealInOS(); expect(executeCommandStub.calledOnceWith('revealFileInOS', vscode.Uri.file(mockPath))).to.be.true;
         });
     });
+
     describe('uploadSite', () => {
         let mockSendText: sinon.SinonStub;
         let mockSiteTreeItem: SiteTreeItem;
@@ -791,4 +792,66 @@ describe('ActionsHubCommandHandlers', () => {
 
     });
 
+    describe('showSiteDetails', () => {
+        it('should show information notification', async () => {
+            mockShowInformationMessage.resolves(Constants.Strings.COPY_TO_CLIPBOARD);
+
+            await showSiteDetails({ siteInfo: {
+                name: "Test Site",
+                websiteId: "test-id",
+                dataModelVersion: 1
+            } as IWebsiteInfo } as SiteTreeItem);
+
+            expect(mockShowInformationMessage.calledOnce).to.be.true;
+        });
+
+        it('should have expected heading', async () => {
+            mockShowInformationMessage.resolves(Constants.Strings.COPY_TO_CLIPBOARD);
+
+            await showSiteDetails({
+                siteInfo: {
+                    name: "Test Site",
+                    websiteId: "test-id",
+                    dataModelVersion: 1
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            const message = mockShowInformationMessage.firstCall.args[0];
+            expect(message).to.include("Site Details");
+        });
+
+        it('should be rendered as modal', async () => {
+            mockShowInformationMessage.resolves(Constants.Strings.COPY_TO_CLIPBOARD);
+
+            await showSiteDetails({
+                siteInfo: {
+                    name: "Test Site",
+                    websiteId: "test-id",
+                    dataModelVersion: 1
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            const message = mockShowInformationMessage.firstCall.args[1];
+            expect(message.modal).to.be.true;
+        });
+
+        it('should show site details', async () => {
+            mockShowInformationMessage.resolves(Constants.Strings.COPY_TO_CLIPBOARD);
+
+            await showSiteDetails({
+                siteInfo: {
+                    name: "Test Site",
+                    websiteId: "test-id",
+                    dataModelVersion: 1
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            expect(mockShowInformationMessage.calledOnce).to.be.true;
+
+            const message = mockShowInformationMessage.firstCall.args[1].detail;
+            expect(message).to.include("Friendly name: Test Site");
+            expect(message).to.include("Website ID: test-id");
+            expect(message).to.include("Data model version: v1");
+        });
+    });
 });

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS, uploadSite, showSiteDetails } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
+import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS, uploadSite, showSiteDetails, openSiteManagement } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
 import { Constants } from '../../../../power-pages/actions-hub/Constants';
 import { oneDSLoggerWrapper } from '../../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper';
 import * as CommonUtils from '../../../../power-pages/commonUtility';
@@ -733,6 +733,72 @@ describe('ActionsHubCommandHandlers', () => {
             const mockPath = 'test-path';
             sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => mockPath);
             await revealInOS(); expect(executeCommandStub.calledOnceWith('revealFileInOS', vscode.Uri.file(mockPath))).to.be.true;
+        });
+    });
+
+    describe('openSiteManagement', () => {
+        let mockUrl: sinon.SinonSpy;
+
+        beforeEach(() => {
+            mockUrl = sandbox.spy(vscode.Uri, 'parse');
+            sandbox.stub(vscode.env, 'openExternal');
+        });
+
+        it('should open site management URL when available', async () => {
+            await openSiteManagement({
+                siteInfo: {
+                    name: "Test Site",
+                    websiteId: "test-id",
+                    dataModelVersion: 1,
+                    status: WebsiteStatus.Active,
+                    websiteUrl: 'https://test-site.com',
+                    isCurrent: false,
+                    siteVisibility: Constants.SiteVisibility.PRIVATE,
+                    siteManagementUrl: "https://test-site-management.com"
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            expect(mockUrl.calledOnce).to.be.true;
+            expect(mockUrl.firstCall.args[0]).to.equal('https://test-site-management.com');
+        });
+
+        it('should show error message when site management URL is not available', async () => {
+            const mockErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage');
+
+            await openSiteManagement({
+                siteInfo: {
+                    name: "Test Site",
+                    websiteId: "test-id",
+                    dataModelVersion: 1,
+                    status: WebsiteStatus.Active,
+                    websiteUrl: 'https://test-site.com',
+                    isCurrent: false,
+                    siteVisibility: Constants.SiteVisibility.PRIVATE
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            expect(mockErrorMessage.calledOnce).to.be.true;
+            expect(mockErrorMessage.firstCall.args[0]).to.equal(Constants.Strings.SITE_MANAGEMENT_URL_NOT_FOUND);
+        });
+
+        it('should show log error when site management URL is not available', async () => {
+            sandbox.stub(vscode.window, 'showErrorMessage');
+
+            await openSiteManagement({
+                siteInfo: {
+                    name: "Test Site",
+                    websiteId: "test-id",
+                    dataModelVersion: 1,
+                    status: WebsiteStatus.Active,
+                    websiteUrl: 'https://test-site.com',
+                    isCurrent: false,
+                    siteVisibility: Constants.SiteVisibility.PRIVATE
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            expect(traceErrorStub.firstCall.args[0]).to.equal(Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND);
+            expect(traceErrorStub.firstCall.args[1]).to.equal(Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND);
+            expect(traceErrorStub.firstCall.args[3]).to.deep.equal({ method: openSiteManagement.name });
         });
     });
 

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -179,6 +179,18 @@ describe("ActionsHubTreeDataProvider", () => {
             await registerCommandStub.getCall(11).args[1]();
             expect(mockCommandHandler.calledOnce).to.be.true;
         });
+
+        it("should register siteDetails command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'showSiteDetails');
+            mockCommandHandler.resolves();
+            const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            actionsHubTreeDataProvider["registerPanel"](pacTerminal);
+
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.siteDetails")).to.be.true;
+
+            await registerCommandStub.getCall(12).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
+        });
     });
 
     describe('getTreeItem', () => {


### PR DESCRIPTION
1. Introduce a new command for displaying site details, including friendly name, website ID, and data model version.

2. Implement error handling for the site management URL and add corresponding tests.

### Feature in action
![Site details](https://github.com/user-attachments/assets/e6f4f1f0-371f-461a-b92b-fb8d578fa895)
