### PR TITLE
Add kusto-kpi-query skill to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ l10n/package.nls.*.json
 
 # Local Claude settings
 .claude/*.local.*
+.claude/skills/kusto-kpi-query/


### PR DESCRIPTION
Keep the local Claude skill for Kusto KPI queries out of version control.