### PR TITLE
Refactor createContentFiles and processDataAndCreateFile to improve folder name handling for webpages

### DIFF
--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -237,36 +237,10 @@ async function createContentFiles(
             throw new Error(ERROR_CONSTANTS.FILE_NAME_EMPTY);
         }
 
-        let folderName = fileName;
-        if (entityName === schemaEntityName.WEBPAGES) {
-            const webpageNames = WebExtensionContext.getWebpageNames();
-
-            console.log(`Processing webpage: ${fileName}, entityId: ${entityId}, already exists: ${webpageNames.has(fileName)}`);
-
-            if (webpageNames.has(fileName)) {
-                // This is a duplicate - append entity ID
-                // add telemetry for duplicate folder name creation
-                WebExtensionContext.telemetry.sendInfoTelemetry(
-                    webExtensionTelemetryEventNames.WEB_EXTENSION_DUPLICATE_FOLDER_NAME_CREATED,
-                    { entityName: entityName, fileName: fileName, entityId: entityId, orgId: WebExtensionContext.organizationId, envId: WebExtensionContext.environmentId }
-                );
-                folderName = getDuplicateFileName(fileName, entityId);
-                console.log(`Created duplicate folder name: ${folderName}`);
-            } else {
-                // First occurrence - just track it
-                webpageNames.add(fileName);
-                console.log(`Added to tracking: ${fileName}`);
-            }
-        }
+        const folderName = fileName;
 
         // Create folder paths
         filePathInPortalFS = filePathInPortalFS ?? `${Constants.PORTALS_URI_SCHEME}:/${portalFolderName}/${subUri}/`;
-        if (exportType && exportType === folderExportType.SubFolders) {
-            filePathInPortalFS = `${filePathInPortalFS}${getSanitizedFileName(folderName)}/`;
-            await portalsFS.createDirectory(
-                vscode.Uri.parse(filePathInPortalFS, true)
-            );
-        }
 
         const languageCodeAttribute = entityDetails?.get(
             schemaEntityKey.LANGUAGE_FIELD
@@ -316,7 +290,9 @@ async function createContentFiles(
             filePathInPortalFS,
             portalsFS,
             defaultFileInfo,
-            rootWebPageIdAttribute)
+            rootWebPageIdAttribute,
+            exportType,
+            folderName)
 
     } catch (error) {
         const errorMsg = (error as Error)?.message;
@@ -344,7 +320,9 @@ async function processDataAndCreateFile(
     filePathInPortalFS: string,
     portalsFS: PortalsFS,
     defaultFileInfo?: IFileInfo,
-    rootWebPageIdAttribute?: string
+    rootWebPageIdAttribute?: string,
+    exportType?: string,
+    originalFolderName?: string
 ) {
     const attributeExtensionMap = attributeExtension as unknown as Map<
         string,
@@ -352,6 +330,65 @@ async function processDataAndCreateFile(
     >;
     let counter = 0;
     let fileUri = "";
+
+    let rootWebPageId = undefined;
+    if (rootWebPageIdAttribute) {
+        const rootWebPageIdPath: IAttributePath = getAttributePath(rootWebPageIdAttribute);
+        rootWebPageId = getAttributeContent(result, rootWebPageIdPath, entityName, entityId);
+    }
+
+    // Handle webpage folder organization by root webpage ID
+    let actualFolderName = originalFolderName || fileName;
+    if (entityName === schemaEntityName.WEBPAGES) {
+        const webpageNames = WebExtensionContext.getWebpageNames();
+
+        // For consistency, use a stable identifier for the suffix when rootWebPageId is null
+        const effectiveRootWebPageId = rootWebPageId || 'no-root';
+        const rootWebPageIdKey = `${fileName}${'#'}${effectiveRootWebPageId}`;
+
+        if (!webpageNames.has(rootWebPageIdKey)) {
+            // This is a new filename+rootWebPageId combination
+            const existingEntriesForFileName = Array.from(webpageNames).filter(key => key.startsWith(`${fileName}${'#'}`));
+
+            if (existingEntriesForFileName.length > 0) {
+                // This filename already exists with a different root webpage ID
+                // Create a suffixed folder name for this NEW root webpage ID group
+                WebExtensionContext.telemetry.sendInfoTelemetry(
+                    webExtensionTelemetryEventNames.WEB_EXTENSION_DUPLICATE_FOLDER_NAME_CREATED,
+                    { entityName: entityName, fileName: fileName, entityId: entityId, orgId: WebExtensionContext.organizationId, envId: WebExtensionContext.environmentId }
+                );
+                // Use effective rootWebPageId for consistent naming
+                actualFolderName = getDuplicateFileName(fileName, effectiveRootWebPageId);
+            } else {
+                // First occurrence of this filename - use original name
+            }
+
+            webpageNames.add(rootWebPageIdKey);
+        } else {
+            // We've seen this exact filename+rootWebPageId combination before
+            // Determine which folder name was used for this specific root webpage ID group
+            const existingEntriesForFileName = Array.from(webpageNames).filter(key => key.startsWith(`${fileName}${'#'}`));
+
+            // Extract and sort root webpage IDs to ensure consistent ordering
+            const rootWebPageIds = existingEntriesForFileName.map(key => key.split('#')[1]).sort();
+            const currentEntryIndex = rootWebPageIds.indexOf(effectiveRootWebPageId);
+
+            if (currentEntryIndex === 0) {
+                // This is the first root webpage ID that was encountered for this filename
+                actualFolderName = fileName;
+            } else {
+                // This is a subsequent root webpage ID - use suffixed folder name
+                actualFolderName = getDuplicateFileName(fileName, effectiveRootWebPageId);
+            }
+        }
+    }    // Create folder directory if needed
+    let finalFilePathInPortalFS = filePathInPortalFS;
+    if (exportType && exportType === folderExportType.SubFolders) {
+        finalFilePathInPortalFS = `${filePathInPortalFS}${getSanitizedFileName(actualFolderName)}/`;
+        await portalsFS.createDirectory(
+            vscode.Uri.parse(finalFilePathInPortalFS, true)
+        );
+    }
 
     for (counter; counter < attributeArray.length; counter++) {
         const fileExtension = attributeExtensionMap?.get(
@@ -371,7 +408,7 @@ async function processDataAndCreateFile(
                     expandedContent,
                     portalsFS,
                     dataverseOrgUrl,
-                    filePathInPortalFS);
+                    finalFilePathInPortalFS);
             }
         }
         else {
@@ -384,16 +421,8 @@ async function processDataAndCreateFile(
                 fileNameWithExtension = defaultFileInfo?.fileName;
             }
 
-            // Get rootpage id
-            let rootWebPageId = undefined;
-
-            if (rootWebPageIdAttribute) {
-                const rootWebPageIdPath: IAttributePath = getAttributePath(rootWebPageIdAttribute);
-                rootWebPageId = getAttributeContent(result, rootWebPageIdPath, entityName, entityId);
-            }
-
             if (fileCreationValid) {
-                fileUri = filePathInPortalFS + fileNameWithExtension;
+                fileUri = finalFilePathInPortalFS + fileNameWithExtension;
                 await createFile(
                     attributeArray[counter],
                     fileExtension,
@@ -433,7 +462,7 @@ async function processDataAndCreateFile(
         }
 
         if (sourceAttributeExtension) {
-            fileUri = filePathInPortalFS + GetFileNameWithExtension(entityName, fileName, languageCode, sourceAttributeExtension);
+            fileUri = finalFilePathInPortalFS + GetFileNameWithExtension(entityName, fileName, languageCode, sourceAttributeExtension);
             await WebExtensionContext.updateSingleFileUrisInContext(
                 vscode.Uri.parse(fileUri)
             );

--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -29,7 +29,7 @@ import {
 } from "../utilities/schemaHelperUtil";
 import WebExtensionContext from "../WebExtensionContext";
 import { webExtensionTelemetryEventNames } from "../../../common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents";
-import { EntityMetadataKeyCore, SchemaEntityMetadata, folderExportType, schemaEntityKey, schemaEntityName, schemaKey } from "../schema/constants";
+import { EntityMetadataKeyCore, SchemaEntityMetadata, folderExportType, schemaEntityKey, schemaEntityName, schemaKey, WEBPAGE_FOLDER_CONSTANTS } from "../schema/constants";
 import { getEntityNameForExpandedEntityContent, getRequestUrlForEntities } from "../utilities/folderHelperUtility";
 import { IAttributePath, IFileInfo } from "../common/interfaces";
 import { portal_schema_V2 } from "../schema/portalSchema";
@@ -342,13 +342,12 @@ async function processDataAndCreateFile(
     if (entityName === schemaEntityName.WEBPAGES) {
         const webpageNames = WebExtensionContext.getWebpageNames();
 
-        // For consistency, use a stable identifier for the suffix when rootWebPageId is null
-        const effectiveRootWebPageId = rootWebPageId || 'no-root';
-        const rootWebPageIdKey = `${fileName}${'#'}${effectiveRootWebPageId}`;
+        const effectiveRootWebPageId = rootWebPageId || WEBPAGE_FOLDER_CONSTANTS.NO_ROOT_PLACEHOLDER;
+        const rootWebPageIdKey = `${fileName}${WEBPAGE_FOLDER_CONSTANTS.DELIMITER}${effectiveRootWebPageId}`;
 
         if (!webpageNames.has(rootWebPageIdKey)) {
             // This is a new filename+rootWebPageId combination
-            const existingEntriesForFileName = Array.from(webpageNames).filter(key => key.startsWith(`${fileName}${'#'}`));
+            const existingEntriesForFileName = Array.from(webpageNames).filter(key => key.startsWith(`${fileName}${WEBPAGE_FOLDER_CONSTANTS.DELIMITER}`));
 
             if (existingEntriesForFileName.length > 0) {
                 // This filename already exists with a different root webpage ID
@@ -367,10 +366,10 @@ async function processDataAndCreateFile(
         } else {
             // We've seen this exact filename+rootWebPageId combination before
             // Determine which folder name was used for this specific root webpage ID group
-            const existingEntriesForFileName = Array.from(webpageNames).filter(key => key.startsWith(`${fileName}${'#'}`));
+            const existingEntriesForFileName = Array.from(webpageNames).filter(key => key.startsWith(`${fileName}${WEBPAGE_FOLDER_CONSTANTS.DELIMITER}`));
 
             // Extract and sort root webpage IDs to ensure consistent ordering
-            const rootWebPageIds = existingEntriesForFileName.map(key => key.split('#')[1]).sort();
+            const rootWebPageIds = existingEntriesForFileName.map(key => key.split(WEBPAGE_FOLDER_CONSTANTS.DELIMITER)[1]).sort();
             const currentEntryIndex = rootWebPageIds.indexOf(effectiveRootWebPageId);
 
             if (currentEntryIndex === 0) {

--- a/src/web/client/schema/constants.ts
+++ b/src/web/client/schema/constants.ts
@@ -88,3 +88,13 @@ export enum EntityMetadataKeyAdx {
     ENTITY_LOGICAL_NAME = "adx_entityname",
     FORM_LOGICAL_NAME = "adx_formname",
 }
+
+export const WEBPAGE_FOLDER_CONSTANTS = {
+    DELIMITER: '#',
+    NO_ROOT_PLACEHOLDER: 'no-root',
+    NULL_PLACEHOLDER: 'null',
+} as const;
+
+export function getRootWebPageIdForTelemetry(rootWebPageId: string | undefined | null): string {
+    return rootWebPageId || WEBPAGE_FOLDER_CONSTANTS.NULL_PLACEHOLDER;
+}


### PR DESCRIPTION
This pull request refactors how webpage content files are organized and created, specifically improving folder naming and handling for duplicate webpage names by grouping them based on their root webpage ID. The changes ensure more consistent and collision-free folder structures when exporting webpages, and enhance telemetry tracking for duplicate folder scenarios.

**Webpage folder organization improvements:**

* Webpage folders are now grouped and named by their root webpage ID, using a combination of the file name and root webpage ID to avoid naming collisions and ensure consistent folder naming.
* The logic for detecting and handling duplicate webpage folder names has been moved from `createContentFiles` to `processDataAndCreateFile`, and expanded to support grouping by root webpage ID. Telemetry events are sent when duplicate folder names are created. [[1]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL240-L269) [[2]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feR334-R392)

**File path and creation refactoring:**

* All file and folder creation logic now uses the new folder naming scheme, updating the file path construction to use the correct folder for each webpage export. [[1]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL374-R411) [[2]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL387-R425) [[3]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL436-R465)
* Additional parameters (`exportType` and `folderName`) are passed between functions to support the new folder organization, improving maintainability and clarity. [[1]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL319-R295) [[2]](diffhunk://#diff-3bdc6b0be6c5885d51a3c8dea2d155cd6c1ab149514f5f75b477a401245493feL347-R325)


<img width="383" height="337" alt="image" src="https://github.com/user-attachments/assets/79bce474-1600-4e83-a9e3-966a53f8b955" />
