### PR TITLE
Replace CLAUDE.md with symlink to Agents.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,7 +1,1 @@
-# Claude Code Instructions
-
-This file provides instructions for Claude Code when working in this repository.
-
-## Primary Reference
-
-**IMPORTANT**: Always follow the guidelines in [Agents.md](../Agents.md) as the primary source of instructions.
+../Agents.md


### PR DESCRIPTION
- Convert .claude/CLAUDE.md from regular file to symbolic link
- Point symlink to ../Agents.md for single source of truth
- Reduces duplication and simplifies maintenance