### PR TITLE
feat(actions-hub): Add download site folder configuration

### DIFF
--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -892,6 +892,9 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     <trans-unit id="microsoft.powerplatform.pages.actionsHub.siteDetails.title">
       <source xml:lang="en">Site Details</source>
     </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.configuration.downloadSite.description">
+      <source xml:lang="en">The folder where site will be downloaded when using Power Pages Actions. Leave this empty to ask for a folder every time you download a site.</source>
+    </trans-unit>
     <trans-unit id="microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite.title">
       <source xml:lang="en">Upload Site</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -577,6 +577,11 @@
             "telemetry",
             "usesOnlineServices"
           ]
+        },
+        "powerPlatform.pages.downloadSiteFolder": {
+          "type": "string",
+          "description": "%microsoft.powerplatform.pages.actionsHub.configuration.downloadSite.description%",
+          "default": ""
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -113,5 +113,6 @@
   "microsoft.powerplatform.pages.actionsHub.activeSite.uploadSite.title": "Upload Site",
   "microsoft.powerplatform.pages.actionsHub.siteDetails.title": "Site Details",
   "microsoft.powerplatform.pages.actionsHub.activeSite.downloadSite.title": "Download Site",
-  "microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio.title": "Open in Power Pages Studio"
+  "microsoft.powerplatform.pages.actionsHub.activeSite.openInStudio.title": "Open in Power Pages Studio",
+  "microsoft.powerplatform.pages.actionsHub.configuration.downloadSite.description": "The folder where site will be downloaded when using Power Pages Actions. Leave this empty to ask for a folder every time you download a site."
 }

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -598,6 +598,16 @@ const getDownloadFolderOptions = () => {
 
 const getDownloadPath = async () => {
     let downloadPath = "";
+    const config = vscode.workspace.getConfiguration(Constants.Strings.CONFIGURATION_NAME);
+    const hasConfiguredDownloadPath = config.has(Constants.Strings.DOWNLOAD_SETTING_NAME);
+
+    if (hasConfiguredDownloadPath) {
+        const configuredDownloadPath = config.get<string>(Constants.Strings.DOWNLOAD_SETTING_NAME) || "";
+        if (fs.existsSync(configuredDownloadPath)) {
+            return configuredDownloadPath;
+        }
+    }
+
     const option = await vscode.window.showQuickPick(getDownloadFolderOptions(), {
         canPickMany: false,
         placeHolder: Constants.Strings.SELECT_DOWNLOAD_FOLDER

--- a/src/client/power-pages/actions-hub/Constants.ts
+++ b/src/client/power-pages/actions-hub/Constants.ts
@@ -44,7 +44,9 @@ export const Constants = {
         ENVIRONMENT_CHANGED_SUCCESSFULLY: vscode.l10n.t("Environment changed successfully."),
         ORGANIZATION_URL_MISSING: "Organization URL is missing in the results.",
         EMPTY_RESULTS_ARRAY: "Results array is empty or not an array.",
-        PAC_AUTH_OUTPUT_FAILURE: "pacAuthCreateOutput is missing or unsuccessful."
+        PAC_AUTH_OUTPUT_FAILURE: "pacAuthCreateOutput is missing or unsuccessful.",
+        CONFIGURATION_NAME: "powerPlatform.pages",
+        DOWNLOAD_SETTING_NAME: "downloadSiteFolder"
     },
     EventNames: {
         ACTIONS_HUB_ENABLED: "ActionsHubEnabled",


### PR DESCRIPTION
- Introduced a new configuration option for specifying the download site folder.

- Added a description for the download site folder setting in localization files to enhance user understanding.

- Updated logic to check for a configured download path in the ActionsHub command handlers, improving user experience when downloading sites.

![image](https://github.com/user-attachments/assets/7659aab9-8a87-41a6-9759-618ba0661305)
