### PR TITLE
Update CHANGELOG.md for version 2.0.111 with pac CLI 1.51.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log - Power Platform Extension
 
+## 2.0.111
+- pac CLI 1.51.1, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
+
 ## 2.0.110
 - Bug Fix
   - Fixed autocomplete issue for page-templates (Desktop)


### PR DESCRIPTION
This pull request updates the changelog to document the new release version 2.0.111 of the Power Platform Extension, which includes an update to pac CLI 1.51.1.

Release documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5): Added a new entry for version 2.0.111, noting the update to pac CLI 1.51.1 and referencing the release notes on nuget.org.