### PR TITLE
[Power Pages] [Actions Hub] Handle null or undefined labels in ActionsHubTreeItem

### DIFF
--- a/src/client/power-pages/actions-hub/tree-items/ActionsHubTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/ActionsHubTreeItem.ts
@@ -7,15 +7,15 @@ import * as vscode from "vscode";
 
 export abstract class ActionsHubTreeItem extends vscode.TreeItem {
     constructor(
-        public readonly label: string,
+        label: string | null | undefined,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
         public readonly iconPath: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } | vscode.ThemeIcon,
         public readonly contextValue: string,
         public readonly description: string = "",
     ) {
-        super(label, collapsibleState);
+        super(label || "", collapsibleState);
 
-        this.tooltip = this.label;
+        this.tooltip = label || "";
     }
 
     public getChildren(): ActionsHubTreeItem[] {

--- a/src/client/power-pages/actions-hub/tree-items/ActiveGroupTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/ActiveGroupTreeItem.ts
@@ -39,12 +39,20 @@ export class ActiveGroupTreeItem extends ActionsHubTreeItem {
                 dataModelVersion: site.dataModel == WebsiteDataModel.Standard ? 1 : 2,
                 websiteUrl: site.websiteUrl,
                 status: WebsiteStatus.Active,
-                isCurrent: CurrentSiteContext.currentSiteId === site.websiteRecordId,
+                isCurrent: this.isCurrentSite(site.websiteRecordId),
                 siteVisibility: site.siteVisibility ?? "",
                 siteManagementUrl: site.siteManagementUrl
             };
 
             return new SiteTreeItem(siteInfo);
         });
+    }
+
+    private isCurrentSite(siteId: string): boolean {
+        if (!CurrentSiteContext.currentSiteId || !siteId) {
+            return false;
+        }
+
+        return CurrentSiteContext.currentSiteId === siteId;
     }
 }

--- a/src/client/test/Integration/power-pages/actions-hub/tree-items/ActionsHubTreeItem.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/tree-items/ActionsHubTreeItem.test.ts
@@ -8,9 +8,9 @@ import { expect } from "chai";
 import { ActionsHubTreeItem } from "../../../../../power-pages/actions-hub/tree-items/ActionsHubTreeItem";
 
 class MockTreeItem extends ActionsHubTreeItem {
-    constructor() {
+    constructor(label: string | null = "Foo") {
         super(
-            "Foo",
+            label,
             vscode.TreeItemCollapsibleState.Collapsed,
             "iconPath",
             "contextValue",
@@ -30,6 +30,12 @@ describe('ActionsHubTreeItem', () => {
         const treeItem = new MockTreeItem();
 
         expect(treeItem.label).to.be.equal("Foo");
+    });
+
+    it('should have expected label when null is passed', () => {
+        const treeItem = new MockTreeItem(null);
+
+        expect(treeItem.tooltip).to.be.equal("");
     });
 
     it('should have the expected collapsible state', () => {

--- a/src/client/test/Integration/power-pages/actions-hub/tree-items/ActiveGroupTreeItem.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/tree-items/ActiveGroupTreeItem.test.ts
@@ -59,11 +59,8 @@ describe('ActiveGroupTreeItem', () => {
         });
 
         describe('when active sites is not empty', () => {
-            beforeEach(() => {
-                sinon.stub(CurrentSiteContext, 'currentSiteId').value('1');
-            });
-
             it('should return an array of SiteTreeItem', () => {
+                sinon.stub(CurrentSiteContext, 'currentSiteId').value('1');
                 const activeWebsites: IWebsiteDetails[] = [
                     {
                         websiteRecordId: "1",
@@ -85,7 +82,7 @@ describe('ActiveGroupTreeItem', () => {
                         dataModel: WebsiteDataModel.Enhanced,
                         environmentId: "env2",
                         siteVisibility: "private",
-                        siteManagementUrl: "http://site1.com/manage"
+                        siteManagementUrl: "http://site2.com/manage"
                     }
                 ];
 
@@ -113,6 +110,71 @@ describe('ActiveGroupTreeItem', () => {
                     status: WebsiteStatus.Active,
                     isCurrent: false,
                     siteVisibility: "private",
+                    siteManagementUrl: "http://site2.com/manage"
+                });
+            });
+
+            it('should return an array of SiteTreeItem when site id is empty', () => {
+                sinon.stub(CurrentSiteContext, 'currentSiteId').value('');
+                const activeWebsites: IWebsiteDetails[] = [
+                    {
+                        websiteRecordId: "",
+                        name: "Site 1",
+                        websiteUrl: "http://site1.com",
+                        dataverseInstanceUrl: "http://dataverse1.com",
+                        dataverseOrganizationId: "org1",
+                        dataModel: WebsiteDataModel.Standard,
+                        environmentId: "env1",
+                        siteVisibility: "public",
+                        siteManagementUrl: "http://site1.com/manage"
+                    }
+                ];
+
+                const treeItem = new ActiveGroupTreeItem(activeWebsites);
+                const children = treeItem.getChildren();
+
+                const site1 = children[0] as SiteTreeItem;
+                expect(site1.siteInfo).to.deep.equal({
+                    name: 'Site 1',
+                    websiteId: '',
+                    dataModelVersion: 1,
+                    websiteUrl: 'http://site1.com',
+                    status: WebsiteStatus.Active,
+                    isCurrent: false,
+                    siteVisibility: "public",
+                    siteManagementUrl: "http://site1.com/manage"
+                });
+            });
+
+            it('should return an array of SiteTreeItem when site id is empty', () => {
+                sinon.stub(CurrentSiteContext, 'currentSiteId').value(null);
+                const activeWebsites: IWebsiteDetails[] = [
+                    {
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        websiteRecordId: null!,
+                        name: "Site 1",
+                        websiteUrl: "http://site1.com",
+                        dataverseInstanceUrl: "http://dataverse1.com",
+                        dataverseOrganizationId: "org1",
+                        dataModel: WebsiteDataModel.Standard,
+                        environmentId: "env1",
+                        siteVisibility: "public",
+                        siteManagementUrl: "http://site1.com/manage"
+                    }
+                ];
+
+                const treeItem = new ActiveGroupTreeItem(activeWebsites);
+                const children = treeItem.getChildren();
+
+                const site1 = children[0] as SiteTreeItem;
+                expect(site1.siteInfo).to.deep.equal({
+                    name: 'Site 1',
+                    websiteId: null,
+                    dataModelVersion: 1,
+                    websiteUrl: 'http://site1.com',
+                    status: WebsiteStatus.Active,
+                    isCurrent: false,
+                    siteVisibility: "public",
                     siteManagementUrl: "http://site1.com/manage"
                 });
             });


### PR DESCRIPTION
This pull request includes changes to the `ActionsHubTreeItem` class and its related tests to handle cases where the label is `null` or `undefined`. The most important changes include updating the constructor of `ActionsHubTreeItem` and adding a new test case to verify the behavior when a `null` label is passed.

Changes to `ActionsHubTreeItem` class:

* [`src/client/power-pages/actions-hub/tree-items/ActionsHubTreeItem.ts`](diffhunk://#diff-61c419179c9505d75e74089dd975a22c3f4c8af7d128efef523ca364c3bbb895L10-R18): Modified the constructor to accept `label` as `string | null | undefined` and updated the `tooltip` assignment to handle `null` or `undefined` labels.

Updates to tests:

* [`src/client/test/Integration/power-pages/actions-hub/tree-items/ActionsHubTreeItem.test.ts`](diffhunk://#diff-984437611279655f34ad138f4785f660a18e9fcf0b4676f24fc082c59e9b2a5fL11-R13): Modified the `MockTreeItem` constructor to accept a `label` parameter and added a new test case to verify the behavior when a `null` label is passed. [[1]](diffhunk://#diff-984437611279655f34ad138f4785f660a18e9fcf0b4676f24fc082c59e9b2a5fL11-R13) [[2]](diffhunk://#diff-984437611279655f34ad138f4785f660a18e9fcf0b4676f24fc082c59e9b2a5fR35-R40)