### PR TITLE
Remove server logic debugging ECS flag

### DIFF
--- a/src/common/ecs-features/ecsFeatureGates.ts
+++ b/src/common/ecs-features/ecsFeatureGates.ts
@@ -140,13 +140,3 @@ export const {
         enableMetadataDiff: false,
     }
 });
-
-export const {
-    feature: EnableServerLogicDebugging
-} = getFeatureConfigs({
-    teamName: PowerPagesClientName,
-    description: 'Enable Server Logic Debugging in VS Code Desktop',
-    fallback: {
-        enableServerLogicDebugging: false,
-    }
-});

--- a/src/debugger/server-logic/ServerLogicDebugger.ts
+++ b/src/debugger/server-logic/ServerLogicDebugger.ts
@@ -11,8 +11,6 @@ import { oneDSLoggerWrapper } from '../../common/OneDSLoggerTelemetry/oneDSLogge
 import { ServerLogicCodeLensProvider } from './ServerLogicCodeLensProvider';
 import { ServerLogicDebugProvider } from './ServerLogicDebugProvider';
 import { desktopTelemetryEventNames } from '../../common/OneDSLoggerTelemetry/client/desktopExtensionTelemetryEventNames';
-import { ECSFeaturesClient } from '../../common/ecs-features/ecsFeatureClient';
-import { EnableServerLogicDebugging } from '../../common/ecs-features/ecsFeatureGates';
 import {
     SERVER_LOGIC_CONFIG_KEYS,
     SERVER_LOGIC_FILES,
@@ -103,31 +101,11 @@ function ensureGitignore(gitignorePath: string): void {
 }
 
 /**
- * Checks if server logic debugging is enabled via FCB
- * @returns true if the feature is enabled
- */
-export function isServerLogicDebuggingEnabled(): boolean {
-    const { enableServerLogicDebugging } = ECSFeaturesClient.getConfig(EnableServerLogicDebugging);
-    return enableServerLogicDebugging;
-}
-
-/**
  * Activates the Server Logic debugger
  */
 export function activateServerLogicDebugger(context: vscode.ExtensionContext): void {
-    const isEnabled = isServerLogicDebuggingEnabled();
-
     // Set context for menu visibility
-    vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.serverLogicDebuggingEnabled", isEnabled);
-
-    // Check FCB before activating
-    if (!isEnabled) {
-        oneDSLoggerWrapper.getLogger().traceInfo(
-            desktopTelemetryEventNames.SERVER_LOGIC_DEBUG_FEATURE_DISABLED,
-            {}
-        );
-        return;
-    }
+    vscode.commands.executeCommand("setContext", "microsoft.powerplatform.pages.serverLogicDebuggingEnabled", true);
 
     const provider = new ServerLogicDebugProvider();
     context.subscriptions.push(

--- a/src/debugger/server-logic/index.ts
+++ b/src/debugger/server-logic/index.ts
@@ -6,8 +6,7 @@
 export {
     activateServerLogicDebugger,
     createServerLogicDebugConfig,
-    ensureRuntimeLoader,
-    isServerLogicDebuggingEnabled
+    ensureRuntimeLoader
 } from './ServerLogicDebugger';
 export {
     ServerLogicDebugProvider,


### PR DESCRIPTION
This pull request removes the feature flag check for enabling Server Logic Debugging in VS Code Desktop. The Server Logic Debugger is now always enabled, and related code for feature flag configuration and checking has been removed for simplification.

Feature flag removal and always-on enablement:

* Removed the `EnableServerLogicDebugging` feature flag configuration from `ecsFeatureGates.ts`, so the debugger is no longer gated by a feature flag.
* Deleted the `isServerLogicDebuggingEnabled` function and all logic that checked this flag in `ServerLogicDebugger.ts`, making the debugger always enabled.
* Updated the activation logic in `activateServerLogicDebugger` to always set the context as enabled and removed telemetry for the disabled state.

Code cleanup and exports:

* Removed imports and exports related to the deleted feature flag and checking logic in both `ServerLogicDebugger.ts` and `index.ts`. [[1]](diffhunk://#diff-a5eecc3dbb0a4fe01f014783e05a44a107ffca978c6d015e89f505bb84e567a5L14-L15) [[2]](diffhunk://#diff-c17d8aa5f3de098f6fe4759c5affd7de86e697ff5bd1d2c78443985d5997cafbL9-R9)