### PR TITLE
Fix error telemetry: remove double logging and add missing error details

### DIFF
--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -761,7 +761,8 @@ export async function preprocessData(
                     const errorMsg = (error as Error)?.message;
                     WebExtensionContext.telemetry.sendErrorTelemetry(webExtensionTelemetryEventNames.WEB_EXTENSION_PREPROCESS_DATA_WEBFORM_STEPS_FAILED,
                         preprocessData.name,
-                        errorMsg);
+                        errorMsg,
+                        error as Error);
                 }
             });
             WebExtensionContext.telemetry.sendInfoTelemetry(webExtensionTelemetryEventNames.WEB_EXTENSION_PREPROCESS_DATA_SUCCESS, { entityType: entityType });

--- a/src/web/client/services/etagHandlerService.ts
+++ b/src/web/client/services/etagHandlerService.ts
@@ -105,11 +105,6 @@ export class EtagHandlerService {
                     webExtensionTelemetryEventNames.WEB_EXTENSION_ENTITY_CONTENT_SAME
                 );
             } else {
-                WebExtensionContext.telemetry.sendErrorTelemetry(
-                    webExtensionTelemetryEventNames.WEB_EXTENSION_ETAG_HANDLER_SERVICE_API_ERROR,
-                    this.getLatestFileContentAndUpdateMetadata.name,
-                    response.statusText
-                );
                 throw await createHttpResponseError(response);
             }
 
@@ -139,7 +134,8 @@ export class EtagHandlerService {
                 WebExtensionContext.telemetry.sendErrorTelemetry(
                     webExtensionTelemetryEventNames.WEB_EXTENSION_ETAG_HANDLER_SERVICE_ERROR,
                     this.getLatestFileContentAndUpdateMetadata.name,
-                    errorMessage
+                    errorMessage,
+                    error as Error
                 );
             }
         }
@@ -190,11 +186,6 @@ export class EtagHandlerService {
                     result[ODATA_ETAG]
                 );
             } else {
-                WebExtensionContext.telemetry.sendErrorTelemetry(
-                    webExtensionTelemetryEventNames.WEB_EXTENSION_ENTITY_CONTENT_UNEXPECTED_RESPONSE,
-                    this.updateFileEtag.name,
-                    response.statusText
-                );
                 throw await createHttpResponseError(response);
             }
 


### PR DESCRIPTION
## Summary
- Remove redundant `sendErrorTelemetry` calls before `throw` in `etagHandlerService` (`getLatestFileContentAndUpdateMetadata` and `updateFileEtag`) — the catch block already handles HTTP errors via `sendAPIFailureTelemetry` with status code, so these were double-logging every HTTP error
- Add missing `error` object parameter to `sendErrorTelemetry` in `getLatestFileContentAndUpdateMetadata` catch block so `errorMessage`, `errorName`, and `stack` are captured in telemetry properties (was previously only logging `eventName` and `methodName`)
- Add missing `error` object parameter to `sendErrorTelemetry` in `remoteFetchProvider` `preprocessData` for webform steps failures

## Test plan
- [x] Unit tests pass (`npm run test`)
- [x] Web extension compiles clean (`npm run compile-web`)
- [x] Web integration tests pass (`npm run test-web-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)