### PR TITLE
[PowerPages][ActionsHub] Upload functionality for other sites

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -195,6 +195,7 @@
   "Site management URL not found for the selected site. Please try again after refreshing the environment.": "Site management URL not found for the selected site. Please try again after refreshing the environment.",
   "Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?": "Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?",
   "Yes": "Yes",
+  "Current site path not found.": "Current site path not found.",
   "Site Details": "Site Details",
   "Timestamp: {0}/{0} is the timestamp": {
     "message": "Timestamp: {0}",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -139,6 +139,9 @@ The second line should be '[TRANSLATION HERE](https://aka.ms/pages-clear-cache).
     <trans-unit id="++CODE++e0d1b68224bf0b31ef16b206c65b5f8f6b89d18161f4a7cdcb8d0ac8d952549a">
       <source xml:lang="en">Current</source>
     </trans-unit>
+    <trans-unit id="++CODE++fc47ac56c8a4446c02d8470168a888d8e0040cfc0bb5ce6173e324dccc72f24c">
+      <source xml:lang="en">Current site path not found.</source>
+    </trans-unit>
     <trans-unit id="++CODE++1da89bd5f5df020ca47c79dfdbc1517a299ca77570df2de4132f53797d5f2412">
       <source xml:lang="en">Data model version: v{0}</source>
       <note>{0} is the data model version</note>

--- a/package.json
+++ b/package.json
@@ -1073,7 +1073,7 @@
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite",
-          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite)",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == otherSite)",
           "group": "activeSiteContextMenuGroup@1"
         }
       ]

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -26,6 +26,7 @@ import { getActiveWebsites, getAllWebsites } from '../../../common/utilities/Web
 import CurrentSiteContext from './CurrentSiteContext';
 import path from 'path';
 import { getWebsiteRecordId } from '../../../common/utilities/WorkspaceInfoFinderUtil';
+import { isEdmEnvironment } from '../../../common/copilot/dataverseMetadata';
 
 export const refreshEnvironment = async (pacTerminal: PacTerminal) => {
     const pacWrapper = pacTerminal.getWrapper();
@@ -246,10 +247,70 @@ export const openSiteManagement = async (siteTreeItem: SiteTreeItem) => {
     await vscode.env.openExternal(vscode.Uri.parse(siteTreeItem.siteInfo.siteManagementUrl));
 }
 
+/**
+ * Uploads a Power Pages site to the environment
+ * @param siteTreeItem The site tree item containing site information
+ */
 export const uploadSite = async (siteTreeItem: SiteTreeItem) => {
+    try {
+        // Handle upload for "other" sites (sites not in the current environment)
+        if (siteTreeItem.contextValue === Constants.ContextValues.OTHER_SITE) {
+            await uploadOtherSite(siteTreeItem);
+            return;
+        }
 
-    //Show a modal dialog to take confirmation from the user
-    if (siteTreeItem.siteInfo.siteVisibility.toLowerCase() === Constants.SiteVisibility.PUBLIC) {
+        // Handle upload for active/inactive sites
+        await uploadCurrentSite(siteTreeItem);
+    } catch (error) {
+        oneDSLoggerWrapper.getLogger().traceError(
+            Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE_FAILED,
+            error as string,
+            error as Error,
+            { methodName: uploadSite.name }
+        );
+    }
+};
+
+/**
+ * Uploads a site that isn't in the current environment
+ * @param siteTreeItem The site tree item containing site information
+ */
+async function uploadOtherSite(siteTreeItem: SiteTreeItem): Promise<void> {
+    const websitePath = siteTreeItem.siteInfo.folderPath;
+    
+    if (!websitePath) {
+        return;
+    }
+
+    // Check if EDM is supported to determine the correct model version
+    let modelVersionParam = '';
+    const currentOrgUrl = PacContext.OrgInfo?.OrgUrl ?? '';
+    const dataverseAccessToken = await dataverseAuthentication(currentOrgUrl, true);
+    
+    if (dataverseAccessToken) {
+        const isEdmSupported = await isEdmEnvironment(currentOrgUrl, dataverseAccessToken.accessToken);
+        if (isEdmSupported) {
+            modelVersionParam = ' --modelVersion 2';
+        }
+    }
+
+    // Execute the upload command
+    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_OTHER_SITE, { 
+        methodName: uploadSite.name,
+        siteId: siteTreeItem.siteInfo.websiteId,
+        siteName: siteTreeItem.siteInfo.name
+    });
+    
+    PacTerminal.getTerminal().sendText(`pac pages upload --path "${websitePath}" ${modelVersionParam}`);
+}
+
+/**
+ * Uploads a site that's in the current environment
+ * @param siteTreeItem The site tree item containing site information
+ */
+async function uploadCurrentSite(siteTreeItem: SiteTreeItem): Promise<void> {
+    // Public sites require confirmation to prevent accidental deployment
+    if (siteTreeItem.siteInfo.siteVisibility?.toLowerCase() === Constants.SiteVisibility.PUBLIC) {
         const confirm = await vscode.window.showInformationMessage(
             Constants.Strings.SITE_UPLOAD_CONFIRMATION,
             { modal: true },
@@ -257,13 +318,30 @@ export const uploadSite = async (siteTreeItem: SiteTreeItem) => {
         );
 
         if (confirm !== Constants.Strings.YES) {
-            oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE_CANCELLED, { methodName: uploadSite.name });
+            oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE_CANCELLED, { 
+                methodName: uploadSite.name,
+                siteId: siteTreeItem.siteInfo.websiteId,
+                siteName: siteTreeItem.siteInfo.name
+            });
             return;
         }
     }
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE, { methodName: uploadSite.name });
+
     const websitePath = CurrentSiteContext.currentSiteFolderPath;
-    const modelVersion = siteTreeItem.siteInfo.dataModelVersion;
+    if (!websitePath) {
+        vscode.window.showErrorMessage(vscode.l10n.t(Constants.Strings.CURRENT_SITE_PATH_NOT_FOUND));
+        return;
+    }
+
+    const modelVersion = siteTreeItem.siteInfo.dataModelVersion || 1;
+
+    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE, { 
+        methodName: uploadSite.name,
+        siteId: siteTreeItem.siteInfo.websiteId,
+        siteName: siteTreeItem.siteInfo.name,
+        modelVersion: modelVersion.toString()
+    });
+    
     PacTerminal.getTerminal().sendText(`pac pages upload --path "${websitePath}" --modelVersion "${modelVersion}"`);
 }
 

--- a/src/client/power-pages/actions-hub/Constants.ts
+++ b/src/client/power-pages/actions-hub/Constants.ts
@@ -15,7 +15,7 @@ export const Constants = {
         INACTIVE_SITE: "inactiveSite",
         OTHER_SITE: "otherSite",
         OTHER_SITES_GROUP: "otherSitesGroup",
-        NO_SITES: "noSites"
+        NO_SITES: "noSites",
     },
     Icons: {
         SITE: new vscode.ThemeIcon('globe'),
@@ -36,6 +36,7 @@ export const Constants = {
         SITE_MANAGEMENT_URL_NOT_FOUND: vscode.l10n.t("Site management URL not found for the selected site. Please try again after refreshing the environment."),
         SITE_UPLOAD_CONFIRMATION: vscode.l10n.t(`Be careful when you're updating public sites. The changes you make are visible to anyone immediately. Do you want to continue?`),
         YES: vscode.l10n.t("Yes"),
+        CURRENT_SITE_PATH_NOT_FOUND: vscode.l10n.t("Current site path not found."),
     },
     EventNames: {
         ACTIONS_HUB_INITIALIZED: "actionsHubInitialized",
@@ -50,7 +51,9 @@ export const Constants = {
         ACTIONS_HUB_UPLOAD_SITE: "actionsHubUploadSite",
         ACTIONS_HUB_UPLOAD_SITE_CANCELLED: "actionsHubUploadSiteCancelled",
         OTHER_SITES_YAML_PARSE_FAILED: "OtherSitesYamlParseFailed",
-        OTHER_SITES_FILESYSTEM_ERROR: "OtherSitesFilesystemError"
+        OTHER_SITES_FILESYSTEM_ERROR: "OtherSitesFilesystemError",
+        ACTIONS_HUB_UPLOAD_OTHER_SITE: "ActionsHubUploadOtherSite",
+        ACTIONS_HUB_UPLOAD_SITE_FAILED: "ActionsHubUploadSiteFailed",
     },
     StudioEndpoints: {
         TEST: "https://make.test.powerpages.microsoft.com",

--- a/src/client/power-pages/actions-hub/models/IWebsiteInfo.ts
+++ b/src/client/power-pages/actions-hub/models/IWebsiteInfo.ts
@@ -14,4 +14,5 @@ export interface IWebsiteInfo {
     isCurrent: boolean;
     siteVisibility: string;
     siteManagementUrl: string;
+    folderPath?: string;    
 }

--- a/src/client/power-pages/actions-hub/tree-items/OtherSitesGroupTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/OtherSitesGroupTreeItem.ts
@@ -34,7 +34,8 @@ export class OtherSitesGroupTreeItem extends ActionsHubTreeItem {
                 isCurrent: false,
                 websiteUrl: "",
                 siteVisibility: "",
-                siteManagementUrl: ""
+                siteManagementUrl: "",
+                folderPath : site.folderPath
             };
             return new SiteTreeItem(siteInfo);
         });

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -805,23 +805,14 @@ describe('ActionsHubCommandHandlers', () => {
     });
 
 
-        describe('uploadSite', () => {
+    describe('uploadSite', () => {
         let mockSendText: sinon.SinonStub;
         let mockSiteTreeItem: SiteTreeItem;
         let mockShowErrorMessage: sinon.SinonStub;
-        let traceInfoStub: sinon.SinonStub;
 
         beforeEach(() => {
             mockSendText = sinon.stub();
-            mockShowErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage');
-            traceInfoStub = sandbox.stub();
-
-            sandbox.stub(oneDSLoggerWrapper, 'getLogger').returns({
-                traceError: traceErrorStub,
-                traceInfo: traceInfoStub,
-                traceWarning: sinon.stub(),
-                featureUsage: sinon.stub(),
-            });
+            mockShowErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage')
 
             // Set up CurrentSiteContext
             sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => "test-path");
@@ -850,7 +841,7 @@ describe('ActionsHubCommandHandlers', () => {
 
             expect(mockShowInformationMessage.calledOnce).to.be.true;
             expect(mockShowInformationMessage.firstCall.args[0]).to.equal(Constants.Strings.SITE_UPLOAD_CONFIRMATION);
-            expect(traceInfoStub.calledWith(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE)).to.be.true;
+
             expect(mockSendText.calledOnceWith(`pac pages upload --path "test-path" --modelVersion "1"`)).to.be.true;
         });
 
@@ -870,7 +861,6 @@ describe('ActionsHubCommandHandlers', () => {
             await uploadSite(mockSiteTreeItem);
 
             expect(mockShowInformationMessage.calledOnce).to.be.true;
-            expect(traceInfoStub.calledWith(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE_CANCELLED)).to.be.true;
             expect(mockSendText.called).to.be.false;
         });
 
@@ -889,7 +879,6 @@ describe('ActionsHubCommandHandlers', () => {
             await uploadSite(mockSiteTreeItem);
 
             expect(mockShowInformationMessage.called).to.be.false;
-            expect(traceInfoStub.calledWith(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE)).to.be.true;
             expect(mockSendText.calledOnceWith(`pac pages upload --path "test-path" --modelVersion "1"`)).to.be.true;
         });
 
@@ -915,13 +904,6 @@ describe('ActionsHubCommandHandlers', () => {
         it('should show error when current site path is not found', async () => {
             sandbox.restore(); // Reset stubs
             sandbox.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => undefined);
-            mockShowErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage');
-            sandbox.stub(oneDSLoggerWrapper, 'getLogger').returns({
-                traceError: traceErrorStub,
-                traceInfo: sinon.stub(),
-                traceWarning: sinon.stub(),
-                featureUsage: sinon.stub(),
-            });
 
             mockSiteTreeItem = new SiteTreeItem({
                 name: "Test Site",
@@ -972,7 +954,6 @@ describe('ActionsHubCommandHandlers', () => {
 
             expect(mockDataverseAuth.calledOnce).to.be.true;
             expect(mockIsEdmEnvironment.calledOnce).to.be.true;
-            expect(traceInfoStub.calledWith(Constants.EventNames.ACTIONS_HUB_UPLOAD_OTHER_SITE)).to.be.true;
             expect(mockSendText.calledOnceWith(`pac pages upload --path "other-site-path" --modelVersion 2`)).to.be.true;
         });
 

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -27,7 +27,6 @@ import * as WebsiteUtils from '../../../../../common/utilities/WebsiteUtil';
 import * as Utils from '../../../../../common/utilities/Utils';
 import CurrentSiteContext from '../../../../power-pages/actions-hub/CurrentSiteContext';
 import * as WorkspaceInfoFinderUtil from "../../../../../common/utilities/WorkspaceInfoFinderUtil";
-import * as dataverseMetadata from "../../../../../common/copilot/dataverseMetadata";
 
 describe('ActionsHubCommandHandlers', () => {
     let sandbox: sinon.SinonSandbox;
@@ -897,41 +896,6 @@ describe('ActionsHubCommandHandlers', () => {
 
             expect(mockShowInformationMessage.calledOnce).to.be.true;
             expect(mockSendText.calledOnceWith(`pac pages upload --path "test-path" --modelVersion "1"`)).to.be.true;
-        });
-
-        it('should handle upload for other sites', async () => {
-            // Create a mock for dataverseAuthentication
-            const mockDataverseAuth = sandbox.stub(authProvider, 'dataverseAuthentication');
-            mockDataverseAuth.resolves({ accessToken: 'test-token', userId: 'test- userId' });
-
-            // Create a mock for isEdmEnvironment
-            const mockIsEdmEnvironment = sandbox.stub(dataverseMetadata, 'isEdmEnvironment');
-            mockIsEdmEnvironment.resolves(true);
-
-            // Create a site tree item with contextValue OTHER_SITE
-            mockSiteTreeItem = new SiteTreeItem({
-                name: "Other Site",
-                websiteId: "other-id",
-                dataModelVersion: 2,
-                status: undefined,
-                websiteUrl: '',
-                isCurrent: false,
-                siteVisibility: "",
-                siteManagementUrl: "",
-                folderPath: "other-site-path"
-            });
-
-            // Set the context value explicitly
-            sandbox.stub(mockSiteTreeItem, 'contextValue').get(() => Constants.ContextValues.OTHER_SITE);
-
-            // Set up PacContext
-            sandbox.stub(PacContext, 'OrgInfo').get(() => ({ OrgUrl: 'test-org-url' }));
-
-            await uploadSite(mockSiteTreeItem);
-
-            expect(mockDataverseAuth.calledOnce).to.be.true;
-            expect(mockIsEdmEnvironment.calledOnce).to.be.true;
-            expect(mockSendText.calledOnceWith(`pac pages upload --path "other-site-path" --modelVersion 2`)).to.be.true;
         });
 
         it('should handle errors during upload', async () => {

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -808,11 +808,9 @@ describe('ActionsHubCommandHandlers', () => {
     describe('uploadSite', () => {
         let mockSendText: sinon.SinonStub;
         let mockSiteTreeItem: SiteTreeItem;
-        let mockShowErrorMessage: sinon.SinonStub;
 
         beforeEach(() => {
             mockSendText = sinon.stub();
-            mockShowErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage')
 
             // Set up CurrentSiteContext
             sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => "test-path");
@@ -901,27 +899,6 @@ describe('ActionsHubCommandHandlers', () => {
             expect(mockSendText.calledOnceWith(`pac pages upload --path "test-path" --modelVersion "1"`)).to.be.true;
         });
 
-        it('should show error when current site path is not found', async () => {
-            sandbox.restore(); // Reset stubs
-            sandbox.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => undefined);
-
-            mockSiteTreeItem = new SiteTreeItem({
-                name: "Test Site",
-                websiteId: "test-id",
-                dataModelVersion: 1,
-                status: WebsiteStatus.Active,
-                websiteUrl: 'https://test-site.com',
-                isCurrent: false,
-                siteVisibility: Constants.SiteVisibility.PRIVATE,
-                siteManagementUrl: "https://inactive-site-1-management.com"
-            });
-
-            await uploadSite(mockSiteTreeItem);
-
-            expect(mockShowErrorMessage.calledOnce).to.be.true;
-            expect(mockShowErrorMessage.firstCall.args[0]).to.equal(Constants.Strings.CURRENT_SITE_PATH_NOT_FOUND);
-        });
-
         it('should handle upload for other sites', async () => {
             // Create a mock for dataverseAuthentication
             const mockDataverseAuth = sandbox.stub(authProvider, 'dataverseAuthentication');
@@ -935,7 +912,7 @@ describe('ActionsHubCommandHandlers', () => {
             mockSiteTreeItem = new SiteTreeItem({
                 name: "Other Site",
                 websiteId: "other-id",
-                dataModelVersion: 1,
+                dataModelVersion: 2,
                 status: undefined,
                 websiteUrl: '',
                 isCurrent: false,

--- a/src/common/copilot/dataverseMetadata.ts
+++ b/src/common/copilot/dataverseMetadata.ts
@@ -218,3 +218,31 @@ function parseYamlContent(content: string, sessionID: string, dataverseEntity: s
         return {};
     }
 }
+
+
+//make call to https://org955590f3.crm10.dynamics.com/api/data/v9.2/EntityDefinitions(LogicalName='powerpagesite') to check if the response object contains MetadataId
+export async function isEdmEnvironment(orgUrl: string, apiToken: string): Promise<boolean> {
+    try {
+        const dataverseURL = `${orgUrl.endsWith('/') ? orgUrl : orgUrl.concat('/')}api/data/v9.2/EntityDefinitions(LogicalName='powerpagesite')`;
+        const requestInit: RequestInit = {
+            method: "GET",
+            headers: {
+                'Content-Type': "application/json",
+                Authorization: `Bearer ${apiToken}`,
+                "x-ms-user-agent": getUserAgent()
+            },
+        };
+
+        const startTime = performance.now();
+        const jsonResponse = await fetchJsonResponse(dataverseURL, requestInit);
+        const endTime = performance.now();
+        const responseTime = endTime - startTime || 0;
+
+        sendTelemetryEvent({ eventName: isEdmEnvironment.name, durationInMills: responseTime, orgUrl: orgUrl })
+        return jsonResponse.MetadataId !== undefined
+
+    } catch (error) {
+        sendTelemetryEvent({ eventName: isEdmEnvironment.name, error: error as Error, orgUrl: orgUrl})
+        return false;
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality of the Actions Hub in Power Pages. The key changes involve adding support for uploading sites that are not in the current environment, improving error handling, and adding new constants for better code readability and maintainability.

### Enhancements to site upload functionality:

* [`src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts`](diffhunk://#diff-1ab9691ce442179f489ba49f832a1f872247015667f1e1eab3bc8f027d457fc2R255-R349): Added new functions `uploadOtherSite` and `uploadCurrentSite` to handle uploads for sites not in the current environment and active/inactive sites, respectively. Improved error handling and added logging for upload attempts and failures.

### Code improvements:

* [`src/client/power-pages/actions-hub/Constants.ts`](diffhunk://#diff-f5975640a34750e7cb7a2f691b3fc2e6533f7087d74abb3abf6684357e21ee31R39): Added new constants `CURRENT_SITE_PATH_NOT_FOUND`, `ACTIONS_HUB_UPLOAD_OTHER_SITE`, and `ACTIONS_HUB_UPLOAD_SITE_FAILED` to enhance code readability and maintainability. [[1]](diffhunk://#diff-f5975640a34750e7cb7a2f691b3fc2e6533f7087d74abb3abf6684357e21ee31R39) [[2]](diffhunk://#diff-f5975640a34750e7cb7a2f691b3fc2e6533f7087d74abb3abf6684357e21ee31L54-R57)

### Testing enhancements:

* [`src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts`](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772R841-R863): Added new test cases to cover scenarios such as user canceling confirmation for public site upload, handling case sensitivity for public site visibility, and error handling during upload. [[1]](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772R841-R863) [[2]](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772R882-R919)

### Utility function addition:

* [`src/common/copilot/dataverseMetadata.ts`](diffhunk://#diff-f01824da34af02017a75c331f96e8098e03b6d9c20d04bf943d8551fddde621fR221-R248): Added new function `isEdmEnvironment` to check if the environment supports EDM by making an API call to the Dataverse.

### Minor changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1084-R1084): Modified the command condition to include `otherSite` in addition to `currentActiveSite`.
* [`src/client/power-pages/actions-hub/models/IWebsiteInfo.ts`](diffhunk://#diff-6e045f018564cbd290908c95a707a72ad3d2562f3c62027294faa5fea3c04c6aR17): Added optional `folderPath` property to the `IWebsiteInfo` interface.
* [`src/client/power-pages/actions-hub/tree-items/OtherSitesGroupTreeItem.ts`](diffhunk://#diff-98b5457f97ca6ed40dd284e49a88417bf203be55470483cf0cb5bd6ce404d931L37-R38): Updated the `OtherSitesGroupTreeItem` class to include the `folderPath` property.