### PR TITLE
Refactor activate function to optimize directory read

### DIFF
--- a/src/web/client/extension.ts
+++ b/src/web/client/extension.ts
@@ -139,8 +139,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                                         title: vscode.l10n.t("Fetching your file ..."),
                                     },
                                     async () => {
-                                        await portalsFS.readDirectory(WebExtensionContext.rootDirectory, true);
-
                                         // Initialize ECS config in webExtensionContext
                                         await ECSFeaturesClient.init(
                                             {
@@ -152,6 +150,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                                                 Location: queryParamsMap.get(queryParameters.GEO) as string
                                             },
                                             PowerPagesClientName);
+                                            
+                                        await portalsFS.readDirectory(WebExtensionContext.rootDirectory, true);
 
                                         const { enableServerLogicChanges } = EnableServerLogicChanges.getConfig() as { enableServerLogicChanges?: boolean };
                                         if (!serverApiAutocompleteInitialized && enableServerLogicChanges) {


### PR DESCRIPTION
- 🔄 Moved portalsFS.readDirectory call to after ECS config initialization for better flow.