### PR TITLE
[Powerpages][ActionsHub]Sort active websites by creation date in fetchWebsites function

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -235,6 +235,11 @@ export const fetchWebsites = async (): Promise<{ activeSites: IWebsiteDetails[],
                 }
             });
 
+            // Sort activesites based on created on date, newly created sites will be on top
+            activeWebsiteDetails.sort((a, b) => {
+                return moment(b.createdOn).diff(moment(a.createdOn));
+            });
+
             const currentEnvSiteIds = createKnownSiteIdsSet(activeWebsiteDetails, inactiveWebsiteDetails);
             const otherSites = findOtherSites(currentEnvSiteIds);
 

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -235,10 +235,8 @@ export const fetchWebsites = async (): Promise<{ activeSites: IWebsiteDetails[],
                 }
             });
 
-            // Sort activesites based on created on date, newly created sites will be on top
-            activeWebsiteDetails.sort((a, b) => {
-                return moment(b.createdOn).diff(moment(a.createdOn));
-            });
+            activeWebsiteDetails.sort(sortByCreatedOn);
+            inactiveWebsiteDetails.sort(sortByCreatedOn);
 
             const currentEnvSiteIds = createKnownSiteIdsSet(activeWebsiteDetails, inactiveWebsiteDetails);
             const otherSites = findOtherSites(currentEnvSiteIds);
@@ -597,4 +595,10 @@ export const openInStudio = async (siteTreeItem: SiteTreeItem) => {
     }
 
     await vscode.env.openExternal(vscode.Uri.parse(studioUrl));
+}
+
+export function sortByCreatedOn<T extends { createdOn?: string | null }>(item1: T, item2: T): number {
+    const date1 = new Date(item1.createdOn || '').valueOf(); //NaN if createdOn is null or undefined
+    const date2 = new Date(item2.createdOn || '').valueOf();
+    return date2 - date1; // Sort in descending order (newest first)
 }


### PR DESCRIPTION
This pull request includes a change to the `fetchWebsites` function in `src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts`. The change adds a sorting mechanism for `activeWebsiteDetails` based on the `createdOn` date, ensuring newly created sites appear at the top.

* [`src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts`](diffhunk://#diff-1ab9691ce442179f489ba49f832a1f872247015667f1e1eab3bc8f027d457fc2R238-R242): Added sorting for `activeWebsiteDetails` based on the `createdOn` date.

[Bug 4767957](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4767957): [Actions Hub] The order of the site lists in 'Active Sites' and 'Inactive Sites' appears different in VsCode compared to PP Home.