### PR TITLE
Add environment initialization context for command execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
       {
         "view": "microsoft.powerplatform.pages.actionsHub",
         "contents": "%microsoft.powerplatform.pages.actionsHub.login%",
-        "when": "!virtualWorkspace && pacCLI.authPanel.interactiveLoginSupported"
+        "when": "!virtualWorkspace && pacCLI.authPanel.interactiveLoginSupported",
+        "enablement": "microsoft.powerplatform.environment.initialized"
       }
     ],
     "commands": [

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -236,11 +236,15 @@ export async function activate(
                 PreviewSite.initialize(context, workspaceFolders, pacTerminal),
                 ActionsHub.initialize(context, pacTerminal)
             ]);
+
+            vscode.commands.executeCommand('setContext', 'microsoft.powerplatform.environment.initialized', true);
         }),
 
         orgChangeErrorEvent(async () => {
             //Even if auth change was unsuccessful, we should still initialize the actions hub
             await ActionsHub.initialize(context, pacTerminal);
+
+            vscode.commands.executeCommand('setContext', 'microsoft.powerplatform.environment.initialized', true);
         })
     );
 


### PR DESCRIPTION
Introduce a new context for command execution during the activation process and organization change error handling.
This ensures that the buttons remain disabled until the environment is initialized and the actions hub is ready to be used.

![Preview](https://github.com/user-attachments/assets/c698a84a-1528-43f3-ac10-9a4699541e81)
