### PR TITLE
Update pac CLI version to 1.44.2 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log - Power Platform Extension
 
+## 2.0.87
+- pac CLI 1.44.2, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
+- Reactivate inactive site support in Power Pages Actions (Desktop)
+
 ## 2.0.86
 - pac CLI 1.43.6, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
 - Bug Fixes

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -339,7 +339,7 @@ async function snapshot() {
     }
 }
 
-const cliVersion = '1.43.6';
+const cliVersion = '1.44.2';
 
 const recompile = gulp.series(
     clean,


### PR DESCRIPTION
Update the pac CLI version in the codebase and reflect this change in the changelog, including reactivation of inactive site support in Power Pages Actions.