### PR TITLE
[July Release] Update CHANGELOG for pac CLI 1.45.3 and bug fixes in Power Pages Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - pac CLI 1.45.3, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
 - Bug Fixes
   - Fixed issue where active sites appeared as inactive in Power Pages Actions for Sovereign Clouds.
-  - Fixed page de-duplication bug in VS Code web.
+  - Fixed duplicate webpage handling bug in VS Code web.
 
 ## 2.0.89
 - pac CLI 1.44.2, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - Power Platform Extension
 
+## 2.0.91
+- pac CLI 1.45.3, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
+- Bug Fixes
+  - Fixed issue where active sites appeared as inactive in Power Pages Actions for Sovereign Clouds.
+  - Fixed page de-duplication bug in VS Code web.
+
 ## 2.0.89
 - pac CLI 1.44.2, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
 - Reactivate inactive site support in Power Pages Actions (Desktop)


### PR DESCRIPTION
This pull request updates the `CHANGELOG.md` file to document the release of version 2.0.91 of the Power Platform Extension. The changes include an update to the pac CLI version and fixes for two bugs.

### Key Changes:

#### Version Update:
* Updated to pac CLI version 1.45.3.

#### Bug Fixes:
* Resolved an issue where active sites were incorrectly displayed as inactive in Power Pages Actions for Sovereign Clouds.
* Fixed a bug causing page duplication in Visual Studio Code web.