### PR TITLE
Update CHANGELOG for pac CLI 1.43.6 release and authentication flow fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - Power Platform Extension
 
+## 2.0.86
+- pac CLI 1.43.6, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
+- Bug Fixes
+  - Fixed authentication flow for Copilot experiences on desktop.
+
 ## 2.0.84
 - pac CLI 1.42.1, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
 - Download/Upload support for code sites in Actions hub.


### PR DESCRIPTION
This pull request updates the `CHANGELOG.md` file to document the release of version 2.0.86 of the Power Platform Extension.

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7): Added an entry for version 2.0.86, which includes an update to `pac CLI` version 1.43.6 and a bug fix for the authentication flow in Copilot experiences on desktop.