### PR TITLE
[Power Pages] [Actions Hub] Add download site command to Actions Hub

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -196,6 +196,9 @@
   "Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?": "Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?",
   "Yes": "Yes",
   "Site Details": "Site Details",
+  "Browse...": "Browse...",
+  "Select the folder that will contain your project root for your site": "Select the folder that will contain your project root for your site",
+  "Select Folder": "Select Folder",
   "Timestamp: {0}/{0} is the timestamp": {
     "message": "Timestamp: {0}",
     "comment": [

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -63,6 +63,9 @@
     <trans-unit id="++CODE++6fab20ee9c8b4cb1fa10d787f3cd4eac13d34d27050fd193162a2399f690f59c">
       <source xml:lang="en">Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?</source>
     </trans-unit>
+    <trans-unit id="++CODE++c58a6bd402efb06c3e7dfd6d68910412fee2dfc1788ae384dc123089ce912285">
+      <source xml:lang="en">Browse...</source>
+    </trans-unit>
     <trans-unit id="++CODE++19766ed6ccb2f4a32778eed80d1928d2c87a18d7c275ccb163ec6709d3eb2e27">
       <source xml:lang="en">Cancel</source>
     </trans-unit>
@@ -461,6 +464,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++0134bc37f2fdeb11daa9e760ecee0ef9706989b33f77a38daadb8b7aae685749">
       <source xml:lang="en">Saving your file ...</source>
     </trans-unit>
+    <trans-unit id="++CODE++e597da9c984517f802536a83c825cd4f017898c5f28030fe1f62fb94f5228828">
+      <source xml:lang="en">Select Folder</source>
+    </trans-unit>
     <trans-unit id="++CODE++6e26632772595a9d2fdf17191f6d7b59983c308d884deed6ba317054f7d30688">
       <source xml:lang="en">Select Folder for new PCF Control</source>
       <note>Do not translate 'PCF' as it is a product name.</note>
@@ -470,6 +476,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     </trans-unit>
     <trans-unit id="++CODE++87468e6a845b82466220c11dd0ca315a4389dc1cb8e0ee102035bb4ce5cb7e39">
       <source xml:lang="en">Select an environment</source>
+    </trans-unit>
+    <trans-unit id="++CODE++26297069e403c73e147151f2964757b7e9149762cf3a8e04ffd833907fb979e4">
+      <source xml:lang="en">Select the folder that will contain your project root for your site</source>
     </trans-unit>
     <trans-unit id="++CODE++4d6f03fa73020c945e651c34d40c5529f3477ac02df254c1764a68d576575e14">
       <source xml:lang="en">Selection is empty.</source>
@@ -694,6 +703,9 @@ The fifth line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.s
     </trans-unit>
     <trans-unit id="pacCLI.openDocumentation.title">
       <source xml:lang="en">Documentation</source>
+    </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite.title">
+      <source xml:lang="en">Download Site</source>
     </trans-unit>
     <trans-unit id="microsoft-powerapps-portals.walkthrough.title">
       <source xml:lang="en">Edit Power Pages code</source>

--- a/package.json
+++ b/package.json
@@ -443,6 +443,10 @@
       {
         "command": "microsoft.powerplatform.pages.actionsHub.siteDetails",
         "title": "%microsoft.powerplatform.pages.actionsHub.siteDetails.title%"
+      },
+      {
+        "command": "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite",
+        "title": "%microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite.title%"
       }
     ],
     "configuration": {
@@ -931,6 +935,10 @@
         {
           "command": "microsoft.powerplatform.pages.actionsHub.siteDetails",
           "when": "never"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite",
+          "when": "never"
         }
       ],
       "view/title": [
@@ -1060,6 +1068,21 @@
           "group": "siteAction@1"
         },
         {
+          "command": "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite)",
+          "group": "siteAction@2"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == nonCurrentActiveSite)",
+          "group": "siteAction@3"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.siteDetails",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == nonCurrentActiveSite || viewItem == inactiveSite)",
+          "group": "siteAction@4"
+        },
+        {
           "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isWindows",
           "group": "siteAction@5"
@@ -1078,16 +1101,6 @@
           "command": "microsoft.powerplatform.pages.actionsHub.inactiveSite.openSiteManagement",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == inactiveSite",
           "group": "siteAction@3"
-        },
-        {
-          "command": "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite",
-          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite)",
-          "group": "siteAction@2"
-        },
-        {
-          "command": "microsoft.powerplatform.pages.actionsHub.siteDetails",
-          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == nonCurrentActiveSite || viewItem == inactiveSite)",
-          "group": "siteAction@4"
         }
       ]
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -111,5 +111,6 @@
   "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux.title": "Open Containing Folder",
   "microsoft.powerplatform.pages.actionsHub.inactiveSite.openSiteManagement.title": "Open site management",
   "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite.title": "Upload Site",
-  "microsoft.powerplatform.pages.actionsHub.siteDetails.title": "Site Details"
+  "microsoft.powerplatform.pages.actionsHub.siteDetails.title": "Site Details",
+  "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite.title": "Download Site"
 }

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -382,7 +382,7 @@ export const showSiteDetails = async (siteTreeItem: SiteTreeItem) => {
     }
 }
 
-const getDownloadFolderOptions = async () => {
+const getDownloadFolderOptions = () => {
     const options = [
         {
             label: Constants.Strings.BROWSE,

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -26,6 +26,7 @@ import { getActiveWebsites, getAllWebsites } from '../../../common/utilities/Web
 import CurrentSiteContext from './CurrentSiteContext';
 import path from 'path';
 import { getWebsiteRecordId } from '../../../common/utilities/WorkspaceInfoFinderUtil';
+import { IWebsiteInfo } from './models/IWebsiteInfo';
 
 export const refreshEnvironment = async (pacTerminal: PacTerminal) => {
     const pacWrapper = pacTerminal.getWrapper();
@@ -379,4 +380,77 @@ export const showSiteDetails = async (siteTreeItem: SiteTreeItem) => {
     if (result === Constants.Strings.COPY_TO_CLIPBOARD) {
         await vscode.env.clipboard.writeText(details);
     }
+}
+
+const getDownloadFolderOptions = async () => {
+    const options = [
+        {
+            label: Constants.Strings.BROWSE,
+            iconPath: new vscode.ThemeIcon("folder")
+        }
+    ] as { label: string, iconPath: vscode.ThemeIcon | undefined }[];
+
+    if (CurrentSiteContext.currentSiteFolderPath) {
+        options.push({
+            label: path.dirname(CurrentSiteContext.currentSiteFolderPath),
+            iconPath: undefined
+        });
+    }
+
+    return options;
+}
+
+const getDownloadPath = async () => {
+    let downloadPath = "";
+    const option = await vscode.window.showQuickPick(getDownloadFolderOptions(), {
+        canPickMany: false,
+        placeHolder: Constants.Strings.SELECT_DOWNLOAD_FOLDER
+    });
+
+    if (option?.label === Constants.Strings.BROWSE) {
+        const folderUri = await vscode.window.showOpenDialog({
+            canSelectFolders: true,
+            canSelectFiles: false,
+            openLabel: Constants.Strings.SELECT_FOLDER,
+            title: Constants.Strings.SELECT_DOWNLOAD_FOLDER
+        });
+
+        if (folderUri && folderUri.length > 0) {
+            downloadPath = folderUri[0].fsPath;
+        }
+    } else {
+        downloadPath = option?.label || "";
+    }
+    return downloadPath;
+}
+
+
+const executeSiteDownloadCommand = (siteInfo: IWebsiteInfo, downloadPath: string) => {
+    const modelVersion = siteInfo.dataModelVersion;
+    const downloadCommandParts = ["pac", "pages", "download"];
+    downloadCommandParts.push("--overwrite");
+    downloadCommandParts.push(`--path "${downloadPath}"`);
+    downloadCommandParts.push(`--webSiteId ${siteInfo.websiteId}`);
+    downloadCommandParts.push(`--modelVersion "${modelVersion}"`);
+
+    const downloadCommand = downloadCommandParts.join(" ");
+
+    PacTerminal.getTerminal().sendText(downloadCommand);
+}
+
+export const downloadSite = async (siteTreeItem: SiteTreeItem) => {
+    let downloadPath = "";
+    const { siteInfo } = siteTreeItem;
+
+    if (siteInfo.isCurrent && CurrentSiteContext.currentSiteFolderPath) {
+        downloadPath = path.dirname(CurrentSiteContext.currentSiteFolderPath);
+    } else {
+        downloadPath = await getDownloadPath();
+    }
+
+    if (!downloadPath) {
+        return;
+    }
+
+    executeSiteDownloadCommand(siteInfo, downloadPath);
 }

--- a/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
@@ -11,7 +11,7 @@ import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLo
 import { EnvironmentGroupTreeItem } from "./tree-items/EnvironmentGroupTreeItem";
 import { IEnvironmentInfo } from "./models/IEnvironmentInfo";
 import { PacTerminal } from "../../lib/PacTerminal";
-import { fetchWebsites, openActiveSitesInStudio, openInactiveSitesInStudio, previewSite, createNewAuthProfile, refreshEnvironment, showEnvironmentDetails, switchEnvironment, revealInOS, openSiteManagement, uploadSite, showSiteDetails } from "./ActionsHubCommandHandlers";
+import { fetchWebsites, openActiveSitesInStudio, openInactiveSitesInStudio, previewSite, createNewAuthProfile, refreshEnvironment, showEnvironmentDetails, switchEnvironment, revealInOS, openSiteManagement, uploadSite, showSiteDetails, downloadSite } from "./ActionsHubCommandHandlers";
 import PacContext from "../../pac/PacContext";
 import CurrentSiteContext from "./CurrentSiteContext";
 import { IOtherSiteInfo, IWebsiteDetails } from "../../../common/services/Interfaces";
@@ -130,7 +130,9 @@ export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<Actio
 
             vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite", uploadSite),
 
-            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.siteDetails", showSiteDetails)
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.siteDetails", showSiteDetails),
+
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite", downloadSite)
         ];
     }
 }

--- a/src/client/power-pages/actions-hub/Constants.ts
+++ b/src/client/power-pages/actions-hub/Constants.ts
@@ -36,7 +36,10 @@ export const Constants = {
         SITE_MANAGEMENT_URL_NOT_FOUND: vscode.l10n.t("Site management URL not found for the selected site. Please try again after refreshing the environment."),
         SITE_UPLOAD_CONFIRMATION: vscode.l10n.t(`Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?`),
         YES: vscode.l10n.t("Yes"),
-        SITE_DETAILS: vscode.l10n.t("Site Details")
+        SITE_DETAILS: vscode.l10n.t("Site Details"),
+        BROWSE: vscode.l10n.t("Browse..."),
+        SELECT_DOWNLOAD_FOLDER: vscode.l10n.t("Select the folder that will contain your project root for your site"),
+        SELECT_FOLDER: vscode.l10n.t("Select Folder")
     },
     EventNames: {
         ACTIONS_HUB_INITIALIZED: "actionsHubInitialized",

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS, uploadSite, createKnownSiteIdsSet, findOtherSites, showSiteDetails, openSiteManagement } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
+import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS, uploadSite, createKnownSiteIdsSet, findOtherSites, showSiteDetails, openSiteManagement, downloadSite } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
 import { Constants } from '../../../../power-pages/actions-hub/Constants';
 import { oneDSLoggerWrapper } from '../../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper';
 import * as CommonUtils from '../../../../power-pages/commonUtility';
@@ -27,6 +27,7 @@ import * as WebsiteUtils from '../../../../../common/utilities/WebsiteUtil';
 import * as Utils from '../../../../../common/utilities/Utils';
 import CurrentSiteContext from '../../../../power-pages/actions-hub/CurrentSiteContext';
 import * as WorkspaceInfoFinderUtil from "../../../../../common/utilities/WorkspaceInfoFinderUtil";
+import path from 'path';
 
 describe('ActionsHubCommandHandlers', () => {
     let sandbox: sinon.SinonSandbox;
@@ -1050,6 +1051,172 @@ describe('ActionsHubCommandHandlers', () => {
             expect(message).to.include("Friendly name: Test Site");
             expect(message).to.include("Website ID: test-id");
             expect(message).to.include("Data model version: v1");
+        });
+    });
+
+    describe('downloadSite', () => {
+        let dirnameSpy: sinon.SinonSpy;
+        let mockSendText: sinon.SinonStub;
+
+        beforeEach(() => {
+            mockSendText = sinon.stub();
+            dirnameSpy = sinon.spy(path, 'dirname');
+            sinon.stub(PacTerminal, 'getTerminal').returns({ sendText: mockSendText } as unknown as vscode.Terminal);
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        describe('when the site is current', () => {
+            it('should download without asking for download path', async () => {
+                sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => "D:/foo/bar");
+                const mockSiteTreeItem = new SiteTreeItem({
+                    isCurrent: true,
+                    websiteId: 'test-id',
+                    dataModelVersion: 2
+                } as IWebsiteInfo);
+
+                await downloadSite(mockSiteTreeItem);
+
+                expect(dirnameSpy.calledOnce).to.be.true;
+                expect(mockSendText.calledOnce).to.be.true;
+                expect(mockSendText.firstCall.args[0]).to.equal('pac pages download --overwrite --path "D:/foo" --webSiteId test-id --modelVersion "2"');
+            });
+        });
+
+        describe('when the site is not current', () => {
+            describe('and there is no current site context', () => {
+                beforeEach(() => {
+                    sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => undefined);
+                });
+
+                it('should only show 1 option in download path quick pick', async () => {
+                    const mockSiteTreeItem = new SiteTreeItem({
+                        isCurrent: false,
+                        websiteId: 'test-id',
+                        dataModelVersion: 2
+                    } as IWebsiteInfo);
+
+                    const mockQuickPick = sinon.stub(vscode.window, 'showQuickPick');
+
+                    await downloadSite(mockSiteTreeItem);
+
+                    expect(mockQuickPick.calledOnce).to.be.true;
+                    const options = mockQuickPick.firstCall.args[0] as { label: string, iconPath: vscode.ThemeIcon }[];
+                    expect(options.length).to.equal(1);
+                    expect(options[0].label).to.equal("Browse...");
+                    expect(mockQuickPick.firstCall.args[1]).to.deep.equal({
+                        canPickMany: false,
+                        placeHolder: Constants.Strings.SELECT_DOWNLOAD_FOLDER
+                    });
+                });
+            });
+
+            describe('but there is a current site context', () => {
+                beforeEach(() => {
+                    sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => "D:/foo/bar");
+                });
+
+                it('should show 2 options in download path quick pick', async () => {
+                    const mockSiteTreeItem = new SiteTreeItem({
+                        isCurrent: false,
+                        websiteId: 'test-id',
+                        dataModelVersion: 2
+                    } as IWebsiteInfo);
+
+                    const mockQuickPick = sinon.stub(vscode.window, 'showQuickPick');
+
+                    await downloadSite(mockSiteTreeItem);
+
+                    expect(mockQuickPick.calledOnce).to.be.true;
+                    const options = mockQuickPick.firstCall.args[0] as vscode.QuickPickItem[];
+                    expect(options.length).to.equal(2);
+                    expect(options[0].label).to.equal("Browse...");
+                    expect(options[1].label).to.equal("D:/foo");
+                    expect(mockQuickPick.firstCall.args[1]).to.deep.equal({
+                        canPickMany: false,
+                        placeHolder: Constants.Strings.SELECT_DOWNLOAD_FOLDER
+                    });
+                });
+
+                it('should download when a path is selected', async () => {
+                    const mockSiteTreeItem = new SiteTreeItem({
+                        isCurrent: false,
+                        websiteId: 'test-id',
+                        dataModelVersion: 2
+                    } as IWebsiteInfo);
+
+                    const mockQuickPick = sinon.stub(vscode.window, 'showQuickPick');
+                    mockQuickPick.resolves({ label: "D:/foo" });
+
+                    await downloadSite(mockSiteTreeItem);
+
+                    expect(mockSendText.calledOnce).to.be.true;
+                    expect(mockSendText.firstCall.args[0]).to.equal('pac pages download --overwrite --path "D:/foo" --webSiteId test-id --modelVersion "2"');
+                });
+
+                it('should show file open dialog when "Browse..." is selected', async () => {
+                    const mockSiteTreeItem = new SiteTreeItem({
+                        isCurrent: false,
+                        websiteId: 'test-id',
+                        dataModelVersion: 2
+                    } as IWebsiteInfo);
+
+                    const mockQuickPick = sinon.stub(vscode.window, 'showQuickPick');
+                    mockQuickPick.resolves({ label: "Browse..." });
+
+                    const mockShowOpenDialog = sinon.stub(vscode.window, 'showOpenDialog');
+                    mockShowOpenDialog.resolves([{ fsPath: "D:/foo" } as unknown as vscode.Uri]);
+
+                    await downloadSite(mockSiteTreeItem);
+
+                    expect(mockShowOpenDialog.calledOnce).to.be.true;
+                    expect(mockShowOpenDialog.firstCall.args[0]).to.deep.equal({
+                        canSelectFolders: true,
+                        canSelectFiles: false,
+                        openLabel: Constants.Strings.SELECT_FOLDER,
+                        title: Constants.Strings.SELECT_DOWNLOAD_FOLDER
+                    });
+                });
+
+                it('should download the site when a path is selected in the file open dialog', async () => {
+                    const mockSiteTreeItem = new SiteTreeItem({
+                        isCurrent: false,
+                        websiteId: 'test-id',
+                        dataModelVersion: 2
+                    } as IWebsiteInfo);
+
+                    const mockQuickPick = sinon.stub(vscode.window, 'showQuickPick');
+                    mockQuickPick.resolves({ label: "Browse..." });
+
+                    const mockShowOpenDialog = sinon.stub(vscode.window, 'showOpenDialog');
+                    mockShowOpenDialog.resolves([{ fsPath: "D:/foo" } as unknown as vscode.Uri]);
+
+                    await downloadSite(mockSiteTreeItem);
+
+                    expect(mockSendText.calledOnce).to.be.true;
+                    expect(mockSendText.firstCall.args[0]).to.equal('pac pages download --overwrite --path "D:/foo" --webSiteId test-id --modelVersion "2"');
+                });
+
+                it('should not download the site when no path is selected in the file open dialog', async () => {
+                    const mockSiteTreeItem = new SiteTreeItem({
+                        isCurrent: false,
+                        websiteId: 'test-id',
+                        dataModelVersion: 2
+                    } as IWebsiteInfo);
+
+                    const mockQuickPick = sinon.stub(vscode.window, 'showQuickPick');
+                    mockQuickPick.resolves({ label: "Browse..." });
+
+                    const mockShowOpenDialog = sinon.stub(vscode.window, 'showOpenDialog');
+                    mockShowOpenDialog.resolves([]);
+
+                    await downloadSite(mockSiteTreeItem);
+
+                    expect(mockSendText.called).to.be.false;
+                });
+            });
         });
     });
 });

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -191,6 +191,18 @@ describe("ActionsHubTreeDataProvider", () => {
             await registerCommandStub.getCall(12).args[1]();
             expect(mockCommandHandler.calledOnce).to.be.true;
         });
+
+        it("should register downloadSite command", async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'downloadSite');
+            mockCommandHandler.resolves();
+            const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            actionsHubTreeDataProvider["registerPanel"](pacTerminal);
+
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite")).to.be.true;
+
+            await registerCommandStub.getCall(13).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
+        });
     });
 
     describe('getTreeItem', () => {


### PR DESCRIPTION
Introduce a new command to download the current site, including user prompts for folder selection and command execution. Update localization strings and register the command in the Actions Hub.

> [!NOTE]
> When the site is `current` then the download location will be automatically picked up. 

## Feature in action
![Download Site](https://github.com/user-attachments/assets/e8cc656d-3b74-4581-a6b6-a49a69150736)
