### PR TITLE
[Power Pages][Preview Site] Show notification when previewing site with pending changes

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -109,7 +109,6 @@
     ]
   },
   "Opening site preview...": "Opening site preview...",
-  "The preview shown is for published changes.": "The preview shown is for published changes.",
   "Site runtime preview feature is not enabled.": "Site runtime preview feature is not enabled.",
   "No workspace folder opened. Please open a site folder to preview.": "No workspace folder opened. Please open a site folder to preview.",
   "Initializing site preview. Please try again after few seconds.": "Initializing site preview. Please try again after few seconds.",
@@ -129,6 +128,8 @@
   },
   "Authenticating...": "Authenticating...",
   "Unable to clear cache": "Unable to clear cache",
+  "Your preview isn't updated. Please upload your site to see the latest changes.": "Your preview isn't updated. Please upload your site to see the latest changes.",
+  "Upload changes": "Upload changes",
   "Enter the name of the web template": "Enter the name of the web template",
   "Please enter a name for the web template.": "Please enter a name for the web template.",
   "A webtemplate with the same name already exists. Please enter a different name.": "A webtemplate with the same name already exists. Please enter a different name.",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -530,9 +530,6 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++5eccedc8c04d2137a9eb74edf18ea469b4b63e7315de4b8fe49c48bb8d0780e9">
       <source xml:lang="en">The pac CLI is ready for use in your VS Code terminal!</source>
     </trans-unit>
-    <trans-unit id="++CODE++db00163e0e6fed2e319e28785c537befb88ded272d245e503d9580322ab2fec8">
-      <source xml:lang="en">The preview shown is for published changes.</source>
-    </trans-unit>
     <trans-unit id="++CODE++18f3be2933741b96e56b1e1f70818fcba46ec9c5b3dcd0e28d801eab15791d84">
       <source xml:lang="en">There was a permissions problem with the server</source>
     </trans-unit>
@@ -579,6 +576,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     </trans-unit>
     <trans-unit id="++CODE++4b8d64fae5d1cbf5f7324782e9b5c430db7c218771e84b0b402a9a4d0ec4bf05">
       <source xml:lang="en">Unmanaged</source>
+    </trans-unit>
+    <trans-unit id="++CODE++7fce0124a7cb74955461f08e39ceaaed1e2850492f077f4e6defd82ef3ca6b0e">
+      <source xml:lang="en">Upload changes</source>
     </trans-unit>
     <trans-unit id="++CODE++696d5f7b79a75961bc5d99ecbbea7b535acc73160e0b6422daa45b0ae7c04368">
       <source xml:lang="en">User: {0}</source>
@@ -629,6 +629,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     </trans-unit>
     <trans-unit id="++CODE++beb45bfdd4c3f6da9bb3687e4d9275790d086c1dffaec84839fa9ec9ce4e9ee2">
       <source xml:lang="en">You can use this in &lt;a href=&quot;#&quot; id=&quot;github-copilot-link&quot;&gt;GitHub Copilot with @powerpages&lt;/a&gt; and leverage best of both world.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++eeb25aaca6a9e3f6c670334480b8e56e2a362ecfec23f8e63617915b22ddc8a0">
+      <source xml:lang="en">Your preview isn't updated. Please upload your site to see the latest changes.</source>
     </trans-unit>
     <trans-unit id="++CODE++3a928d0a6dd0e0c6b56eb3bf08b20e6361e876fd6b2eeca59f718cbfdc310472">
       <source xml:lang="en">dotnet sdk 6.0 or greater must be installed</source>

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -230,7 +230,7 @@ export async function activate(
             }
 
             await Promise.allSettled([
-                PreviewSite.initialize(context, workspaceFolders),
+                PreviewSite.initialize(context, workspaceFolders, pacTerminal),
                 ActionsHub.initialize(context, pacTerminal)
             ]);
         }),

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -164,7 +164,7 @@ export class PacWrapper {
         return this.executeCommandAndParseResults<PacOrgWhoOutput>(new PacArguments("org", "who"));
     }
 
-    public async activeAuth(): Promise <PacAuthWhoOutput> {
+    public async activeAuth(): Promise<PacAuthWhoOutput> {
         return this.executeCommandAndParseResults<PacAuthWhoOutput>(new PacArguments("auth", "who"));
     }
 
@@ -178,6 +178,10 @@ export class PacWrapper {
 
     public async disableTelemetry(): Promise<PacOutput> {
         return this.executeCommandAndParseResults<PacOutput>(new PacArguments("telemetry", "disable"));
+    }
+
+    public async pendingChanges(websitePath: string, dataModelVersion: 1 | 2): Promise<PacOutput> {
+        return this.executeCommandAndParseResults<PacOutput>(new PacArguments("pages", "pending-changes", "-p", websitePath, "-mv", dataModelVersion.toString()));
     }
 
     public exit(): void {

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -31,12 +31,13 @@ export class PacInterop implements IPacInterop {
     private tempWorkingDirectory: string;
     private pacExecutablePath: string;
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public constructor(private readonly context: IPacWrapperContext, cliPath: string) {
         // Set the Working Directory to a random temp folder, as we do not want
         // accidental writes by PAC being placed where they may interfere with things
         this.tempWorkingDirectory = path.join(os.tmpdir(), v4());
         fs.ensureDirSync(this.tempWorkingDirectory);
-        this.pacExecutablePath = path.join(cliPath, PacInterop.getPacExecutableName());
+        this.pacExecutablePath = path.join("D:\\code\\PowerPlatform-Scale-AdminTools\\drop\\Debug\\bolt\\net8.0", PacInterop.getPacExecutableName());
     }
 
     private static getPacExecutableName(): string {

--- a/src/client/pac/PacWrapper.ts
+++ b/src/client/pac/PacWrapper.ts
@@ -31,13 +31,12 @@ export class PacInterop implements IPacInterop {
     private tempWorkingDirectory: string;
     private pacExecutablePath: string;
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public constructor(private readonly context: IPacWrapperContext, cliPath: string) {
         // Set the Working Directory to a random temp folder, as we do not want
         // accidental writes by PAC being placed where they may interfere with things
         this.tempWorkingDirectory = path.join(os.tmpdir(), v4());
         fs.ensureDirSync(this.tempWorkingDirectory);
-        this.pacExecutablePath = path.join("D:\\code\\PowerPlatform-Scale-AdminTools\\drop\\Debug\\bolt\\net8.0", PacInterop.getPacExecutableName());
+        this.pacExecutablePath = path.join(cliPath, PacInterop.getPacExecutableName());
     }
 
     private static getPacExecutableName(): string {

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -158,7 +158,7 @@ export const openInactiveSitesInStudio = async () => await vscode.env.openExtern
 export const previewSite = async (siteTreeItem: SiteTreeItem) => {
     await PreviewSite.clearCache(siteTreeItem.siteInfo.websiteUrl);
 
-    await PreviewSite.launchBrowserAndDevToolsWithinVsCode(siteTreeItem.siteInfo.websiteUrl, siteTreeItem.siteInfo.dataModelVersion);
+    await PreviewSite.launchBrowserAndDevToolsWithinVsCode(siteTreeItem.siteInfo.websiteUrl, siteTreeItem.siteInfo.dataModelVersion, siteTreeItem.siteInfo.siteVisibility);
 };
 
 export const createNewAuthProfile = async (pacWrapper: PacWrapper): Promise<void> => {
@@ -252,10 +252,10 @@ export const openSiteManagement = async (siteTreeItem: SiteTreeItem) => {
     await vscode.env.openExternal(vscode.Uri.parse(siteTreeItem.siteInfo.siteManagementUrl));
 }
 
-export const uploadSite = async (siteTreeItem: SiteTreeItem) => {
+export const uploadSite = async (siteTreeItem: SiteTreeItem, websitePath: string) => {
 
     //Show a modal dialog to take confirmation from the user
-    if (siteTreeItem.siteInfo.siteVisibility.toLowerCase() === Constants.SiteVisibility.PUBLIC) {
+    if (siteTreeItem.siteInfo.siteVisibility?.toLowerCase() === Constants.SiteVisibility.PUBLIC) {
         const confirm = await vscode.window.showInformationMessage(
             Constants.Strings.SITE_UPLOAD_CONFIRMATION,
             { modal: true },
@@ -268,9 +268,9 @@ export const uploadSite = async (siteTreeItem: SiteTreeItem) => {
         }
     }
     oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE, { methodName: uploadSite.name });
-    const websitePath = CurrentSiteContext.currentSiteFolderPath;
+    const websitePathToUpload = websitePath ?? CurrentSiteContext.currentSiteFolderPath;
     const modelVersion = siteTreeItem.siteInfo.dataModelVersion;
-    PacTerminal.getTerminal().sendText(`pac pages upload --path "${websitePath}" --modelVersion "${modelVersion}"`);
+    PacTerminal.getTerminal().sendText(`pac pages upload --path "${websitePathToUpload}" --modelVersion "${modelVersion}"`);
 }
 
 /**

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -158,7 +158,7 @@ export const openInactiveSitesInStudio = async () => await vscode.env.openExtern
 export const previewSite = async (siteTreeItem: SiteTreeItem) => {
     await PreviewSite.clearCache(siteTreeItem.siteInfo.websiteUrl);
 
-    await PreviewSite.launchBrowserAndDevToolsWithinVsCode(siteTreeItem.siteInfo.websiteUrl);
+    await PreviewSite.launchBrowserAndDevToolsWithinVsCode(siteTreeItem.siteInfo.websiteUrl, siteTreeItem.siteInfo.dataModelVersion);
 };
 
 export const createNewAuthProfile = async (pacWrapper: PacWrapper): Promise<void> => {

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -268,7 +268,7 @@ export const uploadSite = async (siteTreeItem: SiteTreeItem, websitePath: string
         }
     }
     oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE, { methodName: uploadSite.name });
-    const websitePathToUpload = websitePath ?? CurrentSiteContext.currentSiteFolderPath;
+    const websitePathToUpload = websitePath || CurrentSiteContext.currentSiteFolderPath;
     const modelVersion = siteTreeItem.siteInfo.dataModelVersion;
     PacTerminal.getTerminal().sendText(`pac pages upload --path "${websitePathToUpload}" --modelVersion "${modelVersion}"`);
 }

--- a/src/client/power-pages/preview-site/Constants.ts
+++ b/src/client/power-pages/preview-site/Constants.ts
@@ -11,7 +11,6 @@ export const Messages = {
     INSTALL: vscode.l10n.t("Install"),
     EDGE_DEV_TOOLS_NOT_INSTALLED_MESSAGE: vscode.l10n.t({ message: "The extension 'Microsoft Edge Tools' is required to run this command. Do you want to install it now?", comment: ["Do not translate 'Microsoft Edge Tools' "] }),
     OPENING_SITE_PREVIEW: vscode.l10n.t("Opening site preview..."),
-    PREVIEW_SHOWN_FOR_PUBLISHED_CHANGES: vscode.l10n.t("The preview shown is for published changes."),
     SITE_PREVIEW_FEATURE_NOT_ENABLED: vscode.l10n.t("Site runtime preview feature is not enabled."),
     NO_FOLDER_OPENED: vscode.l10n.t("No workspace folder opened. Please open a site folder to preview."),
     INITIALIZING_PREVIEW_TRY_AGAIN: vscode.l10n.t("Initializing site preview. Please try again after few seconds."),
@@ -31,9 +30,12 @@ export const Messages = {
     }),
     AUTHENTICATING: vscode.l10n.t("Authenticating..."),
     UNABLE_TO_CLEAR_CACHE: vscode.l10n.t("Unable to clear cache"),
+    PREVIEW_WARNING: vscode.l10n.t("Your preview isn't updated. Please upload your site to see the latest changes."),
+    UPLOAD_CHANGES: vscode.l10n.t("Upload changes")
 };
 
 export const Events = {
     PREVIEW_SITE_INITIALIZED: "PreviewSiteInitialized",
-    PREVIEW_SITE_INITIALIZATION_FAILED: "PreviewSiteInitializationFailed"
+    PREVIEW_SITE_INITIALIZATION_FAILED: "PreviewSiteInitializationFailed",
+    PREVIEW_SITE_UPLOAD_WARNING_FAILED: "PreviewSiteUploadWarningFailed"
 }

--- a/src/client/power-pages/preview-site/PreviewSite.ts
+++ b/src/client/power-pages/preview-site/PreviewSite.ts
@@ -8,22 +8,29 @@ import { ECSFeaturesClient } from '../../../common/ecs-features/ecsFeatureClient
 import { EnableSiteRuntimePreview } from '../../../common/ecs-features/ecsFeatureGates';
 import { WorkspaceFolder } from 'vscode-languageclient/node';
 import { getWebsiteRecordId } from '../../../common/utilities/WorkspaceInfoFinderUtil';
-import { PROVIDER_ID } from '../../../common/services/Constants';
+import { PROVIDER_ID, WebsiteDataModel } from '../../../common/services/Constants';
 import { PPAPIService } from '../../../common/services/PPAPIService';
 import { VSCODE_EXTENSION_GET_WEBSITE_RECORD_ID_EMPTY, VSCODE_EXTENSION_SITE_PREVIEW_ERROR } from '../../../common/services/TelemetryConstants';
-import { EDGE_TOOLS_EXTENSION_ID } from '../../../common/constants';
+import { EDGE_TOOLS_EXTENSION_ID, SUCCESS, TRUE } from '../../../common/constants';
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 import { getWorkspaceFolders, showProgressWithNotification } from '../../../common/utilities/Utils';
 import { Events, Messages } from './Constants';
 import { dataverseAuthentication } from '../../../common/services/AuthenticationProvider';
 import PacContext from '../../pac/PacContext';
 import ArtemisContext from '../../ArtemisContext';
+import { PacTerminal } from '../../lib/PacTerminal';
+import CurrentSiteContext from '../actions-hub/CurrentSiteContext';
+import path from 'path';
+import { IWebsiteDetails } from '../../../common/services/Interfaces';
+import { uploadSite } from '../actions-hub/ActionsHubCommandHandlers';
+import { SiteTreeItem } from '../actions-hub/tree-items/SiteTreeItem';
 
 export const SITE_PREVIEW_COMMAND_ID = "microsoft.powerplatform.pages.preview-site";
 
 export class PreviewSite {
-    private static _websiteUrl: string | undefined = undefined;
+    private static _websiteDetails: IWebsiteDetails | undefined = undefined;
     private static _isInitialized = false;
+    private static _pacTerminal: PacTerminal;
 
 
     static isSiteRuntimePreviewEnabled(): boolean {
@@ -36,10 +43,12 @@ export class PreviewSite {
         return enableSiteRuntimePreview;
     }
 
-    static async initialize(context: vscode.ExtensionContext, workspaceFolders: WorkspaceFolder[]): Promise<void> {
+    static async initialize(context: vscode.ExtensionContext, workspaceFolders: WorkspaceFolder[], pacTerminal: PacTerminal): Promise<void> {
         if (PreviewSite._isInitialized) {
             return;
         }
+
+        PreviewSite._pacTerminal = pacTerminal;
 
         try {
             const isSiteRuntimePreviewEnabled = PreviewSite.isSiteRuntimePreviewEnabled();
@@ -52,16 +61,16 @@ export class PreviewSite {
             const orgDetails = PacContext.OrgInfo;
 
             if (artemisResponse && orgDetails && isSiteRuntimePreviewEnabled) {
-                PacContext.onChanged(async () => await PreviewSite.loadSiteUrl(workspaceFolders));
+                PacContext.onChanged(async () => await PreviewSite.loadSiteDetails(workspaceFolders));
 
                 context.subscriptions.push(
                     vscode.commands.registerCommand(
                         SITE_PREVIEW_COMMAND_ID,
-                        async () => await PreviewSite.handlePreviewRequest()
+                        PreviewSite.handlePreviewRequest
                     )
                 );
 
-                await PreviewSite.loadSiteUrl(workspaceFolders);
+                await PreviewSite.loadSiteDetails(workspaceFolders);
                 await vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.siteRuntimePreviewEnabled", true);
             }
 
@@ -72,29 +81,29 @@ export class PreviewSite {
         }
     }
 
-    static async loadSiteUrl(workspaceFolders: WorkspaceFolder[]): Promise<void> {
-        const websiteUrl = await PreviewSite.getWebSiteUrl(workspaceFolders);
+    static async loadSiteDetails(workspaceFolders: WorkspaceFolder[]): Promise<void> {
+        const websiteDetails = await PreviewSite.getWebsiteDetails(workspaceFolders);
 
-        this._websiteUrl = websiteUrl;
+        this._websiteDetails = websiteDetails;
     }
 
-    private static async getWebSiteUrl(workspaceFolders: WorkspaceFolder[]): Promise<string> {
+    private static async getWebsiteDetails(workspaceFolders: WorkspaceFolder[]): Promise<IWebsiteDetails> {
         const websiteRecordId = getWebsiteRecordId(workspaceFolders);
         if (!websiteRecordId) {
             oneDSLoggerWrapper.getLogger().traceInfo(VSCODE_EXTENSION_GET_WEBSITE_RECORD_ID_EMPTY, {
                 websiteRecordId: websiteRecordId
             });
-            return "";
+            return {} as IWebsiteDetails;
         }
 
         const orgDetails = PacContext.OrgInfo;
 
         if (!orgDetails) {
-            return "";
+            return {} as IWebsiteDetails;
         }
 
         const websiteDetails = await PPAPIService.getWebsiteDetailsByWebsiteRecordId(ArtemisContext.ServiceResponse.stamp, orgDetails.EnvironmentId, websiteRecordId);
-        return websiteDetails?.websiteUrl || "";
+        return websiteDetails ?? {} as IWebsiteDetails;
     }
 
     private static async promptInstallEdgeTools(): Promise<void> {
@@ -108,7 +117,7 @@ export class PreviewSite {
         }
     }
 
-    public static async launchBrowserAndDevToolsWithinVsCode(webSitePreviewURL: string | undefined): Promise<void> {
+    public static async launchBrowserAndDevToolsWithinVsCode(webSitePreviewURL: string | undefined, dataModelVersion: 1 | 2): Promise<void> {
         if (!webSitePreviewURL || webSitePreviewURL === "") {
             return;
         }
@@ -125,7 +134,31 @@ export class PreviewSite {
             async () => await vscode.commands.executeCommand('vscode-edge-devtools.launch', { launchUrl: webSitePreviewURL })
         );
 
-        await vscode.window.showInformationMessage(Messages.PREVIEW_SHOWN_FOR_PUBLISHED_CHANGES);
+        const websitePath = CurrentSiteContext.currentSiteFolderPath;
+        if (websitePath) {
+            await PreviewSite.showUploadWarning(websitePath, dataModelVersion);
+        }
+    }
+
+    private static async showUploadWarning(websitePath: string, dataModelVersion: 1 | 2) {
+        const pendingChangesResult = await PreviewSite._pacTerminal.getWrapper().pendingChanges(path.dirname(websitePath), dataModelVersion);
+
+        try {
+            if (pendingChangesResult.Status === SUCCESS && pendingChangesResult.Information[pendingChangesResult.Information.length - 1].includes(TRUE)) {
+                const result = await vscode.window.showInformationMessage(Messages.PREVIEW_WARNING, Messages.UPLOAD_CHANGES, Messages.CANCEL);
+                if (result === Messages.UPLOAD_CHANGES) {
+                    await uploadSite({
+                        siteInfo: {
+                            dataModelVersion: dataModelVersion,
+                            siteVisibility: this._websiteDetails?.siteVisibility
+                        }
+                    } as SiteTreeItem);
+                }
+            }
+        } catch (exception) {
+            const exceptionError = exception as Error;
+            oneDSLoggerWrapper.getLogger().traceError(Events.PREVIEW_SITE_UPLOAD_WARNING_FAILED, exceptionError.message, exceptionError);
+        }
     }
 
     static async handlePreviewRequest() {
@@ -146,7 +179,7 @@ export class PreviewSite {
             return;
         }
 
-        if (this._websiteUrl === undefined) {
+        if (this._websiteDetails === undefined) {
             oneDSLoggerWrapper.getLogger().traceInfo(VSCODE_EXTENSION_SITE_PREVIEW_ERROR, { error: Messages.INITIALIZING_PREVIEW_TRY_AGAIN });
             await vscode.window.showWarningMessage(Messages.INITIALIZING_PREVIEW_TRY_AGAIN);
             return;
@@ -160,7 +193,7 @@ export class PreviewSite {
             return;
         }
 
-        if (this._websiteUrl === "") {
+        if (!this._websiteDetails.websiteUrl) {
             let shouldRepeatLoginFlow = true;
 
             while (shouldRepeatLoginFlow) {
@@ -168,9 +201,10 @@ export class PreviewSite {
             }
         }
 
-        await PreviewSite.clearCache(this._websiteUrl);
 
-        await PreviewSite.launchBrowserAndDevToolsWithinVsCode(this._websiteUrl);
+        await PreviewSite.clearCache(this._websiteDetails.websiteUrl);
+
+        await PreviewSite.launchBrowserAndDevToolsWithinVsCode(this._websiteDetails.websiteUrl, this._websiteDetails.dataModel === WebsiteDataModel.Standard ? 1 : 2);
     }
 
     public static async clearCache(websiteUrl: string | undefined): Promise<void> {
@@ -237,9 +271,9 @@ export class PreviewSite {
 
                     progress.report({ message: Messages.GETTING_WEBSITE_ENDPOINT });
 
-                    await PreviewSite.loadSiteUrl(getWorkspaceFolders());
+                    await PreviewSite.loadSiteDetails(getWorkspaceFolders());
 
-                    if (this._websiteUrl === "") {
+                    if (!this._websiteDetails?.websiteUrl) {
                         shouldRepeatLoginFlow = true;
                     }
                 }

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -856,7 +856,7 @@ describe('ActionsHubCommandHandlers', () => {
             });
             mockShowInformationMessage.resolves(undefined);
 
-            await uploadSite(mockSiteTreeItem);
+            await uploadSite(mockSiteTreeItem, "");
 
             expect(mockShowInformationMessage.calledOnce).to.be.true;
             expect(mockSendText.called).to.be.false;
@@ -893,7 +893,7 @@ describe('ActionsHubCommandHandlers', () => {
             });
             mockShowInformationMessage.resolves(Constants.Strings.YES);
 
-            await uploadSite(mockSiteTreeItem);
+            await uploadSite(mockSiteTreeItem, "");
 
             expect(mockShowInformationMessage.calledOnce).to.be.true;
             expect(mockSendText.calledOnceWith(`pac pages upload --path "test-path" --modelVersion "1"`)).to.be.true;
@@ -913,7 +913,7 @@ describe('ActionsHubCommandHandlers', () => {
 
             mockSendText.throws(new Error('Upload failed'));
 
-            await uploadSite(mockSiteTreeItem);
+            await uploadSite(mockSiteTreeItem, "");
 
             expect(traceErrorStub.calledOnce).to.be.true;
             expect(traceErrorStub.firstCall.args[0]).to.equal(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE_FAILED);

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -620,7 +620,7 @@ describe('ActionsHubCommandHandlers', () => {
             await previewSite(siteTreeItem);
 
             expect(mockPreviewSiteClearCache.calledOnceWith('https://test-site.com')).to.be.true;
-            expect(mockLaunchBrowserAndDevTools.calledOnceWith('https://test-site.com')).to.be.true;
+            expect(mockLaunchBrowserAndDevTools.calledOnceWith('https://test-site.com', 1)).to.be.true;
         });
     });
 

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -833,7 +833,7 @@ describe('ActionsHubCommandHandlers', () => {
             });
             mockShowInformationMessage.resolves(Constants.Strings.YES);
 
-            await uploadSite(mockSiteTreeItem);
+            await uploadSite(mockSiteTreeItem, "");
 
             expect(mockShowInformationMessage.calledOnce).to.be.true;
             expect(mockShowInformationMessage.firstCall.args[0]).to.equal(Constants.Strings.SITE_UPLOAD_CONFIRMATION);
@@ -852,7 +852,7 @@ describe('ActionsHubCommandHandlers', () => {
                 siteManagementUrl: "https://inactive-site-1-management.com"
             });
 
-            await uploadSite(mockSiteTreeItem);
+            await uploadSite(mockSiteTreeItem, "");
 
             expect(mockShowInformationMessage.called).to.be.false;
             expect(mockSendText.calledOnceWith(`pac pages upload --path "test-path" --modelVersion "1"`)).to.be.true;

--- a/src/client/test/Integration/power-pages/preview-site/PreviewSite.test.ts
+++ b/src/client/test/Integration/power-pages/preview-site/PreviewSite.test.ts
@@ -72,35 +72,35 @@ describe('PreviewSite', () => {
         const mockWorkspaceFolders = [{ uri: 'test/path', name: 'test', index: 0 }];
 
         beforeEach(() => {
-            PreviewSite['_websiteUrl'] = undefined;
+            PreviewSite['_websiteDetails'] = undefined;
         });
 
         it('should set website URL when getWebSiteUrl returns valid URL', async () => {
             // Arrange
             const expectedUrl = 'https://test-website.com';
             const getWebSiteUrlStub = sandbox.stub();
-            getWebSiteUrlStub.resolves(expectedUrl);
-            PreviewSite['getWebSiteUrl'] = getWebSiteUrlStub;
+            getWebSiteUrlStub.resolves({ url: expectedUrl, dataModel: 'Enhanced'});
+            PreviewSite['getWebsiteDetails'] = getWebSiteUrlStub;
 
             // Act
-            await PreviewSite.loadSiteUrl(mockWorkspaceFolders);
+            await PreviewSite.loadSiteDetails(mockWorkspaceFolders);
 
             // Assert
-            expect(PreviewSite['_websiteUrl']).to.equal(expectedUrl);
+            expect(PreviewSite['_websiteDetails']).to.deep.equal({ url: expectedUrl, dataModel: 'Enhanced' })
             expect(getWebSiteUrlStub.calledOnceWith(mockWorkspaceFolders)).to.be.true;
         });
 
-        it('should set empty string when getWebSiteUrl returns empty string', async () => {
+        it('should set details when getWebSiteUrl returns empty URL string', async () => {
             // Arrange
             const getWebSiteUrlStub = sandbox.stub();
-            getWebSiteUrlStub.resolves('');
-            PreviewSite['getWebSiteUrl'] = getWebSiteUrlStub;
+            getWebSiteUrlStub.resolves({ url: '', dataModel: 'Enhanced'});
+            PreviewSite['getWebsiteDetails'] = getWebSiteUrlStub;
 
             // Act
-            await PreviewSite.loadSiteUrl(mockWorkspaceFolders);
+            await PreviewSite.loadSiteDetails(mockWorkspaceFolders);
 
             // Assert
-            expect(PreviewSite['_websiteUrl']).to.equal('');
+            expect(PreviewSite['_websiteDetails']).to.deep.equal({ url: '', dataModel: 'Enhanced' });
             expect(getWebSiteUrlStub.calledOnceWith(mockWorkspaceFolders)).to.be.true;
         });
     });

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -41,6 +41,8 @@ export const PORTAL_YEOMAN_GENERATOR_PACKAGE_TARBALL_NAME = "microsoft-generator
 
 export const SUCCESS = "Success";
 
+export const TRUE = "True";
+
 // Define the schema for file extensions
 export const componentTypeSchema: { [key: string]: { [key: string]: string } } = {
     'adx_webpage': {


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality and maintainability of the `PreviewSite` class and related components. The changes include adding new methods, updating existing methods to handle additional parameters, and modifying constants and test cases to support these updates.

### Enhancements to `PreviewSite` functionality:

* Added a new method `pendingChanges` to the `PacWrapper` class to check for pending changes on a website (`src/client/pac/PacWrapper.ts`).
* Updated the `initialize` method of the `PreviewSite` class to accept a `PacTerminal` parameter and store it for later use (`src/client/power-pages/preview-site/PreviewSite.ts`).
* Modified the `launchBrowserAndDevToolsWithinVsCode` method to take an additional `dataModelVersion` parameter and show a warning if there are pending changes (`src/client/power-pages/preview-site/PreviewSite.ts`). [[1]](diffhunk://#diff-30c5d95c2f7cf50fb017471e573cf9092cb8081368a289e30cf7dcfd03741684L111-R120) [[2]](diffhunk://#diff-30c5d95c2f7cf50fb017471e573cf9092cb8081368a289e30cf7dcfd03741684L128-R161)
* Replaced `_websiteUrl` with `_websiteDetails` in the `PreviewSite` class to store more comprehensive website information (`src/client/power-pages/preview-site/PreviewSite.ts`). [[1]](diffhunk://#diff-30c5d95c2f7cf50fb017471e573cf9092cb8081368a289e30cf7dcfd03741684L149-R182) [[2]](diffhunk://#diff-30c5d95c2f7cf50fb017471e573cf9092cb8081368a289e30cf7dcfd03741684L163-R207)

![Pending Changes](https://github.com/user-attachments/assets/8c79578d-a5d8-4213-aacf-97635309cf41)
