### PR TITLE
Add InvokeCustomApi method to Server API definitions

### DIFF
--- a/src/common/intellisense/ServerApiCompletionProvider.ts
+++ b/src/common/intellisense/ServerApiCompletionProvider.ts
@@ -191,6 +191,17 @@ export class ServerApiDefinitions {
                     ],
                     returnType: "void",
                     example: "Server.Connector.Dataverse.DeleteRecord('contacts', contactId);"
+                },
+                {
+                    name: "InvokeCustomApi",
+                    description: "Invokes a custom API endpoint",
+                    parameters: [
+                        { name: "httpMethod", type: "string", description: "The HTTP method to use (e.g., GET, POST)" },
+                        { name: "url", type: "string", description: "The API endpoint URL" },
+                        { name: "payload", type: "string", description: "The JSON payload to send with the request" }
+                    ],
+                    returnType: "void",
+                    example: "Server.Connector.Dataverse.InvokeCustomApi('POST', '/api/data/v9.0/contacts', payload);"
                 }
             ]
         },


### PR DESCRIPTION
This pull request adds a new API method to the `Server.Connector.Dataverse` API definitions to support invoking custom API endpoints. This enhancement expands the flexibility of the API by allowing users to specify the HTTP method, endpoint URL, and payload.

**New functionality:**

* Added `InvokeCustomApi` method to `Server.Connector.Dataverse` in `ServerApiDefinitions`, enabling invocation of custom API endpoints with configurable HTTP method, URL, and payload.