### PR TITLE
Remove outline from feedback button styles

### DIFF
--- a/src/common/copilot/user-feedback/feedback.css
+++ b/src/common/copilot/user-feedback/feedback.css
@@ -30,7 +30,6 @@ body {
     color: var(--vscode-button-foreground);
     cursor: pointer;
     padding: 6px 11px;
-    outline: 1px solid transparent;
     outline-offset: 2px !important;
     border-radius: 2px;
 }


### PR DESCRIPTION
- ✨ Removed the outline property from button styles for improved accessibility.

![image](https://github.com/user-attachments/assets/0e8f03dd-0fd5-4fca-8632-d68689f29435)

Color contrast ratio of outline
![image](https://github.com/user-attachments/assets/a4b99aa0-533b-4084-bd93-989bc3811937)
