### PR TITLE
[Power Pages] [Actions Hub] Initialize Actions Hub for all workspaces

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -163,6 +163,9 @@ export async function activate(
 
     const workspaceFolders = getWorkspaceFolders();
 
+    // Init OrgChangeNotifier instance
+    OrgChangeNotifier.createOrgChangeNotifierInstance(pacTerminal.getWrapper());
+
     _context.subscriptions.push(
         orgChangeEvent(async (orgDetails: ActiveOrgOutput) => {
             const orgID = orgDetails.OrgId;
@@ -211,7 +214,7 @@ export async function activate(
                 oneDSLoggerWrapper.getLogger().traceInfo(desktopTelemetryEventNames.DESKTOP_EXTENSION_INIT_CONTEXT, initContext);
             }
 
-            if (!copilotNotificationShown) {
+            if (!copilotNotificationShown && workspaceContainsPortalConfigFolder(workspaceFolders)) {
                 let telemetryData = '';
                 let listOfActivePortals = [];
                 try {
@@ -242,9 +245,6 @@ export async function activate(
     );
 
     if (workspaceContainsPortalConfigFolder(workspaceFolders)) {
-
-        // Init OrgChangeNotifier instance
-        OrgChangeNotifier.createOrgChangeNotifierInstance(pacTerminal.getWrapper());
 
         vscode.workspace.onDidOpenTextDocument(didOpenTextDocument);
         vscode.workspace.textDocuments.forEach(didOpenTextDocument);


### PR DESCRIPTION
This pull request includes updates to the `src/client/extension.ts` file to improve the initialization process and conditional logic for showing notifications. The key changes are:

Initialization improvements:
* Added initialization of the `OrgChangeNotifier` instance earlier in the `activate` function to ensure it is set up before any potential organization changes are handled.

Conditional logic updates:
* Modified the condition for showing the copilot notification to include a check for the presence of a portal configuration folder in the workspace. This ensures that the notification is only shown when relevant.

Showing ActionsHub for non-Pages workspace:

![image](https://github.com/user-attachments/assets/292a74e1-f19a-491b-add2-c29ed00e1b46)

