### PR TITLE
Preserve insertion order and add duplicate file handling feature flag

### DIFF
--- a/src/common/ecs-features/ecsFeatureGates.ts
+++ b/src/common/ecs-features/ecsFeatureGates.ts
@@ -109,3 +109,14 @@ export const {
         enableOpenInDesktop: false,
     }
 });
+
+export const {
+    feature: EnableDuplicateFileHandling
+} = getFeatureConfigs({
+    teamName: PowerPagesClientName,
+    description: 'Enable duplicate file handling for webpage folders',
+    fallback: {
+        enableDuplicateFileHandling: true,
+        disallowedDuplicateFileHandlingOrgs: "",
+    }
+});


### PR DESCRIPTION
This pull request introduces a new feature flag for duplicate file handling in webpage folders and updates the logic for handling duplicate file names based on this flag. The changes are grouped into feature flag introduction and logic updates for file handling.

**Feature flag introduction:**

* Added a new feature flag, `EnableDuplicateFileHandling`, to `ecsFeatureGates.ts` with configuration options for enabling/disabling the feature and specifying organizations where it should be disallowed.

**File handling logic updates:**

* Updated imports in `remoteFetchProvider.ts` to include the new `EnableDuplicateFileHandling` flag.
* In `processDataAndCreateFile`, added logic to check if duplicate file handling is enabled and not disabled for the current organization before applying the new duplicate file handling logic for webpage folders.
* Modified the logic for determining which folder name to use for duplicate files: root webpage IDs are now extracted in insertion order (not sorted), preserving the "first folder" logic for duplicate file names.
* Ensured that the new duplicate file handling logic is only applied if the feature flag is enabled and the organization is not in the disallowed list.