### PR TITLE
Add loc manifest file to define the scope of the new loc process

### DIFF
--- a/localize/LocProject.json
+++ b/localize/LocProject.json
@@ -1,0 +1,16 @@
+{
+  "Projects": [
+    {
+      "LanguageSet": "VSCode_12_Languages",
+      "_LanguageSet.comment" : "VSCode_12_Languages resolves to cs;de;es;fr;it;ja;ko;pt-BR;ru;tr;zh-CN;zh-TW",
+      "LocItems": [
+        {
+          "SourceFile": "loc\\translations-export\\vscode-powerplatform.xlf",
+          "CopyOption": "UsePlaceholders",
+          "OutputPath": "loc\\translations-import\\{FileName}.{Lang}{Extension}",
+          "_OutputPath.comment": "For instance, for ko (Korean), OutputPath resolves to loc\\translations-import\\vscode-powerplatform.ko.xlf"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add the loc manifest file to define the scope of the new loc process. Please refer to https://eng.ms/docs/cloud-ai-platform/azure-core/azure-experiences-and-ecosystems/cme-international-customer-exp/software-localization-onelocbuild/onelocbuild/onboarding/localizationproject for the schema of the manifest file.