### PR TITLE
Merge main into release/stable for v2.0.131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - Power Platform Extension
 
-## 2.0.130
+## 2.0.131
 - pac CLI 2.2.1, (see release notes on [nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/))
 
 ## 2.0.128

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -1260,15 +1260,6 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++f9463baef8e56e06230fca093d61bb43810240340033d21ecf4df81e02579913">
       <source xml:lang="en">This will close the active comparison view. Your local files will not be affected.</source>
     </trans-unit>
-    <trans-unit id="++CODE++bcfc420c0358eb6f248fa6328797cfa38fa121baea6320a623280a0d34eeee75">
-      <source xml:lang="en">This file was exported with a newer version of the extension. Please update your extension to import this file.</source>
-    </trans-unit>
-    <trans-unit id="++CODE++e7de2855a45712e1d967171e4d86f37d4014c2f80a515bc552ed4c4a2984c3e4">
-      <source xml:lang="en">This will close all active comparison views. Your local files will not be affected.</source>
-    </trans-unit>
-    <trans-unit id="++CODE++f9463baef8e56e06230fca093d61bb43810240340033d21ecf4df81e02579913">
-      <source xml:lang="en">This will close the active comparison view. Your local files will not be affected.</source>
-    </trans-unit>
     <trans-unit id="++CODE++75670337a398f9840d2951dbc6746497caec6da9dd506ecff57ef79d59c6280f">
       <source xml:lang="en">Thumbs Down</source>
     </trans-unit>


### PR DESCRIPTION
## Summary
- Merge main into release/stable for v2.0.131 release
- Updates CHANGELOG version from 2.0.130 to 2.0.131
- Resolves merge conflicts in CHANGELOG.md and localization xlf file

## Test plan
- [ ] Verify CI passes
- [ ] Verify CHANGELOG.md has version 2.0.131

🤖 Generated with [Claude Code](https://claude.com/claude-code)