### PR TITLE
[Power Pages] [Actions Hub] Add 'Open in Power Pages Studio' command

### DIFF
--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -776,6 +776,9 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     <trans-unit id="pacCLI.openPacLab.title">
       <source xml:lang="en">Open PAC Lab</source>
     </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio.title">
+      <source xml:lang="en">Open in Power Pages Studio</source>
+    </trans-unit>
     <trans-unit id="microsoft.powerplatform.pages.actionsHub.openSitesInStudio.title">
       <source xml:lang="en">Open in Power Pages Studio</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -447,6 +447,10 @@
       {
         "command": "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite",
         "title": "%microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite.title%"
+      },
+      {
+        "command": "microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio",
+        "title": "%microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio.title%"
       }
     ],
     "configuration": {
@@ -939,6 +943,10 @@
         {
           "command": "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite",
           "when": "never"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio",
+          "when": "never"
         }
       ],
       "view/title": [
@@ -1101,6 +1109,11 @@
           "command": "microsoft.powerplatform.pages.actionsHub.inactiveSite.openSiteManagement",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == inactiveSite",
           "group": "siteAction@3"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == nonCurrentActiveSite)",
+          "group": "siteAction@6"
         }
       ]
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -112,5 +112,6 @@
   "microsoft.powerplatform.pages.actionsHub.inactiveSite.openSiteManagement.title": "Open site management",
   "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite.title": "Upload Site",
   "microsoft.powerplatform.pages.actionsHub.siteDetails.title": "Site Details",
-  "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite.title": "Download Site"
+  "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite.title": "Download Site",
+  "microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio.title": "Open in Power Pages Studio"
 }

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -113,43 +113,42 @@ export const switchEnvironment = async (pacTerminal: PacTerminal) => {
     }
 }
 
-const getStudioUrl = (): string => {
+const getStudioBaseUrl = (): string => {
     const artemisContext = ArtemisContext.ServiceResponse;
-
-    let baseEndpoint = "";
 
     switch (artemisContext.stamp) {
         case ServiceEndpointCategory.TEST:
-            baseEndpoint = Constants.StudioEndpoints.TEST;
-            break;
+            return Constants.StudioEndpoints.TEST;
         case ServiceEndpointCategory.PREPROD:
-            baseEndpoint = Constants.StudioEndpoints.PREPROD;
-            break;
+            return Constants.StudioEndpoints.PREPROD;
         case ServiceEndpointCategory.PROD:
-            baseEndpoint = Constants.StudioEndpoints.PROD;
-            break;
+            return Constants.StudioEndpoints.PROD;
         case ServiceEndpointCategory.DOD:
-            baseEndpoint = Constants.StudioEndpoints.DOD;
-            break;
+            return Constants.StudioEndpoints.DOD;
         case ServiceEndpointCategory.GCC:
-            baseEndpoint = Constants.StudioEndpoints.GCC;
-            break;
+            return Constants.StudioEndpoints.GCC;
         case ServiceEndpointCategory.HIGH:
-            baseEndpoint = Constants.StudioEndpoints.HIGH;
-            break;
+            return Constants.StudioEndpoints.HIGH;
         case ServiceEndpointCategory.MOONCAKE:
-            baseEndpoint = Constants.StudioEndpoints.MOONCAKE;
-            break;
-        default:
-            break;
+            return Constants.StudioEndpoints.MOONCAKE;
+    }
+
+    return "";
+}
+
+const getPPHomeUrl = (): string => {
+    const baseEndpoint = getStudioBaseUrl();
+
+    if (!baseEndpoint) {
+        return "";
     }
 
     return `${baseEndpoint}/environments/${PacContext.AuthInfo?.EnvironmentId}/portals/home`;
 }
 
-const getActiveSitesUrl = () => `${getStudioUrl()}/?tab=active`;
+const getActiveSitesUrl = () => `${getPPHomeUrl()}/?tab=active`;
 
-const getInactiveSitesUrl = () => `${getStudioUrl()}/?tab=inactive`;
+const getInactiveSitesUrl = () => `${getPPHomeUrl()}/?tab=inactive`;
 
 export const openActiveSitesInStudio = async () => await vscode.env.openExternal(vscode.Uri.parse(getActiveSitesUrl()));
 
@@ -453,4 +452,29 @@ export const downloadSite = async (siteTreeItem: SiteTreeItem) => {
     }
 
     executeSiteDownloadCommand(siteInfo, downloadPath);
+}
+
+const getStudioUrl = (environmentId: string, websiteId: string) => {
+    if (!environmentId || !websiteId) {
+        return "";
+    }
+
+    const baseEndpoint = getStudioBaseUrl();
+
+    if (!baseEndpoint) {
+        return "";
+    }
+
+    return `${baseEndpoint}/e/${environmentId}/sites/${websiteId}/pages`;
+}
+
+export const openInStudio = async (siteTreeItem: SiteTreeItem) => {
+    const environmentId = PacContext.AuthInfo?.EnvironmentId || "";
+    const studioUrl = getStudioUrl(environmentId, siteTreeItem.siteInfo.websiteId);
+
+    if (!studioUrl) {
+        return;
+    }
+
+    await vscode.env.openExternal(vscode.Uri.parse(studioUrl));
 }

--- a/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
@@ -11,7 +11,7 @@ import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLo
 import { EnvironmentGroupTreeItem } from "./tree-items/EnvironmentGroupTreeItem";
 import { IEnvironmentInfo } from "./models/IEnvironmentInfo";
 import { PacTerminal } from "../../lib/PacTerminal";
-import { fetchWebsites, openActiveSitesInStudio, openInactiveSitesInStudio, previewSite, createNewAuthProfile, refreshEnvironment, showEnvironmentDetails, switchEnvironment, revealInOS, openSiteManagement, uploadSite, showSiteDetails, downloadSite } from "./ActionsHubCommandHandlers";
+import { fetchWebsites, openActiveSitesInStudio, openInactiveSitesInStudio, previewSite, createNewAuthProfile, refreshEnvironment, showEnvironmentDetails, switchEnvironment, revealInOS, openSiteManagement, uploadSite, showSiteDetails, downloadSite, openInStudio } from "./ActionsHubCommandHandlers";
 import PacContext from "../../pac/PacContext";
 import CurrentSiteContext from "./CurrentSiteContext";
 import { IOtherSiteInfo, IWebsiteDetails } from "../../../common/services/Interfaces";
@@ -132,7 +132,9 @@ export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<Actio
 
             vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.siteDetails", showSiteDetails),
 
-            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite", downloadSite)
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite", downloadSite),
+
+            vscode.commands.registerCommand("microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio", openInStudio)
         ];
     }
 }

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS, uploadSite, createKnownSiteIdsSet, findOtherSites, showSiteDetails, openSiteManagement, downloadSite } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
+import { showEnvironmentDetails, refreshEnvironment, switchEnvironment, openActiveSitesInStudio, openInactiveSitesInStudio, createNewAuthProfile, previewSite, fetchWebsites, revealInOS, uploadSite, createKnownSiteIdsSet, findOtherSites, showSiteDetails, openSiteManagement, downloadSite, openInStudio } from '../../../../power-pages/actions-hub/ActionsHubCommandHandlers';
 import { Constants } from '../../../../power-pages/actions-hub/Constants';
 import { oneDSLoggerWrapper } from '../../../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper';
 import * as CommonUtils from '../../../../power-pages/commonUtility';
@@ -1217,6 +1217,69 @@ describe('ActionsHubCommandHandlers', () => {
                     expect(mockSendText.called).to.be.false;
                 });
             });
+        });
+    });
+
+    describe('openInStudio', () => {
+        let mockUrl: sinon.SinonSpy;
+        let mockOpenUrl: sinon.SinonStub;
+
+        beforeEach(() => {
+            mockUrl = sandbox.spy(vscode.Uri, 'parse');
+            mockOpenUrl = sandbox.stub(vscode.env, 'openExternal');
+            sandbox.stub(PacContext, 'AuthInfo').get(() => mockAuthInfo);
+            sandbox.stub(ArtemisContext, 'ServiceResponse').get(() => ({ stamp: ServiceEndpointCategory.TEST }));
+        });
+
+        it('should open in studio', async () => {
+            await openInStudio({
+                siteInfo: {
+                    websiteId: "test-id"
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            expect(mockUrl.calledOnce).to.be.true;
+            expect(mockUrl.firstCall.args[0]).to.equal('https://make.test.powerpages.microsoft.com/e/test-env-id/sites/test-id/pages');
+
+            expect(mockOpenUrl.calledOnce).to.be.true;
+            expect(mockOpenUrl.firstCall.args[0].toString()).to.equal('https://make.test.powerpages.microsoft.com/e/test-env-id/sites/test-id/pages');
+        });
+
+        it('should not open when website id is missing', async () => {
+            await openInStudio({
+                siteInfo: {
+                    websiteId: ""
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            expect(mockUrl.called).to.be.false;
+            expect(mockOpenUrl.called).to.be.false;
+        });
+
+        it('should not open when environment id is missing', async () => {
+            sandbox.stub(PacContext, 'AuthInfo').get(() => ({ ...mockAuthInfo, EnvironmentId: undefined }));
+
+            await openInStudio({
+                siteInfo: {
+                    websiteId: "test-id"
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            expect(mockUrl.called).to.be.false;
+            expect(mockOpenUrl.called).to.be.false;
+        });
+
+        it('should not open when Artemis stamp id is missing', async () => {
+            sandbox.stub(ArtemisContext, 'ServiceResponse').get(() => ({ stamp: 'foo' }));
+
+            await openInStudio({
+                siteInfo: {
+                    websiteId: "test-id"
+                } as IWebsiteInfo
+            } as SiteTreeItem);
+
+            expect(mockUrl.called).to.be.false;
+            expect(mockOpenUrl.called).to.be.false;
         });
     });
 });

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -203,6 +203,18 @@ describe("ActionsHubTreeDataProvider", () => {
             await registerCommandStub.getCall(13).args[1]();
             expect(mockCommandHandler.calledOnce).to.be.true;
         });
+
+        it('should register openSiteInStudio command', async () => {
+            const mockCommandHandler = sinon.stub(CommandHandlers, 'openInStudio');
+            mockCommandHandler.resolves();
+            const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal);
+            actionsHubTreeDataProvider["registerPanel"](pacTerminal);
+
+            expect(registerCommandStub.calledWith("microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio")).to.be.true;
+
+            await registerCommandStub.getCall(14).args[1]();
+            expect(mockCommandHandler.calledOnce).to.be.true;
+        });
     });
 
     describe('getTreeItem', () => {


### PR DESCRIPTION
This pull request introduces a new feature to open sites in the Power Pages Studio, along with some code refactoring and test updates to support this functionality. The most important changes include additions to the `package.json` and `package.nls.json` files, modifications to the `ActionsHubCommandHandlers.ts` file, and updates to the test files.

New feature implementation:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R450-R453): Added new command `microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio` in multiple sections to support opening sites in Power Pages Studio. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R450-R453) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R946-R949) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1112-R1116)
* [`package.nls.json`](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0L115-R116): Added a new title for the command `microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio`.

Code refactoring:

* [`ActionsHubCommandHandlers.ts`](diffhunk://#diff-1ab9691ce442179f489ba49f832a1f872247015667f1e1eab3bc8f027d457fc2L116-R151): Refactored the `getStudioUrl` function to `getStudioBaseUrl`, added a new function `getPPHomeUrl`, and implemented the `openInStudio` function to generate the correct URL and open it in the browser. [[1]](diffhunk://#diff-1ab9691ce442179f489ba49f832a1f872247015667f1e1eab3bc8f027d457fc2L116-R151) [[2]](diffhunk://#diff-1ab9691ce442179f489ba49f832a1f872247015667f1e1eab3bc8f027d457fc2R456-R480)

![image](https://github.com/user-attachments/assets/c0b96aa8-9ff2-4e26-a9b1-6fee658787e3)
