### PR TITLE
Refactor URL generation in ArtemisService

### DIFF
--- a/src/common/services/ArtemisService.ts
+++ b/src/common/services/ArtemisService.ts
@@ -120,18 +120,18 @@ export class ArtemisService {
         const updatedOrgId = orgId.replace(/-/g, "");
         const domain = updatedOrgId.slice(0, -1);
         const domainProd = updatedOrgId.slice(0, -2);
-        const nonProdSegment = updatedOrgId.slice(-1);
-        const prodSegment = updatedOrgId.slice(-2);
-        const tstUrl = `https://${domain}.${nonProdSegment}.organization.api.test.powerplatform.com/gateway/cluster?api-version=1`;
-        const preprodUrl = `https://${domain}.${nonProdSegment}.organization.api.preprod.powerplatform.com/gateway/cluster?api-version=1`;
-        const prodUrl = `https://${domainProd}.${prodSegment}.organization.api.powerplatform.com/gateway/cluster?api-version=1`;
-        const gccUrl = `https://${domain}.${prodSegment}.organization.api.gov.powerplatform.microsoft.us/gateway/cluster?api-version=1`;
-        const highUrl = `https://${domain}.${prodSegment}.organization.api.high.powerplatform.microsoft.us/gateway/cluster?api-version=1`;
-        const mooncakeUrl = `https://${domain}.${prodSegment}.organization.api.powerplatform.partner.microsoftonline.cn/gateway/cluster?app-version=1`;
-        const dodUrl = `https://${domain}.${prodSegment}.organization.api.appsplatform.us/gateway/cluster?app-version=1`;
+        const singleDigitSuffix = updatedOrgId.slice(-1);
+        const doubleDigitSuffix = updatedOrgId.slice(-2);
+        const testUrl = `https://${domain}.${singleDigitSuffix}.organization.api.test.powerplatform.com/gateway/cluster?api-version=1`;
+        const preprodUrl = `https://${domain}.${singleDigitSuffix}.organization.api.preprod.powerplatform.com/gateway/cluster?api-version=1`;
+        const prodUrl = `https://${domainProd}.${doubleDigitSuffix}.organization.api.powerplatform.com/gateway/cluster?api-version=1`;
+        const gccUrl = `https://${domain}.${singleDigitSuffix}.organization.api.gov.powerplatform.microsoft.us/gateway/cluster?api-version=1`;
+        const highUrl = `https://${domain}.${singleDigitSuffix}.organization.api.high.powerplatform.microsoft.us/gateway/cluster?api-version=1`;
+        const mooncakeUrl = `https://${domain}.${singleDigitSuffix}.organization.api.powerplatform.partner.microsoftonline.cn/gateway/cluster?app-version=1`;
+        const dodUrl = `https://${domain}.${singleDigitSuffix}.organization.api.appsplatform.us/gateway/cluster?app-version=1`;
 
         return [
-            { stamp: ServiceEndpointCategory.TEST, endpoint: tstUrl },
+            { stamp: ServiceEndpointCategory.TEST, endpoint: testUrl },
             { stamp: ServiceEndpointCategory.PREPROD, endpoint: preprodUrl },
             { stamp: ServiceEndpointCategory.PROD, endpoint: prodUrl },
             { stamp: ServiceEndpointCategory.GCC, endpoint: gccUrl },


### PR DESCRIPTION
Fix Artemis Service URLs for GCC, HIGH and DOD environments. These environments use a single digit suffix for fetching island information.