### PR TITLE
[PowerPages][Web] PPHome Launch Error Page fix for V1

### DIFF
--- a/src/web/client/common/constants.ts
+++ b/src/web/client/common/constants.ts
@@ -127,6 +127,10 @@ export enum GraphService {
     GRAPH_PROFILE_PICTURE = "profilePicture",
 }
 
+export enum REFERRER{
+    POWER_PAGES_HOME = "PowerPagesHome"
+}
+
 export const MICROSOFT_GRAPH_PROFILE_PICTURE_SERVICE_CALL = "/photo/$value";
 
 // User collaboration constants

--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -30,7 +30,7 @@ import {
     updateFileDirtyChanges,
     updateFileEntityEtag,
 } from "../utilities/fileAndEntityUtil";
-import { getImageFileContent, getRangeForMultilineMatch, isImageFileSupportedForEdit, isVersionControlEnabled, updateFileContentInFileDataMap } from "../utilities/commonUtil";
+import { getImageFileContent, getRangeForMultilineMatch, isImageFileSupportedForEdit, isPortalVersionV1, isVersionControlEnabled, updateFileContentInFileDataMap } from "../utilities/commonUtil";
 import { IFileInfo, ISearchQueryMatch, ISearchQueryResults } from "../common/interfaces";
 import { ERROR_CONSTANTS } from "../../../common/ErrorConstants";
 
@@ -611,7 +611,11 @@ export class PortalsFS implements vscode.FileSystemProvider {
 
         // Try Loading default file first
         const referrer = WebExtensionContext.urlParametersMap.get(queryParameters.REFERRER) as string 
-        if (WebExtensionContext.defaultEntityId !== "" && WebExtensionContext.defaultEntityType !== "" && referrer != REFERRER.POWER_PAGES_HOME ) { // If referrer is power pages home, incorrect home page id is being passed. Leading to error page.
+
+        // If referrer is power pages home and DM is V1, incorrect home page id is being passed. Leading to error page.
+        const shouldLoadDefaultFile = !(referrer === REFERRER.POWER_PAGES_HOME && isPortalVersionV1())
+
+        if (WebExtensionContext.defaultEntityId !== "" && WebExtensionContext.defaultEntityType !== "" && shouldLoadDefaultFile) { 
             await fetchDataFromDataverseAndUpdateVFS(
                 this,
                 {

--- a/src/web/client/dal/fileSystemProvider.ts
+++ b/src/web/client/dal/fileSystemProvider.ts
@@ -9,6 +9,7 @@ import { isValidDirectoryPath, isValidFilePath, isWebFileWithLazyLoad } from "..
 import {
     PORTALS_URI_SCHEME,
     queryParameters,
+    REFERRER,
 } from "../common/constants";
 import WebExtensionContext from "../WebExtensionContext";
 import { fetchDataFromDataverseAndUpdateVFS } from "./remoteFetchProvider";
@@ -609,7 +610,8 @@ export class PortalsFS implements vscode.FileSystemProvider {
         );
 
         // Try Loading default file first
-        if (WebExtensionContext.defaultEntityId !== "" && WebExtensionContext.defaultEntityType !== "") {
+        const referrer = WebExtensionContext.urlParametersMap.get(queryParameters.REFERRER) as string 
+        if (WebExtensionContext.defaultEntityId !== "" && WebExtensionContext.defaultEntityType !== "" && referrer != REFERRER.POWER_PAGES_HOME ) { // If referrer is power pages home, incorrect home page id is being passed. Leading to error page.
             await fetchDataFromDataverseAndUpdateVFS(
                 this,
                 {


### PR DESCRIPTION
Introduce a REFERRER enum and update PortalsFS to manage referrer logic based on the portal version, improving handling of default file loading scenarios.