### PR TITLE
Fix: Update preprod studio endpoint to use test endpoint

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -140,7 +140,7 @@ const getStudioBaseUrl = (): string => {
         case ServiceEndpointCategory.TEST:
             return Constants.StudioEndpoints.TEST;
         case ServiceEndpointCategory.PREPROD:
-            return Constants.StudioEndpoints.PREPROD;
+            return Constants.StudioEndpoints.TEST; //Studio for preprod is same as test
         case ServiceEndpointCategory.PROD:
             return Constants.StudioEndpoints.PROD;
         case ServiceEndpointCategory.DOD:

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts
@@ -366,7 +366,7 @@ describe('ActionsHubCommandHandlers', () => {
                 await openActiveSitesInStudio();
 
                 expect(mockUrl.calledOnce).to.be.true;
-                expect(mockUrl.firstCall.args[0]).to.equal('https://make.preprod.powerpages.microsoft.com/environments/test-env-id/portals/home/?tab=active');
+                expect(mockUrl.firstCall.args[0]).to.equal('https://make.test.powerpages.microsoft.com/environments/test-env-id/portals/home/?tab=active');
             });
         });
 
@@ -467,7 +467,7 @@ describe('ActionsHubCommandHandlers', () => {
                 await openInactiveSitesInStudio();
 
                 expect(mockUrl.calledOnce).to.be.true;
-                expect(mockUrl.firstCall.args[0]).to.equal('https://make.preprod.powerpages.microsoft.com/environments/test-env-id/portals/home/?tab=inactive');
+                expect(mockUrl.firstCall.args[0]).to.equal('https://make.test.powerpages.microsoft.com/environments/test-env-id/portals/home/?tab=inactive');
             });
         });
 


### PR DESCRIPTION
This pull request updates the behavior of the `getStudioBaseUrl` function and its associated test cases to align the pre-production (`PREPROD`) environment with the test (`TEST`) environment in the Power Pages Actions Hub.

### Updates to environment URL handling:

* In `src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts`, the `getStudioBaseUrl` function was updated to return the test environment URL for the `PREPROD` environment, ensuring consistency between the two environments.

### Updates to test cases:

* In `src/client/test/Integration/power-pages/actions-hub/ActionsHubCommandHandlers.test.ts`, updated the expected URLs in test cases for `openActiveSitesInStudio` and `openInactiveSitesInStudio` to reflect the new behavior of using the test environment URL for the `PREPROD` environment. [[1]](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772L369-R369) [[2]](diffhunk://#diff-4dd38b084b3572ae7878d3745e32dc213dd2589d78662e56c029ad00a0f3e772L470-R470)