### PR TITLE
Use GitHub App for loc-update workflow auth

### DIFF
--- a/.github/workflows/loc-update.yml
+++ b/.github/workflows/loc-update.yml
@@ -17,12 +17,19 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 2740120
+          private-key: ${{ secrets.POWER_PAGES_PUBLIC_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.LOC_UPDATE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -40,7 +47,7 @@ jobs:
         run: git add -A
       - name: Commit and Push Changes
         env:
-          GITHUB_TOKEN: ${{ secrets.LOC_UPDATE_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
- Replace PAT with GitHub App token generation
- Add create-github-app-token action step
- Update checkout and push steps to use app token