### PR TITLE
Fix TS2345 type error in showWarningMessage stub

### DIFF
--- a/src/client/test/Integration/power-pages/actions-hub/handlers/metadata-diff/CompareWithEnvironmentHandler.test.ts
+++ b/src/client/test/Integration/power-pages/actions-hub/handlers/metadata-diff/CompareWithEnvironmentHandler.test.ts
@@ -885,7 +885,7 @@ describe("CompareWithEnvironmentHandler", () => {
                 ]);
                 sandbox.stub(WorkspaceInfoFinderUtil, "getWebsiteRecordId").returns("test-website-id");
                 sandbox.stub(WorkspaceInfoFinderUtil, "findPowerPagesSiteFolder").returns(null);
-                sandbox.stub(vscode.window, "showWarningMessage").resolves(Constants.Strings.YES);
+                sandbox.stub(vscode.window, "showWarningMessage").resolves(Constants.Strings.YES as unknown as vscode.MessageItem);
 
                 // Stub MetadataDiffUtils functions
                 sandbox.stub(MetadataDiffUtils, "prepareSiteStoragePath").returns("/test/storage/sites-for-comparison");


### PR DESCRIPTION
- Cast Constants.Strings.YES to MessageItem to fix TypeScript error
- showWarningMessage has multiple overloads and TypeScript inferred the MessageItem version when chaining .resolves() with stub()