### PR TITLE
Add welcome message for non-interactive login in actions hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,12 @@
         "contents": "%microsoft.powerplatform.pages.actionsHub.login%",
         "when": "!virtualWorkspace && pacCLI.authPanel.interactiveLoginSupported",
         "enablement": "microsoft.powerplatform.environment.initialized && !microsoft.powerplatform.pages.actionsHub.loadingWebsites"
+      },
+      {
+        "view": "microsoft.powerplatform.pages.actionsHub",
+        "contents": "%pacCLI.authPanel.welcome.whenInteractiveNotSupported%",
+        "when": "!virtualWorkspace && !pacCLI.authPanel.interactiveLoginSupported",
+        "enablement": "microsoft.powerplatform.environment.initialized && !microsoft.powerplatform.pages.actionsHub.loadingWebsites"
       }
     ],
     "commands": [


### PR DESCRIPTION
This pull request adds improved handling for environments where interactive login is not supported in the authentication panel. Specifically, it introduces a new UI message for users when interactive login is unavailable.

User interface improvements:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R197-R202): Added a new entry to display a specific welcome message (`%pacCLI.authPanel.welcome.whenInteractiveNotSupported%`) in the `actionsHub` view when interactive login is not supported, ensuring users receive appropriate guidance in these scenarios.

<img width="1200" height="936" alt="image" src="https://github.com/user-attachments/assets/55381e32-bd28-4d1c-b00d-5b6eacdb7231" />
