### PR TITLE
Refactor CodeQL screening and remove unsupported checks

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -24,7 +24,7 @@ import { IOtherSiteInfo, IWebsiteDetails, WebsiteYaml } from '../../../common/se
 import { getActiveWebsites, getAllWebsites } from '../../../common/utilities/WebsiteUtil';
 import CurrentSiteContext from './CurrentSiteContext';
 import path from 'path';
-import { getWebsiteRecordId, hasWebsiteYaml, hasPowerPagesSiteFolder, getWebsiteYamlPath } from '../../../common/utilities/WorkspaceInfoFinderUtil';
+import { getWebsiteRecordId, hasWebsiteYaml, getWebsiteYamlPath } from '../../../common/utilities/WorkspaceInfoFinderUtil';
 import { isEdmEnvironment } from '../../../common/copilot/dataverseMetadata';
 import { IWebsiteInfo } from './models/IWebsiteInfo';
 import moment from 'moment';
@@ -575,10 +575,10 @@ export function findOtherSites(knownSiteIds: Set<string>, fsModule = fs, yamlMod
         for (const dir of directories) {
             let websiteYamlPath = getWebsiteYamlPath(dir);
             let hasWebsiteYamlFile = hasWebsiteYaml(dir);
-            const hasPowerPagesSiteFolderExists = hasPowerPagesSiteFolder(dir);
+            const powerPagesSiteFolderExists = fs.existsSync(dir)
             let workingDir = dir;
 
-            if (hasPowerPagesSiteFolderExists) {
+            if (powerPagesSiteFolderExists) {
                 workingDir = path.join(dir, POWERPAGES_SITE_FOLDER);
                 websiteYamlPath = getWebsiteYamlPath(workingDir);
                 hasWebsiteYamlFile = hasWebsiteYaml(workingDir);
@@ -599,7 +599,7 @@ export function findOtherSites(knownSiteIds: Set<string>, fsModule = fs, yamlMod
                             name: websiteData?.adx_name || path.basename(dir), // Use folder name as fallback
                             websiteId: websiteId,
                             folderPath: dir,
-                            isCodeSite: hasPowerPagesSiteFolderExists
+                            isCodeSite: powerPagesSiteFolderExists
                         });
                     }
                 } catch (error) {
@@ -958,6 +958,8 @@ export const runCodeQLScreening = async (siteTreeItem?: SiteTreeItem) => {
             return;
         }
 
+        const powerPagesSiteFolderExists = fs.existsSync(sitePath);
+
         // Check if CodeQL extension is installed
         const codeQLExtension = vscode.extensions.getExtension(CODEQL_EXTENSION_ID);
 
@@ -990,7 +992,7 @@ export const runCodeQLScreening = async (siteTreeItem?: SiteTreeItem) => {
                 Constants.Strings.CODEQL_SCREENING_STARTED,
                 async () => {
                     // Use a custom method that allows specifying the database location
-                    await codeQLAction.executeCodeQLAnalysisWithCustomPath(sitePath, databaseLocation);
+                    await codeQLAction.executeCodeQLAnalysisWithCustomPath(sitePath, databaseLocation, powerPagesSiteFolderExists);
                 }
             );
 

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -958,12 +958,6 @@ export const runCodeQLScreening = async (siteTreeItem?: SiteTreeItem) => {
             return;
         }
 
-        if(!hasPowerPagesSiteFolder(sitePath)) {
-            traceInfo(Constants.EventNames.ACTIONS_HUB_CODEQL_SCREENING_NOT_SUPPORTED, { methodName: runCodeQLScreening.name });
-            await vscode.window.showErrorMessage(Constants.Strings.CODEQL_SCREENING_NOT_SUPPORTED);
-            return;
-        }
-
         // Check if CodeQL extension is installed
         const codeQLExtension = vscode.extensions.getExtension(CODEQL_EXTENSION_ID);
 

--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -972,7 +972,7 @@ export const runCodeQLScreening = async (siteTreeItem?: SiteTreeItem) => {
             );
 
             if (install === Constants.Strings.INSTALL) {
-                await vscode.commands.executeCommand('workbench.extensions.search', CODEQL_EXTENSION_ID);
+                await vscode.commands.executeCommand('workbench.extensions.installExtension', CODEQL_EXTENSION_ID);
                 traceInfo(Constants.EventNames.ACTIONS_HUB_CODEQL_SCREENING_EXTENSION_NOT_INSTALLED, { methodName: runCodeQLScreening.name });
                 return;
             } else {

--- a/src/common/utilities/WorkspaceInfoFinderUtil.ts
+++ b/src/common/utilities/WorkspaceInfoFinderUtil.ts
@@ -110,15 +110,6 @@ export function hasWebsiteYaml(directoryPath: string): boolean {
 }
 
 /**
- * Checks if a .powerpages-site folder exists in the specified directory
- * @param directoryPath The directory path to check
- * @returns True if .powerpages-site folder exists, false otherwise
- */
-export function hasPowerPagesSiteFolder(directoryPath: string): boolean {
-    return fs.existsSync(directoryPath);
-}
-
-/**
  * Gets the path to the website.yml file in the specified directory
  * @param directoryPath The directory path
  * @returns The full path to website.yml


### PR DESCRIPTION
Eliminate the check for unsupported Power Pages site folders in the CodeQL screening process and refactor related methods. Update the installation command for the CodeQL extension to streamline the process.