### PR TITLE
Refactor CodeQL screening and clean up dispose method

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubCommandHandlers.ts
@@ -985,7 +985,9 @@ export const runCodeQLScreening = async (siteTreeItem?: SiteTreeItem) => {
             return;
         }
 
-        const powerPagesSiteFolderExists = fs.existsSync(sitePath);
+        // Check if the .powerpages-site folder exists
+        const sitePathWithFolder = path.join(sitePath, POWERPAGES_SITE_FOLDER);
+        const powerPagesSiteFolderExists = fs.existsSync(sitePathWithFolder);
 
         // Check if CodeQL extension is installed
         const codeQLExtension = vscode.extensions.getExtension(CODEQL_EXTENSION_ID);

--- a/src/client/power-pages/actions-hub/actions/codeQLAction.ts
+++ b/src/client/power-pages/actions-hub/actions/codeQLAction.ts
@@ -860,6 +860,6 @@ export class CodeQLAction {
     }
 
     public dispose(): void {
-        this.outputChannel.dispose();
+
     }
 }


### PR DESCRIPTION
Enhance CodeQL screening to verify the existence of the .powerpages-site folder and remove unnecessary code from the dispose method.