### PR TITLE
Fix typos in OneDSLogger and oneDSLoggerWrapper

### DIFF
--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -116,12 +116,12 @@ export class OneDSLogger implements ITelemetryLogger {
         if ((coreConfig.instrumentationKey ?? "") !== "") {
             this.appInsightsCore.initialize(coreConfig, []);
         }
-        this.intitializeContextInfo();
+        this.initializeContextInfo();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.appInsightsCore.addTelemetryInitializer(this.populateCommonAttributes());
     }
 
-    private intitializeContextInfo() {
+    private initializeContextInfo() {
         OneDSLogger.contextInfo = {
             orgId: "",
             portalId: "",

--- a/src/common/OneDSLoggerTelemetry/oneDSLoggerWrapper.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLoggerWrapper.ts
@@ -12,10 +12,10 @@ import { OneDSLogger } from "./oneDSLogger";
 
 export class oneDSLoggerWrapper {
     private static instance: oneDSLoggerWrapper;
-    private static oneDSLoggerIntance: OneDSLogger;
+    private static oneDSLoggerInstance: OneDSLogger;
 
     private constructor(geo?: string, geoLongName?: string) {
-        oneDSLoggerWrapper.oneDSLoggerIntance = new OneDSLogger(geo, geoLongName);
+        oneDSLoggerWrapper.oneDSLoggerInstance = new OneDSLogger(geo, geoLongName);
     }
 
 
@@ -31,7 +31,7 @@ export class oneDSLoggerWrapper {
     public traceInfo(eventName: string, eventInfo?: object, measurement?: object) {
         try {
             if (!isCustomTelemetryEnabled()) return;
-            oneDSLoggerWrapper.oneDSLoggerIntance.traceInfo(eventName, eventInfo, measurement);
+            oneDSLoggerWrapper.oneDSLoggerInstance.traceInfo(eventName, eventInfo, measurement);
         } catch (exception) {
             console.warn(exception);
         }
@@ -41,7 +41,7 @@ export class oneDSLoggerWrapper {
     public traceWarning(eventName: string, eventInfo?: object, measurement?: object) {
         try {
             if (!isCustomTelemetryEnabled()) return;
-            oneDSLoggerWrapper.oneDSLoggerIntance.traceWarning(eventName, eventInfo, measurement);
+            oneDSLoggerWrapper.oneDSLoggerInstance.traceWarning(eventName, eventInfo, measurement);
         } catch (exception) {
             console.warn(exception);
         }
@@ -51,7 +51,7 @@ export class oneDSLoggerWrapper {
     public traceError(eventName: string, errorMessage: string, exception: Error, eventInfo?: object, measurement?: object) {
         try {
             if (!isCustomTelemetryEnabled()) return;
-            oneDSLoggerWrapper.oneDSLoggerIntance.traceError(eventName, errorMessage, exception, eventInfo, measurement);
+            oneDSLoggerWrapper.oneDSLoggerInstance.traceError(eventName, errorMessage, exception, eventInfo, measurement);
         } catch (exception) {
             console.warn("Caught exception processing the telemetry event: " + exception);
             console.warn(exception);
@@ -62,7 +62,7 @@ export class oneDSLoggerWrapper {
     public featureUsage(featureName: string, eventName: string, customDimensions?: object) {
         try {
             if (!isCustomTelemetryEnabled()) return;
-            oneDSLoggerWrapper.oneDSLoggerIntance.featureUsage(featureName, eventName, customDimensions);
+            oneDSLoggerWrapper.oneDSLoggerInstance.featureUsage(featureName, eventName, customDimensions);
         } catch (exception) {
             console.warn(exception);
         }


### PR DESCRIPTION
- ✏️ Corrected spelling of 'initialize' in OneDSLogger and oneDSLoggerWrapper classes
- 🔧 Updated variable name from 'oneDSLoggerIntance' to 'oneDSLoggerInstance' for consistency