### PR TITLE
[MDiff] Add sorting functionality for metadata diff view

### DIFF
--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -1413,6 +1413,15 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
     <trans-unit id="microsoft.powerplatform.pages.actionsHub.siteDetails.title">
       <source xml:lang="en">Site Details</source>
     </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByName.title">
+      <source xml:lang="en">Sort by Name</source>
+    </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByPath.title">
+      <source xml:lang="en">Sort by Path</source>
+    </trans-unit>
+    <trans-unit id="microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByStatus.title">
+      <source xml:lang="en">Sort by Status</source>
+    </trans-unit>
     <trans-unit id="microsoft.powerplatform.pages.actionsHub.configuration.downloadSite.description">
       <source xml:lang="en">The folder where site will be downloaded when using Power Pages Actions. Leave this empty to ask for a folder every time you download a site.</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -550,6 +550,24 @@
         "when": "microsoft.powerplatform.pages.metadataDiffEnabled"
       },
       {
+        "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByName",
+        "title": "%microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByName.title%",
+        "icon": "$(check)",
+        "when": "microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'list'"
+      },
+      {
+        "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByPath",
+        "title": "%microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByPath.title%",
+        "icon": "$(check)",
+        "when": "microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'list'"
+      },
+      {
+        "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByStatus",
+        "title": "%microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByStatus.title%",
+        "icon": "$(check)",
+        "when": "microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'list'"
+      },
+      {
         "command": "microsoft-powerapps-portals.compareWithEnvironment",
         "category": "Powerpages",
         "title": "%microsoft-powerapps-portals.compareWithEnvironment.title%",
@@ -1270,6 +1288,16 @@
           "group": "inline@2"
         },
         {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.openAll",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffSite && microsoft.powerplatform.pages.metadataDiffEnabled",
+          "group": "siteAction@1"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.removeSite",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffSite && microsoft.powerplatform.pages.metadataDiffEnabled",
+          "group": "siteAction@2"
+        },
+        {
           "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.viewAsTree",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffGroupWithResults && microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'list'",
           "group": "inline@2"
@@ -1285,6 +1313,36 @@
           "group": "inline@3"
         },
         {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.viewAsTree",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffGroupWithResults && microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'list'",
+          "group": "groupAction@1"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.viewAsList",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffGroupWithResults && microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'tree'",
+          "group": "groupAction@1"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.clear",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffGroupWithResults && microsoft.powerplatform.pages.metadataDiffEnabled",
+          "group": "groupAction@2"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByName",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffGroupWithResults && microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'list'",
+          "group": "sortAction@1"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByPath",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffGroupWithResults && microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'list'",
+          "group": "sortAction@2"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByStatus",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffGroupWithResults && microsoft.powerplatform.pages.metadataDiffEnabled && microsoft.powerplatform.pages.metadataDiffViewMode == 'list'",
+          "group": "sortAction@3"
+        },
+        {
           "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.openFile",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffFile && microsoft.powerplatform.pages.metadataDiffEnabled",
           "group": "inline@1"
@@ -1298,6 +1356,11 @@
           "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.discardFolder",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffFolder && microsoft.powerplatform.pages.metadataDiffEnabled",
           "group": "inline@1"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.discardFolder",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffFolder && microsoft.powerplatform.pages.metadataDiffEnabled",
+          "group": "folderAction@1"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.openFile",

--- a/package.nls.json
+++ b/package.nls.json
@@ -126,5 +126,8 @@
   "microsoft.powerplatform.pages.actionsHub.metadataDiff.viewAsList.title": "View as List",
   "microsoft.powerplatform.pages.actionsHub.metadataDiff.discardFile.title": "Discard Local Changes",
   "microsoft.powerplatform.pages.actionsHub.metadataDiff.discardFolder.title": "Discard All Local Changes",
+  "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByName.title": "Sort by Name",
+  "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByPath.title": "Sort by Path",
+  "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByStatus.title": "Sort by Status",
   "microsoft-powerapps-portals.compareWithEnvironment.title": "Compare with Environment"
 }

--- a/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubTreeDataProvider.ts
@@ -44,6 +44,7 @@ import { openMetadataDiffFile } from "./handlers/metadata-diff/OpenMetadataDiffF
 import { openAllMetadataDiffs } from "./handlers/metadata-diff/OpenAllMetadataDiffsHandler";
 import { clearMetadataDiff } from "./handlers/metadata-diff/ClearMetadataDiffHandler";
 import { viewAsTree, viewAsList } from "./handlers/metadata-diff/ToggleViewModeHandler";
+import { sortByName, sortByPath, sortByStatus } from "./handlers/metadata-diff/SortModeHandler";
 import { MetadataDiffDecorationProvider } from "./MetadataDiffDecorationProvider";
 import { removeSiteComparison } from "./handlers/metadata-diff/RemoveSiteHandler";
 import { discardLocalChanges } from "./handlers/metadata-diff/DiscardLocalChangesHandler";
@@ -314,6 +315,9 @@ export class ActionsHubTreeDataProvider implements vscode.TreeDataProvider<Actio
                 vscode.commands.registerCommand(Constants.Commands.METADATA_DIFF_REMOVE_SITE, removeSiteComparison),
                 vscode.commands.registerCommand(Constants.Commands.METADATA_DIFF_VIEW_AS_TREE, viewAsTree),
                 vscode.commands.registerCommand(Constants.Commands.METADATA_DIFF_VIEW_AS_LIST, viewAsList),
+                vscode.commands.registerCommand(Constants.Commands.METADATA_DIFF_SORT_BY_NAME, sortByName),
+                vscode.commands.registerCommand(Constants.Commands.METADATA_DIFF_SORT_BY_PATH, sortByPath),
+                vscode.commands.registerCommand(Constants.Commands.METADATA_DIFF_SORT_BY_STATUS, sortByStatus),
                 vscode.commands.registerCommand(Constants.Commands.METADATA_DIFF_DISCARD_FILE, discardLocalChanges),
                 vscode.commands.registerCommand(Constants.Commands.METADATA_DIFF_DISCARD_FOLDER, discardFolderChanges),
                 MetadataDiffDecorationProvider.getInstance().register()

--- a/src/client/power-pages/actions-hub/Constants.ts
+++ b/src/client/power-pages/actions-hub/Constants.ts
@@ -34,6 +34,9 @@ export const Constants = {
         METADATA_DIFF_VIEW_AS_LIST: "microsoft.powerplatform.pages.actionsHub.metadataDiff.viewAsList",
         METADATA_DIFF_DISCARD_FILE: "microsoft.powerplatform.pages.actionsHub.metadataDiff.discardFile",
         METADATA_DIFF_DISCARD_FOLDER: "microsoft.powerplatform.pages.actionsHub.metadataDiff.discardFolder",
+        METADATA_DIFF_SORT_BY_NAME: "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByName",
+        METADATA_DIFF_SORT_BY_PATH: "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByPath",
+        METADATA_DIFF_SORT_BY_STATUS: "microsoft.powerplatform.pages.actionsHub.metadataDiff.sortByStatus",
         COMPARE_WITH_ENVIRONMENT: "microsoft-powerapps-portals.compareWithEnvironment",
     },
     Icons: {
@@ -410,6 +413,7 @@ export const Constants = {
         ACTIONS_HUB_METADATA_DIFF_DISCARD_FILE: "ActionsHubMetadataDiffDiscardFile",
         ACTIONS_HUB_METADATA_DIFF_DISCARD_FOLDER: "ActionsHubMetadataDiffDiscardFolder",
         ACTIONS_HUB_METADATA_DIFF_VIEW_MODE_CHANGED: "ActionsHubMetadataDiffViewModeChanged",
+        ACTIONS_HUB_METADATA_DIFF_SORT_MODE_CHANGED: "ActionsHubMetadataDiffSortModeChanged",
         ACTIONS_HUB_COMPARE_WITH_ENVIRONMENT_CALLED: "ActionsHubCompareWithEnvironmentCalled",
         ACTIONS_HUB_COMPARE_WITH_ENVIRONMENT_ENVIRONMENT_SELECTED: "ActionsHubCompareWithEnvironmentEnvironmentSelected",
         ACTIONS_HUB_COMPARE_WITH_ENVIRONMENT_CANCELLED: "ActionsHubCompareWithEnvironmentCancelled",

--- a/src/client/power-pages/actions-hub/MetadataDiffContext.ts
+++ b/src/client/power-pages/actions-hub/MetadataDiffContext.ts
@@ -15,6 +15,15 @@ export enum MetadataDiffViewMode {
 }
 
 /**
+ * Enum for metadata diff sort modes (used in list view)
+ */
+export enum MetadataDiffSortMode {
+    Path = "path",
+    Name = "name",
+    Status = "status"
+}
+
+/**
  * Interface for storing comparison results per site
  */
 export interface ISiteComparisonResults {
@@ -25,6 +34,8 @@ export interface ISiteComparisonResults {
 
 const VIEW_MODE_CONTEXT_KEY = "microsoft.powerplatform.pages.metadataDiffViewMode";
 const VIEW_MODE_STORAGE_KEY = "microsoft.powerplatform.pages.metadataDiff.viewModePreference";
+const SORT_MODE_CONTEXT_KEY = "microsoft.powerplatform.pages.metadataDiffSortMode";
+const SORT_MODE_STORAGE_KEY = "microsoft.powerplatform.pages.metadataDiff.sortModePreference";
 
 /**
  * Context for storing metadata diff comparison results
@@ -33,7 +44,8 @@ const VIEW_MODE_STORAGE_KEY = "microsoft.powerplatform.pages.metadataDiff.viewMo
  */
 class MetadataDiffContextClass {
     private _siteResults: Map<string, ISiteComparisonResults> = new Map();
-    private _viewMode: MetadataDiffViewMode = MetadataDiffViewMode.List;
+    private _viewMode: MetadataDiffViewMode = MetadataDiffViewMode.Tree;
+    private _sortMode: MetadataDiffSortMode = MetadataDiffSortMode.Path;
     private _extensionContext: vscode.ExtensionContext | undefined;
 
     private _onChanged: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
@@ -50,8 +62,14 @@ class MetadataDiffContextClass {
         if (savedViewMode) {
             this._viewMode = savedViewMode;
         }
-        // Update VS Code context with loaded view mode
+        // Load persisted sort mode preference from global state
+        const savedSortMode = context.globalState.get<MetadataDiffSortMode>(SORT_MODE_STORAGE_KEY);
+        if (savedSortMode) {
+            this._sortMode = savedSortMode;
+        }
+        // Update VS Code context with loaded view mode and sort mode
         this.updateViewModeContext();
+        this.updateSortModeContext();
     }
 
     /**
@@ -96,6 +114,19 @@ class MetadataDiffContextClass {
 
     public get isListView(): boolean {
         return this._viewMode === MetadataDiffViewMode.List;
+    }
+
+    public get sortMode(): MetadataDiffSortMode {
+        return this._sortMode;
+    }
+
+    public setSortMode(mode: MetadataDiffSortMode): void {
+        if (this._sortMode !== mode) {
+            this._sortMode = mode;
+            this.updateSortModeContext();
+            this.persistSortMode();
+            this._onChanged.fire();
+        }
     }
 
     /**
@@ -183,6 +214,22 @@ class MetadataDiffContextClass {
     private persistViewMode(): void {
         if (this._extensionContext) {
             this._extensionContext.globalState.update(VIEW_MODE_STORAGE_KEY, this._viewMode);
+        }
+    }
+
+    /**
+     * Update VS Code context for sort mode to control command visibility
+     */
+    private updateSortModeContext(): void {
+        vscode.commands.executeCommand("setContext", SORT_MODE_CONTEXT_KEY, this._sortMode);
+    }
+
+    /**
+     * Persist sort mode preference to global state (user-specific, not workspace-specific)
+     */
+    private persistSortMode(): void {
+        if (this._extensionContext) {
+            this._extensionContext.globalState.update(SORT_MODE_STORAGE_KEY, this._sortMode);
         }
     }
 

--- a/src/client/power-pages/actions-hub/handlers/metadata-diff/DiscardLocalChangesHandler.ts
+++ b/src/client/power-pages/actions-hub/handlers/metadata-diff/DiscardLocalChangesHandler.ts
@@ -63,7 +63,7 @@ export async function discardLocalChanges(fileItem: MetadataDiffFileTreeItem): P
         status: comparisonResult.status
     });
 
-    const confirmMessage = Constants.StringFunctions.DISCARD_LOCAL_CHANGES_CONFIRM(comparisonResult.relativePath);
+    const confirmMessage = Constants.StringFunctions.DISCARD_LOCAL_CHANGES_CONFIRM(comparisonResult.localPath);
 
     const confirmButton = Constants.Strings.DISCARD_CHANGES;
     const result = await vscode.window.showWarningMessage(confirmMessage, { modal: true }, confirmButton);

--- a/src/client/power-pages/actions-hub/handlers/metadata-diff/SortModeHandler.ts
+++ b/src/client/power-pages/actions-hub/handlers/metadata-diff/SortModeHandler.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import MetadataDiffContext, { MetadataDiffSortMode } from "../../MetadataDiffContext";
+import { traceInfo } from "../../TelemetryHelper";
+import { Constants } from "../../Constants";
+
+/**
+ * Handler for sorting by file name
+ */
+export const sortByName = (): void => {
+    traceInfo(Constants.EventNames.ACTIONS_HUB_METADATA_DIFF_SORT_MODE_CHANGED, {
+        methodName: sortByName.name,
+        sortMode: MetadataDiffSortMode.Name
+    });
+
+    MetadataDiffContext.setSortMode(MetadataDiffSortMode.Name);
+};
+
+/**
+ * Handler for sorting by file path
+ */
+export const sortByPath = (): void => {
+    traceInfo(Constants.EventNames.ACTIONS_HUB_METADATA_DIFF_SORT_MODE_CHANGED, {
+        methodName: sortByPath.name,
+        sortMode: MetadataDiffSortMode.Path
+    });
+
+    MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
+};
+
+/**
+ * Handler for sorting by status
+ */
+export const sortByStatus = (): void => {
+    traceInfo(Constants.EventNames.ACTIONS_HUB_METADATA_DIFF_SORT_MODE_CHANGED, {
+        methodName: sortByStatus.name,
+        sortMode: MetadataDiffSortMode.Status
+    });
+
+    MetadataDiffContext.setSortMode(MetadataDiffSortMode.Status);
+};

--- a/src/client/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFileTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFileTreeItem.ts
@@ -51,10 +51,9 @@ export class MetadataDiffFileTreeItem extends ActionsHubTreeItem {
             query: `status=${comparisonResult.status}`
         });
 
-        // Set tooltip with full path and status
+        // Set tooltip with full local path and status
         this.tooltip = new vscode.MarkdownString();
-        this.tooltip.appendMarkdown(`**${comparisonResult.relativePath}**\n\n`);
-        this.tooltip.appendMarkdown(`Status: ${MetadataDiffFileTreeItem.getStatusDescription(comparisonResult.status)}`);
+        this.tooltip.appendMarkdown(`${comparisonResult.localPath} • ${MetadataDiffFileTreeItem.getStatusDescription(comparisonResult.status)}`);
 
         // Set command to open diff when clicked
         this.command = {

--- a/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/ActionsHubTreeDataProvider.test.ts
@@ -39,6 +39,7 @@ import * as DownloadSiteHandler from "../../../../power-pages/actions-hub/handle
 import * as LoginToMatchHandler from "../../../../power-pages/actions-hub/handlers/LoginToMatchHandler";
 import * as RunCodeQLScreeningHandler from "../../../../power-pages/actions-hub/handlers/code-ql/RunCodeQlScreeningHandler";
 import { ToolsGroupTreeItem } from "../../../../power-pages/actions-hub/tree-items/ToolsGroupTreeItem";
+import * as SortModeHandler from "../../../../power-pages/actions-hub/handlers/metadata-diff/SortModeHandler";
 
 // Add global type declaration for ArtemisContext
 describe("ActionsHubTreeDataProvider", () => {
@@ -297,6 +298,63 @@ describe("ActionsHubTreeDataProvider", () => {
                 expect(mockCommandHandler.calledOnce).to.be.true;
             } else {
                 throw new Error("CodeQL command was not registered");
+            }
+        });
+
+        it('should register sortByName command', async () => {
+            const mockCommandHandler = sinon.stub(SortModeHandler, 'sortByName');
+            const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal, false);
+            actionsHubTreeDataProvider["registerPanel"]();
+
+            expect(registerCommandStub.calledWith(Constants.Commands.METADATA_DIFF_SORT_BY_NAME)).to.be.true;
+
+            const sortByNameCall = registerCommandStub.getCalls().find(call =>
+                call.args[0] === Constants.Commands.METADATA_DIFF_SORT_BY_NAME
+            );
+
+            if (sortByNameCall) {
+                sortByNameCall.args[1]();
+                expect(mockCommandHandler.calledOnce).to.be.true;
+            } else {
+                throw new Error("sortByName command was not registered");
+            }
+        });
+
+        it('should register sortByPath command', async () => {
+            const mockCommandHandler = sinon.stub(SortModeHandler, 'sortByPath');
+            const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal, false);
+            actionsHubTreeDataProvider["registerPanel"]();
+
+            expect(registerCommandStub.calledWith(Constants.Commands.METADATA_DIFF_SORT_BY_PATH)).to.be.true;
+
+            const sortByPathCall = registerCommandStub.getCalls().find(call =>
+                call.args[0] === Constants.Commands.METADATA_DIFF_SORT_BY_PATH
+            );
+
+            if (sortByPathCall) {
+                sortByPathCall.args[1]();
+                expect(mockCommandHandler.calledOnce).to.be.true;
+            } else {
+                throw new Error("sortByPath command was not registered");
+            }
+        });
+
+        it('should register sortByStatus command', async () => {
+            const mockCommandHandler = sinon.stub(SortModeHandler, 'sortByStatus');
+            const actionsHubTreeDataProvider = ActionsHubTreeDataProvider.initialize(context, pacTerminal, false);
+            actionsHubTreeDataProvider["registerPanel"]();
+
+            expect(registerCommandStub.calledWith(Constants.Commands.METADATA_DIFF_SORT_BY_STATUS)).to.be.true;
+
+            const sortByStatusCall = registerCommandStub.getCalls().find(call =>
+                call.args[0] === Constants.Commands.METADATA_DIFF_SORT_BY_STATUS
+            );
+
+            if (sortByStatusCall) {
+                sortByStatusCall.args[1]();
+                expect(mockCommandHandler.calledOnce).to.be.true;
+            } else {
+                throw new Error("sortByStatus command was not registered");
             }
         });
     });

--- a/src/client/test/Integration/power-pages/actions-hub/MetadataDiffContext.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/MetadataDiffContext.test.ts
@@ -6,7 +6,7 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
-import MetadataDiffContext, { MetadataDiffViewMode } from "../../../../power-pages/actions-hub/MetadataDiffContext";
+import MetadataDiffContext, { MetadataDiffViewMode, MetadataDiffSortMode } from "../../../../power-pages/actions-hub/MetadataDiffContext";
 import { IFileComparisonResult } from "../../../../power-pages/actions-hub/models/IFileComparisonResult";
 
 describe("MetadataDiffContext", () => {
@@ -18,6 +18,8 @@ describe("MetadataDiffContext", () => {
         MetadataDiffContext.clear();
         // Reset view mode to default
         MetadataDiffContext.setViewMode(MetadataDiffViewMode.List);
+        // Reset sort mode to default
+        MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
     });
 
     afterEach(() => {
@@ -276,6 +278,87 @@ describe("MetadataDiffContext", () => {
             expect(mockGlobalState.update.calledWith(
                 "microsoft.powerplatform.pages.metadataDiff.viewModePreference",
                 MetadataDiffViewMode.Tree
+            )).to.be.true;
+        });
+    });
+
+    describe("sortMode", () => {
+        it("should default to path sort mode", () => {
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Path);
+        });
+
+        it("should allow setting sort mode to name", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Name);
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Name);
+        });
+
+        it("should allow setting sort mode to status", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Status);
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Status);
+        });
+
+        it("should allow setting sort mode to path", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Name);
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Path);
+        });
+
+        it("should fire onChanged event when sort mode changes", () => {
+            const onChangedSpy = sandbox.spy();
+            MetadataDiffContext.onChanged(onChangedSpy);
+
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Name);
+
+            expect(onChangedSpy.calledOnce).to.be.true;
+        });
+
+        it("should not fire onChanged event when sort mode is set to same value", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
+            const onChangedSpy = sandbox.spy();
+            MetadataDiffContext.onChanged(onChangedSpy);
+
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
+
+            expect(onChangedSpy.called).to.be.false;
+        });
+
+        it("should load persisted sort mode from global state", () => {
+            const mockGlobalState = {
+                get: sandbox.stub().callsFake((key: string) => {
+                    if (key === "microsoft.powerplatform.pages.metadataDiff.sortModePreference") {
+                        return MetadataDiffSortMode.Status;
+                    }
+                    return undefined;
+                }),
+                update: sandbox.stub().resolves()
+            };
+            const mockContext = {
+                globalState: mockGlobalState
+            } as unknown as vscode.ExtensionContext;
+
+            MetadataDiffContext.initialize(mockContext);
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Status);
+        });
+
+        it("should persist sort mode when changed after initialization", () => {
+            const mockGlobalState = {
+                get: sandbox.stub().returns(undefined),
+                update: sandbox.stub().resolves()
+            };
+            const mockContext = {
+                globalState: mockGlobalState
+            } as unknown as vscode.ExtensionContext;
+
+            MetadataDiffContext.initialize(mockContext);
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Name);
+
+            expect(mockGlobalState.update.calledWith(
+                "microsoft.powerplatform.pages.metadataDiff.sortModePreference",
+                MetadataDiffSortMode.Name
             )).to.be.true;
         });
     });

--- a/src/client/test/Integration/power-pages/actions-hub/handlers/metadata-diff/SortModeHandler.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/handlers/metadata-diff/SortModeHandler.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { sortByName, sortByPath, sortByStatus } from "../../../../../../power-pages/actions-hub/handlers/metadata-diff/SortModeHandler";
+import MetadataDiffContext, { MetadataDiffSortMode } from "../../../../../../power-pages/actions-hub/MetadataDiffContext";
+import * as TelemetryHelper from "../../../../../../power-pages/actions-hub/TelemetryHelper";
+import { Constants } from "../../../../../../power-pages/actions-hub/Constants";
+
+describe("SortModeHandler", () => {
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(TelemetryHelper, "traceInfo");
+
+        // Initialize MetadataDiffContext with a mock extension context to enable setSortMode
+        const mockGlobalState = {
+            get: sandbox.stub().returns(undefined),
+            update: sandbox.stub().resolves()
+        };
+        const mockContext = {
+            globalState: mockGlobalState
+        } as unknown as vscode.ExtensionContext;
+        MetadataDiffContext.initialize(mockContext);
+
+        // Reset sort mode to default state before each test
+        MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        MetadataDiffContext.clear();
+    });
+
+    describe("sortByName", () => {
+        it("should set sort mode to name", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
+
+            sortByName();
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Name);
+        });
+
+        it("should log telemetry event with name sort mode", () => {
+            const traceInfoStub = TelemetryHelper.traceInfo as sinon.SinonStub;
+
+            sortByName();
+
+            expect(traceInfoStub.calledOnce).to.be.true;
+            expect(traceInfoStub.firstCall.args[0]).to.equal(Constants.EventNames.ACTIONS_HUB_METADATA_DIFF_SORT_MODE_CHANGED);
+            expect(traceInfoStub.firstCall.args[1]).to.deep.equal({
+                methodName: "sortByName",
+                sortMode: MetadataDiffSortMode.Name
+            });
+        });
+
+        it("should work when already in name sort mode", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Name);
+
+            sortByName();
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Name);
+        });
+    });
+
+    describe("sortByPath", () => {
+        it("should set sort mode to path", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Name);
+
+            sortByPath();
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Path);
+        });
+
+        it("should log telemetry event with path sort mode", () => {
+            const traceInfoStub = TelemetryHelper.traceInfo as sinon.SinonStub;
+
+            sortByPath();
+
+            expect(traceInfoStub.calledOnce).to.be.true;
+            expect(traceInfoStub.firstCall.args[0]).to.equal(Constants.EventNames.ACTIONS_HUB_METADATA_DIFF_SORT_MODE_CHANGED);
+            expect(traceInfoStub.firstCall.args[1]).to.deep.equal({
+                methodName: "sortByPath",
+                sortMode: MetadataDiffSortMode.Path
+            });
+        });
+
+        it("should work when already in path sort mode", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
+
+            sortByPath();
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Path);
+        });
+    });
+
+    describe("sortByStatus", () => {
+        it("should set sort mode to status", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Path);
+
+            sortByStatus();
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Status);
+        });
+
+        it("should log telemetry event with status sort mode", () => {
+            const traceInfoStub = TelemetryHelper.traceInfo as sinon.SinonStub;
+
+            sortByStatus();
+
+            expect(traceInfoStub.calledOnce).to.be.true;
+            expect(traceInfoStub.firstCall.args[0]).to.equal(Constants.EventNames.ACTIONS_HUB_METADATA_DIFF_SORT_MODE_CHANGED);
+            expect(traceInfoStub.firstCall.args[1]).to.deep.equal({
+                methodName: "sortByStatus",
+                sortMode: MetadataDiffSortMode.Status
+            });
+        });
+
+        it("should work when already in status sort mode", () => {
+            MetadataDiffContext.setSortMode(MetadataDiffSortMode.Status);
+
+            sortByStatus();
+
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Status);
+        });
+    });
+
+    describe("sort mode switching workflow", () => {
+        it("should allow switching between all sort modes", () => {
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Path);
+
+            sortByName();
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Name);
+
+            sortByStatus();
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Status);
+
+            sortByPath();
+            expect(MetadataDiffContext.sortMode).to.equal(MetadataDiffSortMode.Path);
+        });
+
+        it("should log telemetry for each sort mode change", () => {
+            const traceInfoStub = TelemetryHelper.traceInfo as sinon.SinonStub;
+
+            sortByName();
+            sortByStatus();
+            sortByPath();
+
+            expect(traceInfoStub.calledThrice).to.be.true;
+            expect(traceInfoStub.firstCall.args[1].sortMode).to.equal(MetadataDiffSortMode.Name);
+            expect(traceInfoStub.secondCall.args[1].sortMode).to.equal(MetadataDiffSortMode.Status);
+            expect(traceInfoStub.thirdCall.args[1].sortMode).to.equal(MetadataDiffSortMode.Path);
+        });
+    });
+});

--- a/src/client/test/Integration/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFileTreeItem.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFileTreeItem.test.ts
@@ -156,11 +156,30 @@ describe("MetadataDiffFileTreeItem", () => {
     });
 
     describe("tooltip", () => {
-        it("should have tooltip with full path and status", () => {
+        it("should have tooltip with local path and status", () => {
             const result: IFileComparisonResult = { ...mockComparisonResult, status: "modified" };
             const treeItem = new MetadataDiffFileTreeItem(result, "Test Site");
 
             expect(treeItem.tooltip).to.be.instanceOf(vscode.MarkdownString);
+            const tooltipValue = (treeItem.tooltip as vscode.MarkdownString).value;
+            expect(tooltipValue).to.include("/local/file.txt");
+            expect(tooltipValue).to.include("Modified");
+        });
+
+        it("should show Added status in tooltip for added files", () => {
+            const result: IFileComparisonResult = { ...mockComparisonResult, status: "added" };
+            const treeItem = new MetadataDiffFileTreeItem(result, "Test Site");
+
+            const tooltipValue = (treeItem.tooltip as vscode.MarkdownString).value;
+            expect(tooltipValue).to.include("Added");
+        });
+
+        it("should show Deleted status in tooltip for deleted files", () => {
+            const result: IFileComparisonResult = { ...mockComparisonResult, status: "deleted" };
+            const treeItem = new MetadataDiffFileTreeItem(result, "Test Site");
+
+            const tooltipValue = (treeItem.tooltip as vscode.MarkdownString).value;
+            expect(tooltipValue).to.include("Deleted");
         });
     });
 });


### PR DESCRIPTION
This update introduces sorting capabilities for the metadata diff view in the actions hub.

- ✨ Added new commands for sorting by Name, Path, and Status.
- 📜 Updated translations for new sorting options.
- 🔧 Implemented sorting logic in `MetadataDiffSiteTreeItem`.
- 🧪 Added unit tests for sorting functionality in relevant test files.
- 🔄 Refactored existing code to accommodate new sorting modes.

-Priyanshu