### PR TITLE
[PowerPages][GitHub Copilot] Refactor endpoint initialization logic to use cached data and improve efficiency

### DIFF
--- a/src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts
+++ b/src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts
@@ -121,7 +121,7 @@ export class PowerPagesChatParticipant {
                 return createErrorResult(AUTHENTICATION_FAILED_MSG, RESPONSE_SCENARIOS.AUTHENTICATION_FAILED, this.orgID);
             }            const intelligenceApiToken = intelligenceApiAuthResponse.accessToken;
             const userId = intelligenceApiAuthResponse.userId;
-            
+
             // Use cached endpoint info instead of calling getEndpoint on every request
             if (!this.cachedEndpoint || !this.cachedEndpoint.intelligenceEndpoint) {
                 // If not yet initialized, initialize it now
@@ -129,7 +129,7 @@ export class PowerPagesChatParticipant {
                 if (!endpointInitialized) {
                     return createErrorResult(COPILOT_NOT_AVAILABLE_MSG, RESPONSE_SCENARIOS.COPILOT_NOT_AVAILABLE, this.orgID);
                 }
-            }            
+            }
             // Using non-null assertion since we've already checked above
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const intelligenceAPIEndpointInfo = this.cachedEndpoint!;
@@ -252,7 +252,7 @@ export class PowerPagesChatParticipant {
             this.orgUrl = orgUrl;
             this.environmentID = environmentID;
             this.isOrgDetailsInitialized = true;
-            
+
             // Initialize endpoint information after org details are set
             await this.initializeEndpoint();
         } catch (error) {
@@ -265,7 +265,7 @@ export class PowerPagesChatParticipant {
         this.orgID = orgID;
         this.orgUrl = orgUrl;
         this.environmentID = environmentID;
-        
+
         // Re-initialize endpoint information after org change
         await this.initializeEndpoint();
     }
@@ -275,13 +275,13 @@ export class PowerPagesChatParticipant {
             if (!this.orgID || !this.environmentID) {
                 return false;
             }
-            
-            this.cachedEndpoint = await getEndpoint(this.orgID, this.environmentID, this.cachedEndpoint, this.powerPagesAgentSessionId);
-            
+
+            this.cachedEndpoint = await getEndpoint(this.orgID, this.environmentID, this.powerPagesAgentSessionId);
+
             if (!this.cachedEndpoint.intelligenceEndpoint) {
                 return false;
             }
-            
+
             return true;
         } catch (error) {
             oneDSLoggerWrapper.getLogger().traceError(VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_ERROR, 'Failed to initialize endpoint', error as Error, { sessionId: this.powerPagesAgentSessionId }, {});

--- a/src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts
+++ b/src/common/chat-participants/powerpages/PowerPagesChatParticipant.ts
@@ -119,17 +119,22 @@ export class PowerPagesChatParticipant {
 
             if (!intelligenceApiAuthResponse) {
                 return createErrorResult(AUTHENTICATION_FAILED_MSG, RESPONSE_SCENARIOS.AUTHENTICATION_FAILED, this.orgID);
-            }
-
-            const intelligenceApiToken = intelligenceApiAuthResponse.accessToken;
+            }            const intelligenceApiToken = intelligenceApiAuthResponse.accessToken;
             const userId = intelligenceApiAuthResponse.userId;
-            const intelligenceAPIEndpointInfo = await getEndpoint(this.orgID, this.environmentID, this.cachedEndpoint, this.powerPagesAgentSessionId);
-
-            if (!intelligenceAPIEndpointInfo.intelligenceEndpoint) {
-                return createErrorResult(COPILOT_NOT_AVAILABLE_MSG, RESPONSE_SCENARIOS.COPILOT_NOT_AVAILABLE, this.orgID);
-            }
-
-            const copilotAvailabilityStatus = checkCopilotAvailability(intelligenceAPIEndpointInfo.intelligenceEndpoint, this.orgID, this.powerPagesAgentSessionId);
+            
+            // Use cached endpoint info instead of calling getEndpoint on every request
+            if (!this.cachedEndpoint || !this.cachedEndpoint.intelligenceEndpoint) {
+                // If not yet initialized, initialize it now
+                const endpointInitialized = await this.initializeEndpoint();
+                if (!endpointInitialized) {
+                    return createErrorResult(COPILOT_NOT_AVAILABLE_MSG, RESPONSE_SCENARIOS.COPILOT_NOT_AVAILABLE, this.orgID);
+                }
+            }            
+            // Using non-null assertion since we've already checked above
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const intelligenceAPIEndpointInfo = this.cachedEndpoint!;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const copilotAvailabilityStatus = checkCopilotAvailability(intelligenceAPIEndpointInfo.intelligenceEndpoint!, this.orgID, this.powerPagesAgentSessionId);
 
             if (!copilotAvailabilityStatus) {
                 return createErrorResult(COPILOT_NOT_AVAILABLE_MSG, RESPONSE_SCENARIOS.COPILOT_NOT_AVAILABLE, this.orgID);
@@ -162,7 +167,7 @@ export class PowerPagesChatParticipant {
                 const commandRequest = {
                     request,
                     stream,
-                    intelligenceAPIEndpointInfo,
+                    intelligenceAPIEndpointInfo: this.cachedEndpoint,
                     intelligenceApiToken,
                     powerPagesAgentSessionId: this.powerPagesAgentSessionId,
                     orgID: this.orgID,
@@ -203,9 +208,9 @@ export class PowerPagesChatParticipant {
                     sessionID: this.powerPagesAgentSessionId,
                     entityName: entityName,
                     entityColumns: componentInfo,
-                    aibEndpoint: intelligenceAPIEndpointInfo.intelligenceEndpoint,
-                    geoName: intelligenceAPIEndpointInfo.geoName,
-                    crossGeoDataMovementEnabledPPACFlag: intelligenceAPIEndpointInfo.crossGeoDataMovementEnabledPPACFlag,
+                    aibEndpoint: this.cachedEndpoint?.intelligenceEndpoint || '',
+                    geoName: this.cachedEndpoint?.geoName || '',
+                    crossGeoDataMovementEnabledPPACFlag: this.cachedEndpoint?.crossGeoDataMovementEnabledPPACFlag || false,
                     relatedFiles: relatedFiles
                 };
 
@@ -247,6 +252,9 @@ export class PowerPagesChatParticipant {
             this.orgUrl = orgUrl;
             this.environmentID = environmentID;
             this.isOrgDetailsInitialized = true;
+            
+            // Initialize endpoint information after org details are set
+            await this.initializeEndpoint();
         } catch (error) {
             return;
         }
@@ -257,5 +265,27 @@ export class PowerPagesChatParticipant {
         this.orgID = orgID;
         this.orgUrl = orgUrl;
         this.environmentID = environmentID;
+        
+        // Re-initialize endpoint information after org change
+        await this.initializeEndpoint();
+    }
+
+    private async initializeEndpoint(): Promise<boolean> {
+        try {
+            if (!this.orgID || !this.environmentID) {
+                return false;
+            }
+            
+            this.cachedEndpoint = await getEndpoint(this.orgID, this.environmentID, this.cachedEndpoint, this.powerPagesAgentSessionId);
+            
+            if (!this.cachedEndpoint.intelligenceEndpoint) {
+                return false;
+            }
+            
+            return true;
+        } catch (error) {
+            oneDSLoggerWrapper.getLogger().traceError(VSCODE_EXTENSION_GITHUB_POWER_PAGES_AGENT_ERROR, 'Failed to initialize endpoint', error as Error, { sessionId: this.powerPagesAgentSessionId }, {});
+            return false;
+        }
     }
 }

--- a/src/common/chat-participants/powerpages/PowerPagesChatParticipantUtils.ts
+++ b/src/common/chat-participants/powerpages/PowerPagesChatParticipantUtils.ts
@@ -21,12 +21,11 @@ import * as vscode from 'vscode';
 export async function getEndpoint(
     orgID: string,
     environmentID: string,
-    cachedEndpoint: IIntelligenceAPIEndpointInformation | null,
     sessionID: string
 ): Promise<IIntelligenceAPIEndpointInformation> {
-    if (!cachedEndpoint) {
-        cachedEndpoint = await ArtemisService.getIntelligenceEndpoint(orgID, sessionID, environmentID) as IIntelligenceAPIEndpointInformation; // TODO - add session ID
-    }
+
+    const cachedEndpoint = await ArtemisService.getIntelligenceEndpoint(orgID, sessionID, environmentID) as IIntelligenceAPIEndpointInformation; // TODO - add session ID
+
     return cachedEndpoint;
 }
 


### PR DESCRIPTION
This pull request refactors the `PowerPagesChatParticipant` class to optimize endpoint management by introducing caching and an initialization method. The changes aim to reduce redundant calls to `getEndpoint` and improve error handling for endpoint initialization.

### Endpoint Management Improvements:

* Added a private `initializeEndpoint` method to handle endpoint initialization and caching. This method ensures that the endpoint is only fetched when necessary and validates its availability.
* Updated the logic to use `this.cachedEndpoint` instead of repeatedly calling `getEndpoint` for every request, reducing unnecessary API calls. [[1]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L122-R137) [[2]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29L165-R170)
* Modified references to endpoint properties (`intelligenceEndpoint`, `geoName`, `crossGeoDataMovementEnabledPPACFlag`) to use `this.cachedEndpoint` with fallback values to handle cases where the endpoint is unavailable.

### Initialization Enhancements:

* Ensured that `initializeEndpoint` is called after setting organization details (`orgID`, `orgUrl`, `environmentID`) to guarantee the endpoint is ready for use. [[1]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29R255-R257) [[2]](diffhunk://#diff-885f58fd5bd7ee590ddae0f7854d056026aff9b576864e07f61887fb7586da29R268-R289)