### PR TITLE
[MDiff] Hide discard actions for imported comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -1509,6 +1509,11 @@
           "group": "inline@1"
         },
         {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.openFile",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffFileImported && microsoft.powerplatform.pages.metadataDiffEnabled",
+          "group": "inline@1"
+        },
+        {
           "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.discardFile",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffFile && microsoft.powerplatform.pages.metadataDiffEnabled",
           "group": "inline@2"
@@ -1526,6 +1531,11 @@
         {
           "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.openFile",
           "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffFile && microsoft.powerplatform.pages.metadataDiffEnabled",
+          "group": "fileAction@1"
+        },
+        {
+          "command": "microsoft.powerplatform.pages.actionsHub.metadataDiff.openFile",
+          "when": "view == microsoft.powerplatform.pages.actionsHub && viewItem == metadataDiffFileImported && microsoft.powerplatform.pages.metadataDiffEnabled",
           "group": "fileAction@1"
         },
         {

--- a/src/client/power-pages/actions-hub/Constants.ts
+++ b/src/client/power-pages/actions-hub/Constants.ts
@@ -24,7 +24,9 @@ export const Constants = {
         METADATA_DIFF_SITE: "metadataDiffSite",
         METADATA_DIFF_SITE_IMPORTED: "metadataDiffSiteImported",
         METADATA_DIFF_FOLDER: "metadataDiffFolder",
+        METADATA_DIFF_FOLDER_IMPORTED: "metadataDiffFolderImported",
         METADATA_DIFF_FILE: "metadataDiffFile",
+        METADATA_DIFF_FILE_IMPORTED: "metadataDiffFileImported",
     },
     Commands: {
         METADATA_DIFF_OPEN_FILE: "microsoft.powerplatform.pages.actionsHub.metadataDiff.openFile",

--- a/src/client/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFileTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFileTreeItem.ts
@@ -34,12 +34,17 @@ export class MetadataDiffFileTreeItem extends ActionsHubTreeItem {
         // Build description based on view mode
         const description = MetadataDiffFileTreeItem.buildDescription(comparisonResult);
 
+        // Use different context value for imported items to hide discard option
+        const contextValue = isImported
+            ? Constants.ContextValues.METADATA_DIFF_FILE_IMPORTED
+            : Constants.ContextValues.METADATA_DIFF_FILE;
+
         super(
             fileName,
             vscode.TreeItemCollapsibleState.None,
             // Pass empty ThemeIcon - it will be overridden by resourceUri
             new vscode.ThemeIcon("file"),
-            Constants.ContextValues.METADATA_DIFF_FILE,
+            contextValue,
             description
         );
         this.comparisonResult = comparisonResult;

--- a/src/client/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFolderTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFolderTreeItem.ts
@@ -15,17 +15,24 @@ export class MetadataDiffFolderTreeItem extends ActionsHubTreeItem {
     public readonly childrenMap: Map<string, MetadataDiffFolderTreeItem | MetadataDiffFileTreeItem>;
     private readonly _siteName: string;
     private readonly _folderPath: string;
+    private readonly _isImported: boolean;
 
-    constructor(folderName: string, siteName: string, folderPath: string) {
+    constructor(folderName: string, siteName: string, folderPath: string, isImported: boolean = false) {
+        // Use different context value for imported items to hide discard option
+        const contextValue = isImported
+            ? Constants.ContextValues.METADATA_DIFF_FOLDER_IMPORTED
+            : Constants.ContextValues.METADATA_DIFF_FOLDER;
+
         super(
             folderName,
             vscode.TreeItemCollapsibleState.Expanded,
             Constants.Icons.METADATA_DIFF_FOLDER,
-            Constants.ContextValues.METADATA_DIFF_FOLDER
+            contextValue
         );
         this.childrenMap = new Map();
         this._siteName = siteName;
         this._folderPath = folderPath;
+        this._isImported = isImported;
     }
 
     public getChildren(): ActionsHubTreeItem[] {
@@ -59,6 +66,10 @@ export class MetadataDiffFolderTreeItem extends ActionsHubTreeItem {
 
     public get folderPath(): string {
         return this._folderPath;
+    }
+
+    public get isImported(): boolean {
+        return this._isImported;
     }
 
     /**

--- a/src/client/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffSiteTreeItem.ts
+++ b/src/client/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffSiteTreeItem.ts
@@ -138,7 +138,7 @@ export class MetadataDiffSiteTreeItem extends ActionsHubTreeItem {
                     // Look in root children
                     let folder = rootChildren.get(folderName) as MetadataDiffFolderTreeItem | undefined;
                     if (!folder) {
-                        folder = new MetadataDiffFolderTreeItem(folderName, this._siteName, currentPath);
+                        folder = new MetadataDiffFolderTreeItem(folderName, this._siteName, currentPath, this._isImported);
                         rootChildren.set(folderName, folder);
                     }
                     currentFolder = folder;
@@ -146,7 +146,7 @@ export class MetadataDiffSiteTreeItem extends ActionsHubTreeItem {
                     // Look in current folder's children
                     let folder = currentFolder.childrenMap.get(folderName) as MetadataDiffFolderTreeItem | undefined;
                     if (!folder) {
-                        folder = new MetadataDiffFolderTreeItem(folderName, this._siteName, currentPath);
+                        folder = new MetadataDiffFolderTreeItem(folderName, this._siteName, currentPath, this._isImported);
                         currentFolder.childrenMap.set(folderName, folder);
                     }
                     currentFolder = folder;

--- a/src/client/test/Integration/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFileTreeItem.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFileTreeItem.test.ts
@@ -56,6 +56,12 @@ describe("MetadataDiffFileTreeItem", () => {
 
             expect(treeItem.contextValue).to.equal(Constants.ContextValues.METADATA_DIFF_FILE);
         });
+
+        it("should have imported context value when isImported is true", () => {
+            const treeItem = new MetadataDiffFileTreeItem(mockComparisonResult, "Test Site", true);
+
+            expect(treeItem.contextValue).to.equal(Constants.ContextValues.METADATA_DIFF_FILE_IMPORTED);
+        });
     });
 
     describe("resourceUri", () => {

--- a/src/client/test/Integration/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFolderTreeItem.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/tree-items/metadata-diff/MetadataDiffFolderTreeItem.test.ts
@@ -43,6 +43,12 @@ describe("MetadataDiffFolderTreeItem", () => {
             expect(treeItem.contextValue).to.equal(Constants.ContextValues.METADATA_DIFF_FOLDER);
         });
 
+        it("should have imported context value when isImported is true", () => {
+            const treeItem = new MetadataDiffFolderTreeItem("folder", "Test Site", "folder", true);
+
+            expect(treeItem.contextValue).to.equal(Constants.ContextValues.METADATA_DIFF_FOLDER_IMPORTED);
+        });
+
         it("should have empty children map initially", () => {
             const treeItem = new MetadataDiffFolderTreeItem("folder", "Test Site", "folder");
 
@@ -54,6 +60,18 @@ describe("MetadataDiffFolderTreeItem", () => {
 
             expect(treeItem.siteName).to.equal("Test Site");
             expect(treeItem.folderPath).to.equal("root/folder");
+        });
+
+        it("should have isImported default to false", () => {
+            const treeItem = new MetadataDiffFolderTreeItem("folder", "Test Site", "folder");
+
+            expect(treeItem.isImported).to.be.false;
+        });
+
+        it("should store isImported when provided", () => {
+            const treeItem = new MetadataDiffFolderTreeItem("folder", "Test Site", "folder", true);
+
+            expect(treeItem.isImported).to.be.true;
         });
     });
 


### PR DESCRIPTION
Improve the metadata diff feature by hiding discard actions for imported comparison items and extending tests to verify this behavior.