### PR TITLE
[POC] Pages Metadata Diff Tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1141,6 +1141,14 @@
           "icon": "./src/client/assets/powerPages.svg",
           "contextualTitle": "%microsoft.powerplatform.pages.actionsHub.title%",
           "visibility": "visible"
+        },
+        {
+          "id": "microsoft.powerplatform.pages.metadataDiff",
+          "name": "%microsoft.powerplatform.pages.metadataDiff.title%",
+          "when": "microsoft.powerplatform.pages.metadataDiffEnabled",
+          "icon": "./src/client/assets/powerPages.svg",
+          "contextualTitle": "%microsoft.powerplatform.pages.metadataDiff.title%",
+          "visibility": "visible"
         }
       ]
     },

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -47,6 +47,8 @@ import { ActionsHub } from "./power-pages/actions-hub/ActionsHub";
 import { extractAuthInfo, extractOrgInfo } from "./power-pages/commonUtility";
 import PacContext from "./pac/PacContext";
 import ArtemisContext from "./ArtemisContext";
+import { MetadataDiff } from "../common/power-pages/metadata-diff/MetadataDiff";
+import { MetadataDiffTreeDataProvider } from "../common/power-pages/metadata-diff/MetadataDiffTreeDataProvider";
 
 let client: LanguageClient;
 let _context: vscode.ExtensionContext;
@@ -259,6 +261,8 @@ export async function activate(
 
     const workspaceFolderWatcher = vscode.workspace.onDidChangeWorkspaceFolders(handleWorkspaceFolderChange);
     _context.subscriptions.push(workspaceFolderWatcher);
+
+    MetadataDiff.initialize(context)
 
     if (shouldEnableDebugger()) {
         activateDebugger(context);

--- a/src/common/ecs-features/ecsFeatureGates.ts
+++ b/src/common/ecs-features/ecsFeatureGates.ts
@@ -68,3 +68,13 @@ export const {
         enableActionsHub: false,
     },
 });
+
+export const {
+    feature: EnableMetadataDiff
+} = getFeatureConfigs({
+    teamName: PowerPagesClientName,
+    description: 'Enable Metadata Diff comparison in VS Code',
+    fallback: {
+        enableMetadataDiff: false,
+    },
+});

--- a/src/common/power-pages/metadata-diff/Constants.ts
+++ b/src/common/power-pages/metadata-diff/Constants.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+export const Constants = {
+    EventNames: {
+        METADATA_DIFF_INITIALIZED: "metadataDiffInitialized",
+        METADATA_DIFF_INITIALIZATION_FAILED: "metadataDiffInitializationFailed",
+        METADATA_DIFF_CURRENT_ENV_FETCH_FAILED: "metadataDiffCurrentEnvFetchFailed",
+    }
+};

--- a/src/common/power-pages/metadata-diff/MetadataDiff.ts
+++ b/src/common/power-pages/metadata-diff/MetadataDiff.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { ECSFeaturesClient } from "../../ecs-features/ecsFeatureClient";
+import { EnableMetadataDiff } from "../../ecs-features/ecsFeatureGates";
+import { MetadataDiffTreeDataProvider } from "./MetadataDiffTreeDataProvider";
+import { oneDSLoggerWrapper } from "../../OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { Constants } from "./Constants";
+
+export class MetadataDiff {
+    private static _isInitialized = false;
+
+    static isEnabled(): boolean {
+        const enableMetadataDiff = ECSFeaturesClient.getConfig(EnableMetadataDiff).enableMetadataDiff
+
+        if (enableMetadataDiff === undefined) {
+            return false;
+        }
+
+        return enableMetadataDiff;
+    }
+
+    static async initialize(context: vscode.ExtensionContext): Promise<void> {
+        if (MetadataDiff._isInitialized) {
+            return;
+        }
+
+        try {
+            const isMetadataDiffEnabled = MetadataDiff.isEnabled();
+
+            oneDSLoggerWrapper.getLogger().traceInfo("EnableMetadataDiff", {
+                isEnabled: isMetadataDiffEnabled.toString()
+            });
+
+            vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.metadataDiffEnabled", isMetadataDiffEnabled);
+
+            if (!isMetadataDiffEnabled) {
+                return;
+            }
+            const treeDataProvider = MetadataDiffTreeDataProvider.initialize(context);
+            context.subscriptions.push(
+                vscode.window.registerTreeDataProvider("microsoft.powerplatform.pages.metadataDiff", treeDataProvider)
+            );
+
+            MetadataDiff._isInitialized = true;
+            oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.METADATA_DIFF_INITIALIZED);
+        } catch (exception) {
+            const exceptionError = exception as Error;
+            oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.METADATA_DIFF_INITIALIZATION_FAILED, exceptionError.message, exceptionError);
+        }
+    }
+}

--- a/src/common/power-pages/metadata-diff/MetadataDiffTreeDataProvider.ts
+++ b/src/common/power-pages/metadata-diff/MetadataDiffTreeDataProvider.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { MetadataDiffTreeItem } from "./tree-items/MetadataDiffTreeItem";
+import { Constants } from "./Constants";
+import { oneDSLoggerWrapper } from "../../OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { MetadataDiffFileItem } from "./tree-items/MetadataDiffFileItem";
+import { MetadataDiffFolderItem } from "./tree-items/MetadataDiffFolderItem";
+
+export class MetadataDiffTreeDataProvider implements vscode.TreeDataProvider<MetadataDiffTreeItem> {
+    private readonly _disposables: vscode.Disposable[] = [];
+    private readonly _context: vscode.ExtensionContext;
+    private _onDidChangeTreeData: vscode.EventEmitter<MetadataDiffTreeItem | undefined | void> = new vscode.EventEmitter<MetadataDiffTreeItem | undefined | void>();
+    readonly onDidChangeTreeData: vscode.Event<MetadataDiffTreeItem | undefined | void> = this._onDidChangeTreeData.event;
+
+    private constructor(context: vscode.ExtensionContext) {
+        this._context = context;
+    }
+
+    private refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    public static initialize(context: vscode.ExtensionContext): MetadataDiffTreeDataProvider {
+        return new MetadataDiffTreeDataProvider(context);
+    }
+
+    getTreeItem(element: MetadataDiffTreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+
+    private getAllFilesRecursively(dir: string, fileList: string[] = []): string[] {
+        const files = fs.readdirSync(dir);
+
+        for (const file of files) {
+            const fullPath = path.join(dir, file);
+            if (fs.statSync(fullPath).isDirectory()) {
+                this.getAllFilesRecursively(fullPath, fileList);
+            } else {
+                fileList.push(fullPath);
+            }
+        }
+
+        return fileList;
+    }
+
+    private async getDiffFilesWithMockChanges(): Promise<string[]> {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders) {
+            return [];
+        }
+
+        const workspacePath = workspaceFolders[0].uri.fsPath;
+        const storagePath = this._context.storageUri?.fsPath;
+        if (!storagePath) {
+            return [];
+        }
+
+        const diffFiles: string[] = [];
+        const allFiles = this.getAllFilesRecursively(workspacePath);
+
+        // Create copies in storagePath if they don't exist
+        for (const file of allFiles) {
+            const relativePath = path.relative(workspacePath, file);
+            const storageFile = path.join(storagePath, relativePath);
+
+            // Ensure directory exists
+            fs.mkdirSync(path.dirname(storageFile), { recursive: true });
+
+            if (!fs.existsSync(storageFile)) {
+                fs.copyFileSync(file, storageFile);
+            }
+        }
+
+        // Mock a random file change
+        const randomFile = allFiles[Math.floor(Math.random() * allFiles.length)];
+        fs.writeFileSync(path.join(storagePath, path.relative(workspacePath, randomFile)), "");
+
+        // Compare files
+        for (const file of allFiles) {
+            const relativePath = path.relative(workspacePath, file);
+            const storageFile = path.join(storagePath, relativePath);
+
+            if (fs.existsSync(storageFile)) {
+                const workspaceContent = fs.readFileSync(file, "utf8");
+                const storageContent = fs.readFileSync(storageFile, "utf8");
+
+                if (workspaceContent !== storageContent) {
+                    diffFiles.push(relativePath);
+                }
+            } else {
+                diffFiles.push(relativePath);
+            }
+        }
+
+        return diffFiles;
+    }
+
+    async getChildren(element?: MetadataDiffTreeItem): Promise<MetadataDiffTreeItem[] | null | undefined> {
+        if (element) {
+            return element.getChildren();
+        }
+
+        try {
+            const diffFiles = await this.getDiffFilesWithMockChanges();
+            if (diffFiles.length === 0) {
+                return [];
+            }
+
+            const filePathMap = new Map<string, string>();
+
+            diffFiles.forEach(relativePath => {
+                const storedFileUri = vscode.Uri.joinPath(this._context.storageUri!, relativePath);
+                filePathMap.set(relativePath, storedFileUri.fsPath);
+            });
+
+            return this.buildTreeHierarchy(filePathMap);
+        } catch (error) {
+            oneDSLoggerWrapper.getLogger().traceError(
+                Constants.EventNames.METADATA_DIFF_CURRENT_ENV_FETCH_FAILED,
+                error as string,
+                error as Error,
+                { methodName: this.getChildren },
+                {}
+            );
+            return null;
+        }
+    }
+
+    private buildTreeHierarchy(filePathMap: Map<string, string>): MetadataDiffTreeItem[] {
+        const rootItems: Map<string, MetadataDiffTreeItem> = new Map();
+        const workspaceRoot = vscode.workspace.workspaceFolders![0].uri.fsPath;
+
+        filePathMap.forEach((storedFilePath, relativePath) => {
+            const parts = relativePath.split(path.sep);
+            let currentLevel = rootItems;
+            let parentItem: MetadataDiffTreeItem | undefined;
+
+            for (let i = 0; i < parts.length; i++) {
+                const isFile = i === parts.length - 1;
+                const name = parts[i];
+
+                if (!currentLevel.has(name)) {
+                    let newItem: MetadataDiffTreeItem;
+
+                    if (isFile) {
+                        const absoluteWorkspaceFilePath = path.join(workspaceRoot, relativePath);
+                        newItem = new MetadataDiffFileItem(name, absoluteWorkspaceFilePath, storedFilePath);
+                    } else {
+                        newItem = new MetadataDiffFolderItem(name);
+                    }
+
+                    if (parentItem) {
+                        (parentItem as MetadataDiffFolderItem).getChildrenMap().set(name, newItem);
+                    }
+
+                    currentLevel.set(name, newItem);
+                }
+
+                parentItem = currentLevel.get(name);
+                if (!isFile) {
+                    currentLevel = (parentItem as MetadataDiffFolderItem).getChildrenMap();
+                }
+            }
+        });
+
+        return Array.from(rootItems.values());
+    }
+}

--- a/src/common/power-pages/metadata-diff/tree-items/MetadataDiffFileItem.ts
+++ b/src/common/power-pages/metadata-diff/tree-items/MetadataDiffFileItem.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { MetadataDiffTreeItem } from "./MetadataDiffTreeItem";
+
+export class MetadataDiffFileItem extends MetadataDiffTreeItem {
+    constructor(label: string, workspaceFilePath: string, storedFilePath: string) {
+        super(label, vscode.TreeItemCollapsibleState.None, "file", workspaceFilePath);
+
+        const workspaceUri = vscode.Uri.file(workspaceFilePath);
+        const storedUri = vscode.Uri.file(storedFilePath);
+
+        this.resourceUri = workspaceUri;
+        this.command = {
+            command: "vscode.diff",
+            title: "Compare Changes",
+            arguments: [storedUri, workspaceUri, `Diff: ${label}`]
+        };
+        this.iconPath = new vscode.ThemeIcon("file");
+    }
+}

--- a/src/common/power-pages/metadata-diff/tree-items/MetadataDiffFolderItem.ts
+++ b/src/common/power-pages/metadata-diff/tree-items/MetadataDiffFolderItem.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { MetadataDiffTreeItem } from "./MetadataDiffTreeItem";
+
+export class MetadataDiffFolderItem extends MetadataDiffTreeItem {
+    constructor(label: string) {
+        super(label, vscode.TreeItemCollapsibleState.Collapsed, "folder");
+        this.iconPath = new vscode.ThemeIcon("folder");
+    }
+}

--- a/src/common/power-pages/metadata-diff/tree-items/MetadataDiffTreeItem.ts
+++ b/src/common/power-pages/metadata-diff/tree-items/MetadataDiffTreeItem.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+
+export abstract class MetadataDiffTreeItem extends vscode.TreeItem {
+    protected _children: Map<string, MetadataDiffTreeItem> = new Map();
+
+    constructor(
+        public readonly label: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly contextValue: string,
+        public readonly filePath?: string, // Workspace file path
+        public readonly storedFilePath?: string // Backup copy path
+    ) {
+        super(label, collapsibleState);
+        this.tooltip = this.label;
+
+        if (filePath && storedFilePath) {
+            this.command = {
+                command: "metadataDiff.openDiff",
+                title: "Open Diff",
+                arguments: [filePath, storedFilePath] // Pass file paths to the command
+            };
+        }
+    }
+
+    public getChildren(): MetadataDiffTreeItem[] {
+        return Array.from(this._children.values());
+    }
+
+    public getChildrenMap(): Map<string, MetadataDiffTreeItem> {
+        return this._children;
+    }
+}


### PR DESCRIPTION
The staged code introduces a new feature called "Metadata Diff" for the Power Platform VS Code extension. Here's a concise review:

What's Added?

Feature Gate (ecsFeatureGates.ts):

Adds a new feature flag EnableMetadataDiff to control the availability of the Metadata Diff feature.
Constants (Constants.ts):

Defines telemetry event names for initialization and error handling related to Metadata Diff.
Metadata Diff Initialization (MetadataDiff.ts):

Initializes the Metadata Diff feature based on the ECS feature flag.
Sets VS Code context (microsoft.powerplatform.pages.metadataDiffEnabled) to control UI visibility.
Logs telemetry events for initialization success or failure.
Tree Data Provider (MetadataDiffTreeDataProvider.ts):

Implements a VS Code Tree Data Provider to display file differences.
Recursively scans workspace files, creates backup copies, and mocks file changes for testing.
Builds a hierarchical tree structure representing changed files and folders.
Tree Items (MetadataDiffTreeItem.ts, MetadataDiffFileItem.ts, MetadataDiffFolderItem.ts):

Defines abstract and concrete classes for tree items representing files and folders.
Implements commands to open file diffs using VS Code's built-in diff viewer.
Extension Activation (extension.ts):

Registers the Metadata Diff Tree Data Provider with VS Code.
Initializes the Metadata Diff feature during extension activation.
Localization (package.nls.json, bundle.l10n.json):

Adds localized strings for the Metadata Diff feature.
Package Manifest (package.json):

Registers the new Metadata Diff view in the VS Code explorer.