### PR TITLE
[Power Pages][Actions Hub] Added SessionID support to Power Pages actions

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -213,6 +213,12 @@
       "{0} is the timestamp"
     ]
   },
+  "Session ID: {0}/{0} is the Session ID": {
+    "message": "Session ID: {0}",
+    "comment": [
+      "{0} is the Session ID"
+    ]
+  },
   "Tenant ID: {0}/{0} is the Tenant ID": {
     "message": "Tenant ID: {0}",
     "comment": [

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -512,6 +512,10 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++142027a259879fdd2b6410360a9cd3798f433c2fc5668bb685dd4ff513072e16">
       <source xml:lang="en">Session Details</source>
     </trans-unit>
+    <trans-unit id="++CODE++08b44927dd7cd913d5c36c74e3ccf55ef966b6c2f067b173fbbe4e3c32f30d15">
+      <source xml:lang="en">Session ID: {0}</source>
+      <note>{0} is the Session ID</note>
+    </trans-unit>
     <trans-unit id="++CODE++899fb203e6c2faac8093e21a2fa8db0d4b13d16ea5492461d8b72dbcee3ecf2a">
       <source xml:lang="en">Show Output Panel</source>
     </trans-unit>

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -60,6 +60,7 @@ const getEnvironmentDetails = () => {
     const artemisResponse = ArtemisContext.ServiceResponse.response;
 
     if (authInfo) {
+        detailsArray.push(vscode.l10n.t({ message: "Session ID: {0}", args: [vscode.env.sessionId], comment: "{0} is the Session ID" }));
         detailsArray.push(vscode.l10n.t({ message: "Tenant ID: {0}", args: [authInfo.TenantId], comment: "{0} is the Tenant ID" }));
         detailsArray.push(vscode.l10n.t({ message: "Object ID: {0}", args: [authInfo.EntraIdObjectId], comment: "{0} is the Object ID" }));
         detailsArray.push(vscode.l10n.t({ message: "Organization ID: {0}", args: [authInfo.OrganizationId], comment: "{0} is the Organization ID" }));

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -79,6 +79,7 @@ describe('ActionsHubCommandHandlers', () => {
         traceErrorStub = sandbox.stub(TelemetryHelper, 'traceError');
         sandbox.stub(TelemetryHelper, "getBaseEventInfo").returns({ foo: 'bar' });
         sandbox.stub(TelemetryHelper, "traceInfo");
+        sandbox.stub(vscode.env, 'sessionId').get(() => 'test-session-id');
     });
 
     afterEach(() => {
@@ -126,6 +127,7 @@ describe('ActionsHubCommandHandlers', () => {
 
             const message = mockShowInformationMessage.firstCall.args[1].detail;
             expect(message).to.include("Timestamp");
+            expect(message).to.include("Session ID: test-session-id");
             expect(message).to.include("Tenant ID: test-tenant");
             expect(message).to.include("Object ID: test-object-id");
             expect(message).to.include("Organization ID: test-org-id");


### PR DESCRIPTION
This pull request introduces support for displaying and testing the "Session ID" in various components of the application. Key changes include updates to localization files, integration of the "Session ID" into environment details, and corresponding test coverage.

### Localization Updates:
* Added a new localization entry for "Session ID: {0}" in `l10n/bundle.l10n.json` with the appropriate message and comment.
* Included a corresponding translation unit for "Session ID: {0}" in `loc/translations-export/vscode-powerplatform.xlf`, ensuring proper integration into the translation workflow.

### Feature Integration:
* Modified `ActionsHubCommandHandlers.ts` to include the "Session ID" in the environment details array, using `vscode.env.sessionId` for dynamic data.

### Test Coverage:
* Stubbed `vscode.env.sessionId` in the `ActionsHubCommandHandlers` test suite to return a mock value ("test-session-id") for testing purposes.
* Added a test assertion to verify that the "Session ID" is correctly included in the generated message.