### PR TITLE
[Power Pages][Actions Hub] Refactor telemetry logging 

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as yaml from 'yaml';
 import { Constants } from './Constants';
-import { oneDSLoggerWrapper } from '../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper';
 import { PacTerminal } from '../../lib/PacTerminal';
 import { SUCCESS, UTF8_ENCODING, WEBSITE_YML } from '../../../common/constants';
 import { AuthInfo, OrgListOutput } from '../../pac/PacTypes';
@@ -30,7 +29,7 @@ import { isEdmEnvironment } from '../../../common/copilot/dataverseMetadata';
 import { IWebsiteInfo } from './models/IWebsiteInfo';
 import moment from 'moment';
 import { SiteVisibility } from './models/SiteVisibility';
-import { getBaseEventInfo } from './TelemetryHelper';
+import { getBaseEventInfo, traceError, traceInfo } from './TelemetryHelper';
 
 const sortByCreatedOn = <T extends { createdOn?: string | null }>(item1: T, item2: T): number => {
     const date1 = new Date(item1.createdOn || '').valueOf(); //NaN if createdOn is null or undefined
@@ -39,7 +38,7 @@ const sortByCreatedOn = <T extends { createdOn?: string | null }>(item1: T, item
 }
 
 export const refreshEnvironment = async (pacTerminal: PacTerminal) => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_REFRESH_ENVIRONMENT_CALLED, { methodName: refreshEnvironment.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_REFRESH_ENVIRONMENT_CALLED, { methodName: refreshEnvironment.name });
     const pacWrapper = pacTerminal.getWrapper();
     try {
         const pacActiveAuth = await pacWrapper.activeAuth();
@@ -48,7 +47,7 @@ export const refreshEnvironment = async (pacTerminal: PacTerminal) => {
             PacContext.setContext(authInfo);
         }
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_REFRESH_FAILED, error as string, error as Error, { methodName: refreshEnvironment.name }, {});
+        traceError(Constants.EventNames.ACTIONS_HUB_REFRESH_FAILED, error as Error, { methodName: refreshEnvironment.name });
     }
 }
 
@@ -76,7 +75,7 @@ const getEnvironmentDetails = () => {
 };
 
 export const showEnvironmentDetails = async () => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_SHOW_ENVIRONMENT_DETAILS_CALLED, { methodName: showEnvironmentDetails.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_SHOW_ENVIRONMENT_DETAILS_CALLED, { methodName: showEnvironmentDetails.name });
     try {
         const message = Constants.Strings.SESSION_DETAILS;
         const details = getEnvironmentDetails();
@@ -87,7 +86,7 @@ export const showEnvironmentDetails = async () => {
             await vscode.env.clipboard.writeText(details);
         }
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_SHOW_ENVIRONMENT_DETAILS_FAILED, error as string, error as Error, { methodName: showEnvironmentDetails.name }, {});
+        traceError(Constants.EventNames.ACTIONS_HUB_SHOW_ENVIRONMENT_DETAILS_FAILED, error as Error, { methodName: showEnvironmentDetails.name });
     }
 };
 
@@ -109,7 +108,7 @@ const getEnvironmentList = async (pacTerminal: PacTerminal, authInfo: AuthInfo):
 }
 
 export const switchEnvironment = async (pacTerminal: PacTerminal) => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_SWITCH_ENVIRONMENT_CALLED, { methodName: switchEnvironment.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_SWITCH_ENVIRONMENT_CALLED, { methodName: switchEnvironment.name });
     const pacWrapper = pacTerminal.getWrapper();
     const authInfo = PacContext.AuthInfo;
 
@@ -125,11 +124,11 @@ export const switchEnvironment = async (pacTerminal: PacTerminal) => {
                 await showProgressWithNotification(Constants.Strings.CHANGING_ENVIRONMENT, async () => await pacWrapper.orgSelect(selectedEnv.detail));
                 await vscode.window.showInformationMessage(Constants.Strings.ENVIRONMENT_CHANGED_SUCCESSFULLY);
             } else {
-                oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_SWITCH_ENVIRONMENT_CANCELLED, { methodName: switchEnvironment.name, ...getBaseEventInfo() });
+                traceInfo(Constants.EventNames.ACTIONS_HUB_SWITCH_ENVIRONMENT_CANCELLED, { methodName: switchEnvironment.name });
             }
         }
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_SWITCH_ENVIRONMENT_FAILED, error as string, error as Error, { methodName: switchEnvironment.name, ...getBaseEventInfo() });
+        traceError(Constants.EventNames.ACTIONS_HUB_SWITCH_ENVIRONMENT_FAILED, error as Error, { methodName: switchEnvironment.name });
     }
 }
 
@@ -171,36 +170,36 @@ const getActiveSitesUrl = () => `${getPPHomeUrl()}/?tab=active`;
 const getInactiveSitesUrl = () => `${getPPHomeUrl()}/?tab=inactive`;
 
 export const openActiveSitesInStudio = async () => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_OPEN_ACTIVE_SITES_IN_STUDIO_CALLED, { methodName: openActiveSitesInStudio.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_OPEN_ACTIVE_SITES_IN_STUDIO_CALLED, { methodName: openActiveSitesInStudio.name });
     try {
         await vscode.env.openExternal(vscode.Uri.parse(getActiveSitesUrl()));
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_OPEN_ACTIVE_SITES_IN_STUDIO_FAILED, error as string, error as Error, { methodName: openActiveSitesInStudio.name, ...getBaseEventInfo() });
+        traceError(Constants.EventNames.ACTIONS_HUB_OPEN_ACTIVE_SITES_IN_STUDIO_FAILED, error as Error, { methodName: openActiveSitesInStudio.name });
     }
 };
 
 export const openInactiveSitesInStudio = async () => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_OPEN_INACTIVE_SITES_IN_STUDIO_CALLED, { methodName: openInactiveSitesInStudio.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_OPEN_INACTIVE_SITES_IN_STUDIO_CALLED, { methodName: openInactiveSitesInStudio.name });
     try {
         await vscode.env.openExternal(vscode.Uri.parse(getInactiveSitesUrl()));
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_OPEN_INACTIVE_SITES_IN_STUDIO_FAILED, error as string, error as Error, { methodName: openInactiveSitesInStudio.name, ...getBaseEventInfo() });
+        traceError(Constants.EventNames.ACTIONS_HUB_OPEN_INACTIVE_SITES_IN_STUDIO_FAILED, error as Error, { methodName: openInactiveSitesInStudio.name });
     }
 };
 
 export const previewSite = async (siteTreeItem: SiteTreeItem) => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_PREVIEW_SITE_CALLED, { methodName: previewSite.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_PREVIEW_SITE_CALLED, { methodName: previewSite.name });
     try {
         await PreviewSite.clearCache(siteTreeItem.siteInfo.websiteUrl);
 
         await PreviewSite.launchBrowserAndDevToolsWithinVsCode(siteTreeItem.siteInfo.websiteUrl, siteTreeItem.siteInfo.dataModelVersion, siteTreeItem.siteInfo.siteVisibility);
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_PREVIEW_SITE_FAILED, error as string, error as Error, { methodName: previewSite.name, ...getBaseEventInfo() });
+        traceError(Constants.EventNames.ACTIONS_HUB_PREVIEW_SITE_FAILED, error as Error, { methodName: previewSite.name });
     }
 };
 
 export const createNewAuthProfile = async (pacWrapper: PacWrapper): Promise<void> => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_CREATE_AUTH_PROFILE_CALLED, { methodName: createNewAuthProfile.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_CREATE_AUTH_PROFILE_CALLED, { methodName: createNewAuthProfile.name });
     try {
         const pacAuthCreateOutput = await createAuthProfileExp(pacWrapper);
         if (pacAuthCreateOutput && pacAuthCreateOutput.Status === SUCCESS) {
@@ -211,41 +210,37 @@ export const createNewAuthProfile = async (pacWrapper: PacWrapper): Promise<void
                     // DV authentication is required to ensure PAC and VSCode accounts are in sync
                     await dataverseAuthentication(orgUrl, true);
                 } else {
-                    oneDSLoggerWrapper.getLogger().traceError(
+                    traceError(
                         createNewAuthProfile.name,
-                        Constants.Strings.ORGANIZATION_URL_MISSING,
                         new Error(Constants.Strings.ORGANIZATION_URL_MISSING),
-                        {}
+                        { methodName: createNewAuthProfile.name }
                     );
                 }
             } else {
-                oneDSLoggerWrapper.getLogger().traceError(
+                traceError(
                     createNewAuthProfile.name,
-                    Constants.Strings.EMPTY_RESULTS_ARRAY,
                     new Error(Constants.Strings.EMPTY_RESULTS_ARRAY),
-                    {}
+                    { methodName: createNewAuthProfile.name }
                 );
             }
         } else {
-            oneDSLoggerWrapper.getLogger().traceError(
+            traceError(
                 createNewAuthProfile.name,
-                Constants.Strings.PAC_AUTH_OUTPUT_FAILURE,
                 new Error(Constants.Strings.PAC_AUTH_OUTPUT_FAILURE),
-                {}
+                { methodName: createNewAuthProfile.name }
             );
         }
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(
+        traceError(
             Constants.EventNames.ACTIONS_HUB_CREATE_AUTH_PROFILE_FAILED,
-            error as string,
             error as Error,
-            { methodName: createNewAuthProfile.name, ...getBaseEventInfo() }
+            { methodName: createNewAuthProfile.name }
         );
     }
 };
 
 export const fetchWebsites = async (): Promise<{ activeSites: IWebsiteDetails[], inactiveSites: IWebsiteDetails[], otherSites: IOtherSiteInfo[] }> => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_FETCH_WEBSITES_CALLED, { methodName: fetchWebsites.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_FETCH_WEBSITES_CALLED, { methodName: fetchWebsites.name });
     try {
         const orgInfo = PacContext.OrgInfo;
         if (ArtemisContext.ServiceResponse?.stamp && orgInfo) {
@@ -281,14 +276,14 @@ export const fetchWebsites = async (): Promise<{ activeSites: IWebsiteDetails[],
             return { activeSites: activeWebsiteDetails, inactiveSites: inactiveWebsiteDetails, otherSites: otherSites };
         }
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_FETCH_WEBSITES_FAILED, error as string, error as Error, { methodName: fetchWebsites.name }, {});
+        traceError(Constants.EventNames.ACTIONS_HUB_FETCH_WEBSITES_FAILED, error as Error, { methodName: fetchWebsites.name });
     }
 
     return { activeSites: [], inactiveSites: [], otherSites: [] };
 }
 
 export const revealInOS = async (siteTreeItem: SiteTreeItem) => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_REVEAL_IN_OS_CALLED, { methodName: revealInOS.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_REVEAL_IN_OS_CALLED, { methodName: revealInOS.name });
     try {
         let folderPath = CurrentSiteContext.currentSiteFolderPath;
         if (siteTreeItem.contextValue === Constants.ContextValues.OTHER_SITE) {
@@ -299,31 +294,30 @@ export const revealInOS = async (siteTreeItem: SiteTreeItem) => {
             return;
         }
 
-        oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_REVEAL_IN_OS_SUCCESSFUL, { methodName: revealInOS.name, ...getBaseEventInfo() });
+        traceInfo(Constants.EventNames.ACTIONS_HUB_REVEAL_IN_OS_SUCCESSFUL, { methodName: revealInOS.name });
         await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(folderPath));
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_REVEAL_IN_OS_FAILED, error as string, error as Error, { methodName: revealInOS.name, ...getBaseEventInfo() });
+        traceError(Constants.EventNames.ACTIONS_HUB_REVEAL_IN_OS_FAILED, error as Error, { methodName: revealInOS.name });
     }
 }
 
 export const openSiteManagement = async (siteTreeItem: SiteTreeItem) => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_OPEN_SITE_MANAGEMENT_CALLED, { methodName: openSiteManagement.name, siteId: siteTreeItem.siteInfo.websiteId, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_OPEN_SITE_MANAGEMENT_CALLED, { methodName: openSiteManagement.name, siteId: siteTreeItem.siteInfo.websiteId });
     try {
         if (!siteTreeItem.siteInfo.siteManagementUrl) {
             vscode.window.showErrorMessage(vscode.l10n.t(Constants.Strings.SITE_MANAGEMENT_URL_NOT_FOUND));
-            oneDSLoggerWrapper.getLogger().traceError(
-                Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND,
+            traceError(
                 Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND,
                 new Error(Constants.EventNames.SITE_MANAGEMENT_URL_NOT_FOUND),
-                { method: openSiteManagement.name, siteId: siteTreeItem.siteInfo.websiteId, ...getBaseEventInfo() }
+                { method: openSiteManagement.name, siteId: siteTreeItem.siteInfo.websiteId }
             );
             return;
         }
 
-        oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_OPEN_SITE_MANAGEMENT_SUCCESSFUL, { methodName: openSiteManagement.name, siteId: siteTreeItem.siteInfo.websiteId, ...getBaseEventInfo() });
+        traceInfo(Constants.EventNames.ACTIONS_HUB_OPEN_SITE_MANAGEMENT_SUCCESSFUL, { methodName: openSiteManagement.name, siteId: siteTreeItem.siteInfo.websiteId });
         await vscode.env.openExternal(vscode.Uri.parse(siteTreeItem.siteInfo.siteManagementUrl));
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(Constants.EventNames.ACTIONS_HUB_OPEN_SITE_MANAGEMENT_FAILED, error as string, error as Error, { methodName: openSiteManagement.name, siteId: siteTreeItem.siteInfo.websiteId, ...getBaseEventInfo() });
+        traceError(Constants.EventNames.ACTIONS_HUB_OPEN_SITE_MANAGEMENT_FAILED, error as Error, { methodName: openSiteManagement.name, siteId: siteTreeItem.siteInfo.websiteId });
     }
 }
 
@@ -333,7 +327,7 @@ export const openSiteManagement = async (siteTreeItem: SiteTreeItem) => {
  * @param websitePath The path to the website folder to upload. If not passed the current site context will be used.
  */
 export const uploadSite = async (siteTreeItem: SiteTreeItem, websitePath: string) => {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE_CALLED, { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE_CALLED, { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId });
     try {
         // Handle upload for "other" sites (sites not in the current environment)
         if (siteTreeItem.contextValue === Constants.ContextValues.OTHER_SITE) {
@@ -344,11 +338,10 @@ export const uploadSite = async (siteTreeItem: SiteTreeItem, websitePath: string
         // Handle upload for active/inactive sites
         await uploadCurrentSite(siteTreeItem, websitePath);
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(
+        traceError(
             Constants.EventNames.ACTIONS_HUB_UPLOAD_SITE_FAILED,
-            error as string,
             error as Error,
-            { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId, ...getBaseEventInfo() }
+            { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId }
         );
     }
 };
@@ -358,7 +351,7 @@ export const uploadSite = async (siteTreeItem: SiteTreeItem, websitePath: string
  * @param siteTreeItem The site tree item containing site information
  */
 async function uploadOtherSite(siteTreeItem: SiteTreeItem): Promise<void> {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_OTHER_SITE_CALLED, { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_OTHER_SITE_CALLED, { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId });
     const websitePath = siteTreeItem.siteInfo.folderPath;
 
     if (!websitePath) {
@@ -379,7 +372,7 @@ async function uploadOtherSite(siteTreeItem: SiteTreeItem): Promise<void> {
         }
     }
 
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_OTHER_SITE_PAC_TRIGGERED, { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId, dataModelVersion, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_OTHER_SITE_PAC_TRIGGERED, { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId, dataModelVersion });
     PacTerminal.getTerminal().sendText(`pac pages upload --path "${websitePath}" ${modelVersionParam}`);
 }
 
@@ -388,7 +381,7 @@ async function uploadOtherSite(siteTreeItem: SiteTreeItem): Promise<void> {
  * @param siteTreeItem The site tree item containing site information
  */
 async function uploadCurrentSite(siteTreeItem: SiteTreeItem, websitePath: string): Promise<void> {
-    oneDSLoggerWrapper.getLogger().traceInfo(
+    traceInfo(
         Constants.EventNames.ACTIONS_HUB_UPLOAD_CURRENT_SITE_CALLED,
         {
             methodName: uploadSite.name,
@@ -407,7 +400,7 @@ async function uploadCurrentSite(siteTreeItem: SiteTreeItem, websitePath: string
         );
 
         if (confirm !== Constants.Strings.YES) {
-            oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_CURRENT_SITE_CANCELLED_PUBLIC_SITE, {
+            traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_CURRENT_SITE_CANCELLED_PUBLIC_SITE, {
                 methodName: uploadSite.name,
                 siteId: siteTreeItem.siteInfo.websiteId,
                 modelVersion: siteTreeItem.siteInfo.dataModelVersion,
@@ -425,7 +418,7 @@ async function uploadCurrentSite(siteTreeItem: SiteTreeItem, websitePath: string
 
     const modelVersion = siteTreeItem.siteInfo.dataModelVersion || 1;
 
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_CURRENT_SITE_PAC_TRIGGERED, { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId, dataModelVersion: modelVersion, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_UPLOAD_CURRENT_SITE_PAC_TRIGGERED, { methodName: uploadSite.name, siteIdToUpload: siteTreeItem.siteInfo.websiteId, dataModelVersion: modelVersion });
     PacTerminal.getTerminal().sendText(`pac pages upload --path "${websitePathToUpload}" --modelVersion "${modelVersion}"`);
 }
 
@@ -435,7 +428,7 @@ async function uploadCurrentSite(siteTreeItem: SiteTreeItem, websitePath: string
  * @returns Array of site information objects for sites found in the parent folder
  */
 export function findOtherSites(knownSiteIds: Set<string>, fsModule = fs, yamlModule = yaml): IOtherSiteInfo[] {
-    oneDSLoggerWrapper.getLogger().traceInfo(Constants.EventNames.ACTIONS_HUB_FIND_OTHER_SITES_CALLED, { methodName: findOtherSites.name, ...getBaseEventInfo() });
+    traceInfo(Constants.EventNames.ACTIONS_HUB_FIND_OTHER_SITES_CALLED, { methodName: findOtherSites.name });
 
     // Get the workspace folders
     const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -482,11 +475,10 @@ export function findOtherSites(knownSiteIds: Set<string>, fsModule = fs, yamlMod
                         });
                     }
                 } catch (error) {
-                    oneDSLoggerWrapper.getLogger().traceError(
+                    traceError(
                         Constants.EventNames.ACTIONS_HUB_FIND_OTHER_SITES_YAML_PARSE_FAILED,
-                        error as string,
                         error as Error,
-                        { methodName: findOtherSites.name, ...getBaseEventInfo() }
+                        { methodName: findOtherSites.name }
                     );
                 }
             }
@@ -494,11 +486,10 @@ export function findOtherSites(knownSiteIds: Set<string>, fsModule = fs, yamlMod
 
         return otherSites;
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(
+        traceError(
             Constants.EventNames.ACTIONS_HUB_FIND_OTHER_SITES_FAILED,
-            error as string,
             error as Error,
-            { methodName: findOtherSites.name, ...getBaseEventInfo() }
+            { methodName: findOtherSites.name }
         );
         return [];
     }
@@ -528,7 +519,7 @@ export function createKnownSiteIdsSet(
 export const showSiteDetails = async (siteTreeItem: SiteTreeItem) => {
     const siteInfo = siteTreeItem.siteInfo;
 
-    oneDSLoggerWrapper.getLogger().traceInfo(
+    traceInfo(
         Constants.EventNames.ACTIONS_HUB_SHOW_SITE_DETAILS_CALLED,
         {
             methodName: showSiteDetails.name,
@@ -562,7 +553,7 @@ export const showSiteDetails = async (siteTreeItem: SiteTreeItem) => {
         const result = await vscode.window.showInformationMessage(Constants.Strings.SITE_DETAILS, { detail: formattedDetails, modal: true }, Constants.Strings.COPY_TO_CLIPBOARD);
 
         if (result === Constants.Strings.COPY_TO_CLIPBOARD) {
-            oneDSLoggerWrapper.getLogger().traceInfo(
+            traceInfo(
                 Constants.EventNames.ACTIONS_HUB_SHOW_SITE_DETAILS_COPY_TO_CLIPBOARD,
                 {
                     methodName: showSiteDetails.name,
@@ -574,9 +565,8 @@ export const showSiteDetails = async (siteTreeItem: SiteTreeItem) => {
             await vscode.env.clipboard.writeText(formattedDetails);
         }
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(
+        traceError(
             Constants.EventNames.ACTIONS_HUB_SHOW_SITE_DETAILS_FAILED,
-            error as string,
             error as Error,
             {
                 methodName: showSiteDetails.name,
@@ -641,7 +631,7 @@ const executeSiteDownloadCommand = (siteInfo: IWebsiteInfo, downloadPath: string
 
     const downloadCommand = downloadCommandParts.join(" ");
 
-    oneDSLoggerWrapper.getLogger().traceInfo(
+    traceInfo(
         Constants.EventNames.ACTIONS_HUB_DOWNLOAD_SITE_PAC_TRIGGERED,
         {
             methodName: downloadSite.name,
@@ -654,7 +644,7 @@ const executeSiteDownloadCommand = (siteInfo: IWebsiteInfo, downloadPath: string
 }
 
 export const downloadSite = async (siteTreeItem: SiteTreeItem) => {
-    oneDSLoggerWrapper.getLogger().traceInfo(
+    traceInfo(
         Constants.EventNames.ACTIONS_HUB_DOWNLOAD_SITE_CALLED,
         {
             methodName: downloadSite.name,
@@ -680,9 +670,8 @@ export const downloadSite = async (siteTreeItem: SiteTreeItem) => {
 
         executeSiteDownloadCommand(siteInfo, downloadPath);
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(
+        traceError(
             Constants.EventNames.ACTIONS_HUB_DOWNLOAD_SITE_FAILED,
-            error as string,
             error as Error,
             {
                 methodName: downloadSite.name,
@@ -709,7 +698,7 @@ const getStudioUrl = (environmentId: string, websiteId: string) => {
 }
 
 export const openInStudio = async (siteTreeItem: SiteTreeItem) => {
-    oneDSLoggerWrapper.getLogger().traceInfo(
+    traceInfo(
         Constants.EventNames.ACTIONS_HUB_OPEN_SITE_IN_STUDIO_CALLED,
         {
             methodName: openInStudio.name,
@@ -728,9 +717,8 @@ export const openInStudio = async (siteTreeItem: SiteTreeItem) => {
 
         await vscode.env.openExternal(vscode.Uri.parse(studioUrl));
     } catch (error) {
-        oneDSLoggerWrapper.getLogger().traceError(
+        traceError(
             Constants.EventNames.ACTIONS_HUB_OPEN_SITE_IN_STUDIO_FAILED,
-            error as string,
             error as Error,
             {
                 methodName: openInStudio.name,

--- a/src/client/power-pages/actions-hub/TelemetryHelper.ts
+++ b/src/client/power-pages/actions-hub/TelemetryHelper.ts
@@ -6,6 +6,7 @@
 import PacContext from "../../pac/PacContext";
 import CurrentSiteContext from "./CurrentSiteContext";
 import ArtemisContext from '../../ArtemisContext';
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
 export const getBaseEventInfo = () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,4 +34,16 @@ export const getBaseEventInfo = () => {
     }
 
     return eventInfo;
+}
+
+export const traceInfo = (eventName: string, eventInfo?: object) => {
+    const baseEventInfo = getBaseEventInfo();
+    const eventData = { ...baseEventInfo, ...eventInfo };
+    oneDSLoggerWrapper.getLogger().traceInfo(eventName, eventData);
+}
+
+export const traceError = (eventName: string, error: Error, eventInfo?: object) => {
+    const baseEventInfo = getBaseEventInfo();
+    const eventData = { ...baseEventInfo, error: error.message, ...eventInfo };
+    oneDSLoggerWrapper.getLogger().traceError(eventName, error.message, error, eventData);
 }

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -331,7 +331,6 @@ export class OneDSLogger implements ITelemetryLogger {
                 envelope.data.context = JSON.stringify(OneDSLogger.contextInfo);
                 envelope.data.userRegion = OneDSLogger.userRegion;
                 envelope.data.orgGeo = OneDSLogger.orgGeo;
-                console.log("************************************************************** Telemetry event: " + JSON.stringify(envelope.data, null, 2));
                 // At the end of event enrichment, redact the sensitive data for all the applicable fields
                 //  envelope = this.redactSensitiveDataFromEvent(envelope);
             }

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -378,10 +378,12 @@ export class OneDSLogger implements ITelemetryLogger {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private populateVscodeDesktopAttributes(envelope: any) {
         if (envelope.data.eventName == desktopExtTelemetryEventNames.DESKTOP_EXTENSION_INIT_CONTEXT) {
-            OneDSLogger.contextInfo.orgId = JSON.parse(envelope.data.eventInfo).OrgId;
-            OneDSLogger.contextInfo.envId = JSON.parse(envelope.data.eventInfo).EnvironmentId;
-            OneDSLogger.orgGeo = JSON.parse(envelope.data.eventInfo).orgGeo;
-            OneDSLogger.userInfo.oid = JSON.parse(envelope.data.eventInfo).AadId;
+            const eventInfo = JSON.parse(envelope.data.eventInfo);
+            OneDSLogger.userInfo.tid = eventInfo.tenantId ?? '';
+            OneDSLogger.contextInfo.orgId = eventInfo.OrgId;
+            OneDSLogger.contextInfo.envId = eventInfo.EnvironmentId;
+            OneDSLogger.orgGeo = eventInfo.orgGeo;
+            OneDSLogger.userInfo.oid = eventInfo.AadId;
             // TODO: Populate website id
             OneDSLogger.contextInfo.websiteId = 'test'
         }


### PR DESCRIPTION
Refactor telemetry logging in the Actions Hub by replacing the oneDSLoggerWrapper with direct calls to traceInfo and traceError. Remove unnecessary console logs from telemetry events to enhance output clarity while ensuring sensitive data redaction remains intact. Update unit tests for TelemetryHelper to verify the new logging behavior. Adjust context population in OneDSLogger for tenantId.