### PR TITLE
Enhance website data retrieval with fallback support and new Git ALM format

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -596,7 +596,7 @@ export function findOtherSites(knownSiteIds: Set<string>, fsModule = fs, yamlMod
                         const websiteData = yamlModule.parse(yamlContent) as WebsiteYaml;
 
                         otherSites.push({
-                            name: websiteData?.adx_name || path.basename(dir), // Use folder name as fallback
+                            name: websiteData?.adx_name || websiteData?.name || path.basename(dir), // Use folder name as fallback
                             websiteId: websiteId,
                             folderPath: dir,
                             isCodeSite: powerPagesSiteFolderExists

--- a/src/common/services/Interfaces.ts
+++ b/src/common/services/Interfaces.ts
@@ -69,4 +69,5 @@ export interface WebsiteYaml {
     adx_statuscode?: number;
     adx_website_language?: number | string;
     adx_websiteid?: string;
+    name?: string
 }

--- a/src/common/utilities/WorkspaceInfoFinderUtil.ts
+++ b/src/common/utilities/WorkspaceInfoFinderUtil.ts
@@ -59,8 +59,13 @@ export function getWebsiteRecordId(param: { uri: string }[] | string): string {
         if (fs.existsSync(websiteYmlPath)) {
             const fileContent = fs.readFileSync(websiteYmlPath, 'utf8');
             const parsedYaml = parse(fileContent);
-            if (parsedYaml && parsedYaml.adx_websiteid) {
-                return parsedYaml.adx_websiteid;
+            if (parsedYaml) {
+                // Check for adx_websiteid first, then fallback to id (to support new Git ALM format)
+                if (parsedYaml.adx_websiteid) {
+                    return parsedYaml.adx_websiteid;
+                } else if (parsedYaml.id) {
+                    return parsedYaml.id;
+                }
             }
         }
     } catch (exception) {


### PR DESCRIPTION
This pull request improves how website metadata is handled and retrieved from YAML files, with a focus on supporting new formats and providing better fallbacks for missing data. The most important changes include updating interfaces to support additional fields, enhancing fallback logic for website identification, and improving the way site names are determined.

**Website metadata handling improvements:**

* Updated the `WebsiteYaml` interface in `Interfaces.ts` to include an optional `name` field for better compatibility with new YAML formats.
* Enhanced the logic for determining site names in `findOtherSites` (`ActionsHubCommandHandlers.ts`) by falling back to `websiteData.name` if `adx_name` is not present, before using the folder name.

**Website identification logic:**

* Improved `getWebsiteRecordId` (`WorkspaceInfoFinderUtil.ts`) to first check for `adx_websiteid`, and then fallback to `id` if present, supporting new Git ALM YAML formats.