### PR TITLE
Fix Telemetry: Send telemetry for non-prod environments to test cluster

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -202,7 +202,7 @@ export async function activate(
             if (artemisResponse !== null && artemisResponse.response !== null) {
                 ArtemisContext.setContext(artemisResponse);
 
-                const { geoName, geoLongName, clusterName, clusterNumber } = artemisResponse.response;
+                const { geoName, geoLongName, clusterName, clusterNumber, environment } = artemisResponse.response;
                 let AadObjectId, EnvID, TenantID;
 
                 if ((pacActiveAuth && pacActiveAuth.Status === SUCCESS)) {
@@ -231,7 +231,7 @@ export async function activate(
                     registerCopilotPanels(pacWrapper);
                 }
 
-                oneDSLoggerWrapper.instantiate(geoName, geoLongName);
+                oneDSLoggerWrapper.instantiate(geoName, geoLongName, environment);
                 let initContext: object = { ...orgDetails, orgGeo: geoName };
                 if (AadObjectId) {
                     initContext = { ...initContext, AadId: AadObjectId }

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -33,6 +33,7 @@ export class OneDSLogger implements ITelemetryLogger {
     private static contextInfo: IContextInfo;
     private static userRegion: string = "";
     private static orgGeo: string = "";
+    private static testInstrumentationEnvironments = new Set(['preprod', 'test', 'tie']);
 
     private readonly regexPatternsToRedact = [
         /key["\\ ']*[:=]+["\\ ']*([a-zA-Z0-9]*)/igm,
@@ -84,7 +85,7 @@ export class OneDSLogger implements ITelemetryLogger {
         },
     };
 
-    public constructor(geo?: string, geoLongName?: string) {
+    public constructor(geo?: string, geoLongName?: string, environment?: string) {
 
         this.appInsightsCore = new AppInsightsCore();
         this.postChannel = new PostChannel();
@@ -94,7 +95,7 @@ export class OneDSLogger implements ITelemetryLogger {
             httpXHROverride: this.fetchHttpXHROverride,
         };
 
-        const instrumentationSetting: IInstrumentationSettings = OneDSLogger.getInstrumentationSettings(geo, geoLongName); // Need to replace with actual data
+        const instrumentationSetting: IInstrumentationSettings = OneDSLogger.getInstrumentationSettings(geo, geoLongName, environment); // Need to replace with actual data
 
         // Configure App insights core to send to collector
         const coreConfig: IExtendedConfiguration = {
@@ -136,12 +137,17 @@ export class OneDSLogger implements ITelemetryLogger {
         }
     }
 
-    private static getInstrumentationSettings(geo?: string, geoLongName?: string): IInstrumentationSettings {
+    private static getInstrumentationSettings(geo?: string, geoLongName?: string, environment?: string): IInstrumentationSettings {
         const buildRegion: string = region;
         const instrumentationSettings: IInstrumentationSettings = {
             endpointURL: 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/',
             instrumentationKey: 'ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402'
         };
+
+        if (environment && OneDSLogger.testInstrumentationEnvironments.has(environment.toLowerCase())) {
+            return instrumentationSettings;
+        }
+
         switch (geoLongName) {
             case 'usgov':
                 geo = 'gov';
@@ -156,6 +162,7 @@ export class OneDSLogger implements ITelemetryLogger {
                 geo = 'mooncake';
                 break;
         }
+
         switch (buildRegion) {
             case 'tie':
             case 'test':
@@ -174,8 +181,8 @@ export class OneDSLogger implements ITelemetryLogger {
                     case 'za':
                     case 'ae':
                     case 'kr':
-                        instrumentationSettings.endpointURL = 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
-                            instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        instrumentationSettings.endpointURL = 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/';
+                        instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
                         break;
                     case 'eu':
                     case 'uk':
@@ -183,28 +190,28 @@ export class OneDSLogger implements ITelemetryLogger {
                     case 'fr':
                     case 'no':
                     case 'ch':
-                        instrumentationSettings.endpointURL = 'https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/',
-                            instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        instrumentationSettings.endpointURL = 'https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/';
+                        instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
                         break;
                     case 'gov':
-                        instrumentationSettings.endpointURL = 'https://tb.events.data.microsoft.com/OneCollector/1.0/',
-                            instrumentationSettings.instrumentationKey = '2f217cb8f40440eeb8b0aa80a2be2f7e-e0ec7b51-d1bb-4d8c-83b1-cc77aaba9009-7472'
+                        instrumentationSettings.endpointURL = 'https://tb.events.data.microsoft.com/OneCollector/1.0/';
+                        instrumentationSettings.instrumentationKey = '2f217cb8f40440eeb8b0aa80a2be2f7e-e0ec7b51-d1bb-4d8c-83b1-cc77aaba9009-7472'
                         break;
                     case 'high':
-                        instrumentationSettings.endpointURL = 'https://tb.events.data.microsoft.com/OneCollector/1.0/',
-                            instrumentationSettings.instrumentationKey = '4a07e143372c46aabf3841dc4f0ef795-a753031e-2005-4282-9451-a086fea4234a-6942'
+                        instrumentationSettings.endpointURL = 'https://tb.events.data.microsoft.com/OneCollector/1.0/';
+                        instrumentationSettings.instrumentationKey = '4a07e143372c46aabf3841dc4f0ef795-a753031e-2005-4282-9451-a086fea4234a-6942'
                         break;
                     case 'dod':
-                        instrumentationSettings.endpointURL = 'https://pf.events.data.microsoft.com/OneCollector/1.0/',
-                            instrumentationSettings.instrumentationKey = 'af47f3d608774379a53fa07cf36362ea-69701588-1aad-43ee-8b52-f71125849774-6656'
+                        instrumentationSettings.endpointURL = 'https://pf.events.data.microsoft.com/OneCollector/1.0/';
+                        instrumentationSettings.instrumentationKey = 'af47f3d608774379a53fa07cf36362ea-69701588-1aad-43ee-8b52-f71125849774-6656'
                         break;
                     case 'mooncake':
-                        instrumentationSettings.endpointURL = 'https://collector.azure.cn/OneCollector/1.0/',
-                            instrumentationSettings.instrumentationKey = 'f9b6e63b5e394453ba8f58f7a7b9aea7-f38fcfa2-eb34-48bc-9ae2-61fba4abbd39-7390' //prod key;
+                        instrumentationSettings.endpointURL = 'https://collector.azure.cn/OneCollector/1.0/';
+                        instrumentationSettings.instrumentationKey = 'f9b6e63b5e394453ba8f58f7a7b9aea7-f38fcfa2-eb34-48bc-9ae2-61fba4abbd39-7390' //prod key;
                         break;
                     default:
-                        instrumentationSettings.endpointURL = 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
-                            instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        instrumentationSettings.endpointURL = 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/';
+                        instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
                         break;
                 }
                 break;

--- a/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLogger.ts
@@ -9,7 +9,7 @@ import { AppInsightsCore, type IExtendedConfiguration } from "@microsoft/1ds-cor
 import { PostChannel, type IChannelConfiguration, type IXHROverride } from "@microsoft/1ds-post-js";
 import { ITelemetryLogger } from "./ITelemetryLogger";
 import { IContextInfo, IUserInfo } from "./IEventTypes";
-import { EventType, Severity } from "./telemetryConstants";
+import { EndpointUrls, EventType, InstrumentationKeys, Severity } from "./telemetryConstants";
 import * as vscode from "vscode";
 import { getExtensionType, getExtensionVersion, getOperatingSystem, getOperatingSystemLabel, getOperatingSystemVersion } from "../utilities/Utils";
 import { EXTENSION_ID } from "../constants";
@@ -140,8 +140,8 @@ export class OneDSLogger implements ITelemetryLogger {
     private static getInstrumentationSettings(geo?: string, geoLongName?: string, environment?: string): IInstrumentationSettings {
         const buildRegion: string = region;
         const instrumentationSettings: IInstrumentationSettings = {
-            endpointURL: 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/',
-            instrumentationKey: 'ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402'
+            endpointURL: EndpointUrls.INTERNAL,
+            instrumentationKey: InstrumentationKeys.INTERNAL
         };
 
         if (environment && OneDSLogger.testInstrumentationEnvironments.has(environment.toLowerCase())) {
@@ -181,8 +181,8 @@ export class OneDSLogger implements ITelemetryLogger {
                     case 'za':
                     case 'ae':
                     case 'kr':
-                        instrumentationSettings.endpointURL = 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/';
-                        instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        instrumentationSettings.endpointURL = EndpointUrls.US;
+                        instrumentationSettings.instrumentationKey = InstrumentationKeys.US_AND_EU;
                         break;
                     case 'eu':
                     case 'uk':
@@ -190,28 +190,28 @@ export class OneDSLogger implements ITelemetryLogger {
                     case 'fr':
                     case 'no':
                     case 'ch':
-                        instrumentationSettings.endpointURL = 'https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/';
-                        instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        instrumentationSettings.endpointURL = EndpointUrls.EU;
+                        instrumentationSettings.instrumentationKey = InstrumentationKeys.US_AND_EU;
                         break;
                     case 'gov':
-                        instrumentationSettings.endpointURL = 'https://tb.events.data.microsoft.com/OneCollector/1.0/';
-                        instrumentationSettings.instrumentationKey = '2f217cb8f40440eeb8b0aa80a2be2f7e-e0ec7b51-d1bb-4d8c-83b1-cc77aaba9009-7472'
+                        instrumentationSettings.endpointURL = EndpointUrls.GOV_AND_HIGH;
+                        instrumentationSettings.instrumentationKey = InstrumentationKeys.GOV;
                         break;
                     case 'high':
-                        instrumentationSettings.endpointURL = 'https://tb.events.data.microsoft.com/OneCollector/1.0/';
-                        instrumentationSettings.instrumentationKey = '4a07e143372c46aabf3841dc4f0ef795-a753031e-2005-4282-9451-a086fea4234a-6942'
+                        instrumentationSettings.endpointURL = EndpointUrls.GOV_AND_HIGH;
+                        instrumentationSettings.instrumentationKey = InstrumentationKeys.HIGH;
                         break;
                     case 'dod':
-                        instrumentationSettings.endpointURL = 'https://pf.events.data.microsoft.com/OneCollector/1.0/';
-                        instrumentationSettings.instrumentationKey = 'af47f3d608774379a53fa07cf36362ea-69701588-1aad-43ee-8b52-f71125849774-6656'
+                        instrumentationSettings.endpointURL = EndpointUrls.DOD;
+                        instrumentationSettings.instrumentationKey = InstrumentationKeys.DOD;
                         break;
                     case 'mooncake':
-                        instrumentationSettings.endpointURL = 'https://collector.azure.cn/OneCollector/1.0/';
-                        instrumentationSettings.instrumentationKey = 'f9b6e63b5e394453ba8f58f7a7b9aea7-f38fcfa2-eb34-48bc-9ae2-61fba4abbd39-7390' //prod key;
+                        instrumentationSettings.endpointURL = EndpointUrls.MOONCAKE;
+                        instrumentationSettings.instrumentationKey = InstrumentationKeys.MOONCAKE;
                         break;
                     default:
-                        instrumentationSettings.endpointURL = 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/';
-                        instrumentationSettings.instrumentationKey = '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172'
+                        instrumentationSettings.endpointURL = EndpointUrls.US;
+                        instrumentationSettings.instrumentationKey = InstrumentationKeys.US_AND_EU;
                         break;
                 }
                 break;

--- a/src/common/OneDSLoggerTelemetry/oneDSLoggerWrapper.ts
+++ b/src/common/OneDSLoggerTelemetry/oneDSLoggerWrapper.ts
@@ -14,8 +14,8 @@ export class oneDSLoggerWrapper {
     private static instance: oneDSLoggerWrapper;
     private static oneDSLoggerInstance: OneDSLogger;
 
-    private constructor(geo?: string, geoLongName?: string) {
-        oneDSLoggerWrapper.oneDSLoggerInstance = new OneDSLogger(geo, geoLongName);
+    private constructor(geo?: string, geoLongName?: string, environment?: string) {
+        oneDSLoggerWrapper.oneDSLoggerInstance = new OneDSLogger(geo, geoLongName, environment);
     }
 
 
@@ -23,8 +23,8 @@ export class oneDSLoggerWrapper {
         return this.instance;
     }
 
-    static instantiate(geo?: string, geoLongName?: string) {
-        oneDSLoggerWrapper.instance = new oneDSLoggerWrapper(geo, geoLongName);
+    static instantiate(geo?: string, geoLongName?: string, environment?: string) {
+        oneDSLoggerWrapper.instance = new oneDSLoggerWrapper(geo, geoLongName, environment);
     }
 
     /// Trace info log

--- a/src/common/OneDSLoggerTelemetry/telemetryConstants.ts
+++ b/src/common/OneDSLoggerTelemetry/telemetryConstants.ts
@@ -57,3 +57,21 @@ export const AUTH_KEYS = {
     ORGANIZATION_UNIQUE_NAME: 'Organization Unique Name:',
     ORGANIZATION_FRIENDLY_NAME: 'Organization Friendly Name:'
 };
+
+export const EndpointUrls = {
+    INTERNAL: 'https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/',
+    US: 'https://us-mobile.events.data.microsoft.com/OneCollector/1.0/',
+    EU: 'https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/',
+    GOV_AND_HIGH: 'https://tb.events.data.microsoft.com/OneCollector/1.0/',
+    DOD: 'https://pf.events.data.microsoft.com/OneCollector/1.0/',
+    MOONCAKE: 'https://collector.azure.cn/OneCollector/1.0/'
+} as const;
+
+export const InstrumentationKeys = {
+    INTERNAL: 'ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402',
+    US_AND_EU: '197418c5cb8c4426b201f9db2e87b914-87887378-2790-49b0-9295-51f43b6204b1-7172',
+    GOV: '2f217cb8f40440eeb8b0aa80a2be2f7e-e0ec7b51-d1bb-4d8c-83b1-cc77aaba9009-7472',
+    HIGH: '4a07e143372c46aabf3841dc4f0ef795-a753031e-2005-4282-9451-a086fea4234a-6942',
+    DOD: 'af47f3d608774379a53fa07cf36362ea-69701588-1aad-43ee-8b52-f71125849774-6656',
+    MOONCAKE: 'f9b6e63b5e394453ba8f58f7a7b9aea7-f38fcfa2-eb34-48bc-9ae2-61fba4abbd39-7390'
+} as const;

--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -106,7 +106,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 const orgId = queryParamsMap.get(queryParameters.ORG_ID) as string;
                 await fetchArtemisData(orgId);
                 WebExtensionContext.telemetry.sendInfoTelemetry(webExtensionTelemetryEventNames.WEB_EXTENSION_ORG_GEO, { orgId: orgId, orgGeo: WebExtensionContext.geoName });
-                oneDSLoggerWrapper.instantiate(WebExtensionContext.geoName, WebExtensionContext.geoLongName);
+                oneDSLoggerWrapper.instantiate(WebExtensionContext.geoName, WebExtensionContext.geoLongName, WebExtensionContext.serviceEndpointCategory);
 
                 WebExtensionContext.telemetry.sendExtensionInitPathParametersTelemetry(
                     appName,


### PR DESCRIPTION
This pull request introduces enhancements to the telemetry logging system by adding support for environment-specific configurations. The changes ensure that the logging system can handle different environments (e.g., preprod, test) and adapt instrumentation settings accordingly. Additionally, minor adjustments were made to improve code clarity and maintainability.

### Enhancements to telemetry logging:

* Added an `environment` parameter to the `OneDSLogger` constructor and related methods, allowing environment-specific configurations to be passed and used for telemetry logging. (`src/common/OneDSLoggerTelemetry/oneDSLogger.ts`: [[1]](diffhunk://#diff-1c7a0bcddd4688b6e489876d4ab1a031b03f1dcf43f9b9725f460df8758606dfL87-R88) [[2]](diffhunk://#diff-1c7a0bcddd4688b6e489876d4ab1a031b03f1dcf43f9b9725f460df8758606dfL97-R98) [[3]](diffhunk://#diff-1c7a0bcddd4688b6e489876d4ab1a031b03f1dcf43f9b9725f460df8758606dfL139-R150)
* Introduced a new `testInstrumentationEnvironments` set to handle specific test environments (`preprod`, `test`, `tie`) with default instrumentation settings. (`src/common/OneDSLoggerTelemetry/oneDSLogger.ts`: [[1]](diffhunk://#diff-1c7a0bcddd4688b6e489876d4ab1a031b03f1dcf43f9b9725f460df8758606dfR36) [[2]](diffhunk://#diff-1c7a0bcddd4688b6e489876d4ab1a031b03f1dcf43f9b9725f460df8758606dfL139-R150)
* Updated the `instantiate` method in `oneDSLoggerWrapper` to include the `environment` parameter, ensuring the logger is initialized with the correct context. (`src/common/OneDSLoggerTelemetry/oneDSLoggerWrapper.ts`: [src/common/OneDSLoggerTelemetry/oneDSLoggerWrapper.tsL17-R27](diffhunk://#diff-18f2616f6d19053302f2fb31da650b9f5fd00baf90ab65733431a20a82beea87L17-R27))