### PR TITLE
[Power Pages] [Actions Hub] Enhance revealInOS command to support others ites

### DIFF
--- a/package.json
+++ b/package.json
@@ -1092,17 +1092,17 @@
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.windows",
-          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isWindows",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == otherSite) && isWindows",
           "group": "siteAction@5"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.mac",
-          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isMac",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == otherSite) && isMac",
           "group": "siteAction@5"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.currentActiveSite.revealInOS.linux",
-          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == currentActiveSite && isLinux",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && (viewItem == currentActiveSite || viewItem == otherSite) && isLinux",
           "group": "siteAction@5"
         },
         {

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -232,10 +232,17 @@ export const fetchWebsites = async (): Promise<{ activeSites: IWebsiteDetails[],
     return { activeSites: [], inactiveSites: [], otherSites: [] };
 }
 
-export const revealInOS = async () => {
-    if (CurrentSiteContext.currentSiteFolderPath) {
-        await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(CurrentSiteContext.currentSiteFolderPath));
+export const revealInOS = async (siteTreeItem: SiteTreeItem) => {
+    let folderPath = CurrentSiteContext.currentSiteFolderPath;
+    if (siteTreeItem.contextValue === Constants.ContextValues.OTHER_SITE) {
+        folderPath = siteTreeItem.siteInfo.folderPath || "";
     }
+
+    if (!folderPath) {
+        return;
+    }
+
+    await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(folderPath));
 }
 
 export const openSiteManagement = async (siteTreeItem: SiteTreeItem) => {

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -724,17 +724,36 @@ describe('ActionsHubCommandHandlers', () => {
             executeCommandStub.restore();
         });
 
-        it('should not reveal file in OS when file path is not provided', async () => {
-            sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => undefined);
-            await revealInOS();
+        describe('when opening active site', () => {
+            it('should not reveal file in OS when file path is not provided', async () => {
+                sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => undefined);
+                await revealInOS({ contextValue: Constants.ContextValues.CURRENT_ACTIVE_SITE } as SiteTreeItem);
 
-            expect(executeCommandStub.called).to.be.false;
+                expect(executeCommandStub.called).to.be.false;
+            });
+
+            it('should reveal file in OS when file path is provided', async () => {
+                const mockPath = 'test-path';
+                sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => mockPath);
+                await revealInOS({ contextValue: Constants.ContextValues.CURRENT_ACTIVE_SITE } as SiteTreeItem);
+
+                expect(executeCommandStub.calledOnceWith('revealFileInOS', vscode.Uri.file(mockPath))).to.be.true;
+            });
         });
 
-        it('should reveal file in OS when file path is provided', async () => {
-            const mockPath = 'test-path';
-            sinon.stub(CurrentSiteContext, 'currentSiteFolderPath').get(() => mockPath);
-            await revealInOS(); expect(executeCommandStub.calledOnceWith('revealFileInOS', vscode.Uri.file(mockPath))).to.be.true;
+        describe('when opening other site', () => {
+            it('should not reveal file in OS when file path is not provided', async () => {
+                await revealInOS({ contextValue: Constants.ContextValues.OTHER_SITE, siteInfo: {} } as SiteTreeItem);
+
+                expect(executeCommandStub.called).to.be.false;
+            });
+
+            it('should reveal file in OS when file path is provided', async () => {
+                const mockPath = 'test-path';
+                await revealInOS({ contextValue: Constants.ContextValues.OTHER_SITE, siteInfo: { folderPath: mockPath } } as SiteTreeItem);
+
+                expect(executeCommandStub.calledOnceWith('revealFileInOS', vscode.Uri.file(mockPath))).to.be.true;
+            });
         });
     });
 


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality of the `revealInOS` command and update the associated tests. The most important changes include modifying the command conditions in `package.json`, updating the `revealInOS` function to handle multiple site contexts, and adding new tests to cover these scenarios.

Enhancements to command functionality:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1095-R1105): Updated the conditions for `revealInOS` commands to handle both `currentActiveSite` and `otherSite` for Windows, Mac, and Linux.

Updates to `revealInOS` function:

* [`src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts`](diffhunk://#diff-1ab9691ce442179f489ba49f832a1f872247015667f1e1eab3bc8f027d457fc2L235-R245): Modified the `revealInOS` function to accept a `siteTreeItem` parameter and determine the folder path based on the site context.

Improvements to tests:

* [`src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts`](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772R727-R756): Added new test cases to verify the `revealInOS` function behavior for both `currentActiveSite` and `otherSite` contexts.


![image](https://github.com/user-attachments/assets/fb6fabff-725e-44d7-b5ca-7e1885f5fc8b)
