### PR TITLE
Add telemetry events for desktop opening actions

### DIFF
--- a/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts
+++ b/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts
@@ -129,7 +129,12 @@ export enum webExtensionTelemetryEventNames {
     WEB_EXTENSION_SEARCH_TEXT = "WebExtensionSearchText",
     WEB_EXTENSION_SEARCH_FILE = "WebExtensionSearchFile",
     WEB_EXTENSION_SOURCE_ATTRIBUTE_INVALID = "WebExtensionSourceAttributeInvalid",
+    WEB_EXTENSION_OPEN_DESKTOP_CLICKED = "WebExtensionOpenDesktopClicked",
+    WEB_EXTENSION_OPEN_DESKTOP_FEATURE_DISABLED = "WebExtensionOpenDesktopFeatureDisabled",
     WEB_EXTENSION_OPEN_DESKTOP_TRIGGERED = "WebExtensionOpenDesktopTriggered",
     WEB_EXTENSION_OPEN_DESKTOP_FAILED = "WebExtensionOpenDesktopFailed",
+    WEB_EXTENSION_OPEN_DESKTOP_URI_OPENED = "WebExtensionOpenDesktopUriOpened",
+    WEB_EXTENSION_OPEN_DESKTOP_DIALOG_DOWNLOAD_CLICKED = "WebExtensionOpenDesktopDialogDownloadClicked",
+    WEB_EXTENSION_OPEN_DESKTOP_DIALOG_UPDATE_CLICKED = "WebExtensionOpenDesktopDialogUpdateClicked",
     WEB_EXTENSION_DUPLICATE_FOLDER_NAME_CREATED = "WebExtensionDuplicateFolderNameCreated"
 }


### PR DESCRIPTION
This pull request adds enhanced telemetry tracking for the "Open in VS Code Desktop" feature in the Power Pages navigation provider, improving observability for user actions and feature flag status. It introduces new telemetry events, tracks user interactions with dialog options, and ensures feature gating via ECS flags.

**Telemetry enhancements for "Open in Desktop" flow:**

- Added new telemetry event names to the `webExtensionTelemetryEventNames` enum for tracking user actions and dialog interactions related to the "Open in Desktop" feature.
- Updated the `openInDesktop` method in `powerPagesNavigationProvider.ts` to send telemetry events when the feature is clicked, when the ECS feature flag is disabled, when the desktop flow is triggered, and when the desktop URI is successfully opened. [[1]](diffhunk://#diff-96d103f6c47a0b6a7fee791b25952d72eefa3b5e6af58bf38c8d6bb25663683eR176-R200) [[2]](diffhunk://#diff-96d103f6c47a0b6a7fee791b25952d72eefa3b5e6af58bf38c8d6bb25663683eR237-R284)
- Added telemetry tracking for user selections in the informational dialog (download VS Code or update extension) after attempting to open in desktop.

**Feature flag enforcement:**

- Added a check for the ECS feature flag before proceeding with the "Open in Desktop" flow, and sent a telemetry event if the feature is disabled.

**Code cleanup:**

- Removed redundant telemetry logging for URI generation in favor of more granular event tracking at relevant points in the flow.