### PR TITLE
[Power Pages][Preview] Close existing Edge DevTools before launching preview

### DIFF
--- a/src/client/power-pages/preview-site/Constants.ts
+++ b/src/client/power-pages/preview-site/Constants.ts
@@ -37,5 +37,6 @@ export const Messages = {
 export const Events = {
     PREVIEW_SITE_INITIALIZED: "PreviewSiteInitialized",
     PREVIEW_SITE_INITIALIZATION_FAILED: "PreviewSiteInitializationFailed",
-    PREVIEW_SITE_UPLOAD_WARNING_FAILED: "PreviewSiteUploadWarningFailed"
+    PREVIEW_SITE_UPLOAD_WARNING_FAILED: "PreviewSiteUploadWarningFailed",
+    PREVIEW_SITE_CLOSE_EXISTING_PREVIEW_FAILED: "PreviewSiteCloseExistingPreviewFailed"
 }

--- a/src/client/power-pages/preview-site/PreviewSite.ts
+++ b/src/client/power-pages/preview-site/PreviewSite.ts
@@ -131,7 +131,10 @@ export class PreviewSite {
 
         await showProgressWithNotification(
             Messages.OPENING_SITE_PREVIEW,
-            async () => await vscode.commands.executeCommand('vscode-edge-devtools.launch', { launchUrl: webSitePreviewURL })
+            async () => {
+                PreviewSite.closeExistingPreview();
+                await vscode.commands.executeCommand('vscode-edge-devtools.launch', { launchUrl: webSitePreviewURL });
+            }
         );
 
         const websitePath = CurrentSiteContext.currentSiteFolderPath;
@@ -285,5 +288,15 @@ export class PreviewSite {
         }
 
         return shouldRepeatLoginFlow;
+    }
+
+    private static closeExistingPreview() {
+        vscode.window.tabGroups.all.forEach((tabGroup) => {
+            tabGroup.tabs.forEach(async (tab) => {
+                if (tab.label.toLowerCase().startsWith("edge devtools")) {
+                    await vscode.window.tabGroups.close(tab);
+                }
+            });
+        });
     }
 }

--- a/src/client/power-pages/preview-site/PreviewSite.ts
+++ b/src/client/power-pages/preview-site/PreviewSite.ts
@@ -75,6 +75,9 @@ export class PreviewSite {
             }
 
             PreviewSite._isInitialized = true;
+            oneDSLoggerWrapper.getLogger().traceInfo(Events.PREVIEW_SITE_INITIALIZED, {
+                isEnabled: isSiteRuntimePreviewEnabled.toString()
+            });
         } catch (exception) {
             const exceptionError = exception as Error;
             oneDSLoggerWrapper.getLogger().traceError(Events.PREVIEW_SITE_INITIALIZATION_FAILED, exceptionError.message, exceptionError);
@@ -291,12 +294,17 @@ export class PreviewSite {
     }
 
     private static closeExistingPreview() {
-        vscode.window.tabGroups.all.forEach((tabGroup) => {
-            tabGroup.tabs.forEach(async (tab) => {
-                if (tab.label.toLowerCase().startsWith("edge devtools")) {
-                    await vscode.window.tabGroups.close(tab);
-                }
+        try {
+            vscode.window.tabGroups.all.forEach((tabGroup) => {
+                tabGroup.tabs.forEach(async (tab) => {
+                    if (tab.label.toLowerCase().startsWith("edge devtools")) {
+                        await vscode.window.tabGroups.close(tab);
+                    }
+                });
             });
-        });
+        } catch (error) {
+            const exceptionError = error as Error;
+            oneDSLoggerWrapper.getLogger().traceError(Events.PREVIEW_SITE_CLOSE_EXISTING_PREVIEW_FAILED, (error as Error).message, exceptionError);
+        }
     }
 }


### PR DESCRIPTION
- 🔧 Added a method to close existing Edge DevTools tabs before launching a new preview.
- 🚀 Updated the site preview command to ensure no duplicate DevTools instances are open.

![Close existing preview](https://github.com/user-attachments/assets/fc08234a-a89f-4d24-a671-d204d74b9417)
