### PR TITLE
[PowerPages][ActionsHub][Codespaces] Update Actions Hub visibility condition for virtual workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1229,7 +1229,7 @@
         {
           "id": "microsoft.powerplatform.pages.actionsHub",
           "name": "%microsoft.powerplatform.pages.actionsHub.title%",
-          "when": "microsoft.powerplatform.pages.actionsHubEnabled && !isWeb",
+          "when": "microsoft.powerplatform.pages.actionsHubEnabled && !virtualWorkspace",
           "icon": "./src/client/assets/powerPages.svg",
           "contextualTitle": "%microsoft.powerplatform.pages.actionsHub.title%",
           "visibility": "visible"


### PR DESCRIPTION
This pull request updates the activation condition for the Power Platform Pages Actions Hub in the `package.json` file. The change ensures that the hub is enabled only when not in a virtual workspace, rather than specifically checking for web environments.

Configuration update:

* Changed the `when` condition for the `microsoft.powerplatform.pages.actionsHub` contribution to use `!virtualWorkspace` instead of `!isWeb` in `package.json`.

<img width="1362" height="987" alt="image" src="https://github.com/user-attachments/assets/7b2339a7-f0f3-4ff9-aa8f-8104ef1a3c33" />
