### PR TITLE
Update CHANGELOG for pac CLI version bump to 2.0.100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - Power Platform Extension
 
-## 2.0.99
+## 2.0.100
 - pac CLI 1.48.2, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
 - Bug Fixes
   - Fixed auth mismatch issue for Power Pages Actions (Desktop)


### PR DESCRIPTION
Update the CHANGELOG to reflect the release of pac CLI 1.48.2 and version bumps to  2.0.100.