### PR TITLE
Fix Dependabot alert 121: update tar to patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17547,9 +17547,10 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1858,7 +1858,8 @@
     "@octokit/plugin-paginate-rest": "^9.2.2",
     "@octokit/request-error": "^5.1.1",
     "qs": "^6.14.2",
-    "tar": "^7.5.7",
+    "tar": "^7.5.8",
     "lodash": "^4.17.23"
   }
 }
+


### PR DESCRIPTION
## Summary
- fix GHSA-83g3-92jg-28cx for tar
- bump tar override to ^7.5.8 and lockfile to tar 7.5.9
- verified with npm ls tar, npm run build, and npm test