### PR TITLE
fix: handle null or undefined siteAddress in reactivateSite URL construction

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -932,7 +932,7 @@ export const reactivateSite = async (siteTreeItem: SiteTreeItem) => {
 
     let siteAddress = websiteUrl;
     if(siteAddress === null || siteAddress === undefined) {
-        siteAddress = "";
+        siteAddress = ""; // Studio generates a new URL for the site
     }
 
     const reactivateSiteUrl = `${getStudioBaseUrl()}/e/${environmentId}/portals/create?reactivateWebsiteId=${websiteId}&siteName=${encodeURIComponent(name)}&siteAddress=${encodeURIComponent(siteAddress)}&siteLanguageId=${languageCode}&isNewDataModel=${isNewDataModel}`;

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -930,7 +930,12 @@ export const reactivateSite = async (siteTreeItem: SiteTreeItem) => {
 
     const isNewDataModel = siteTreeItem.siteInfo.dataModelVersion === 2;
 
-    const reactivateSiteUrl = `${getStudioBaseUrl()}/e/${environmentId}/portals/create?reactivateWebsiteId=${websiteId}&siteName=${encodeURIComponent(name)}&siteAddress=${encodeURIComponent(websiteUrl)}&siteLanguageId=${languageCode}&isNewDataModel=${isNewDataModel}`;
+    let siteAddress = websiteUrl;
+    if(siteAddress === null || siteAddress === undefined) {
+        siteAddress = "";
+    }
+
+    const reactivateSiteUrl = `${getStudioBaseUrl()}/e/${environmentId}/portals/create?reactivateWebsiteId=${websiteId}&siteName=${encodeURIComponent(name)}&siteAddress=${encodeURIComponent(siteAddress)}&siteLanguageId=${languageCode}&isNewDataModel=${isNewDataModel}`;
 
     await vscode.env.openExternal(vscode.Uri.parse(reactivateSiteUrl));
 };


### PR DESCRIPTION
This pull request includes a small change to the `reactivateSite` function in the `ActionsHubCommandHandlers.ts` file. The change ensures that the `siteAddress` variable is set to an empty string if `websiteUrl` is `null` or `undefined`, preventing potential issues with URL construction.