### PR TITLE
Fix Dependabot security vulnerability in liquidjs (#134)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "gpt-tokenizer": "^2.1.1",
         "gulp": "^5.0.0",
         "https-browserify": "^1.0.0",
-        "liquidjs": "^10.2.0",
+        "liquidjs": "^10.25.0",
         "n-readlines": "^1.0.1",
         "puppeteer-core": "^22.13.1",
         "recursive-readdir": "^2.2.3",
@@ -10915,9 +10915,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.24.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
-      "integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
+      "version": "10.25.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.0.tgz",
+      "integrity": "sha512-XpO7AiGULTG4xcTlwkcTI5JreFG7b6esLCLp+aUSh7YuQErJZEoUXre9u9rbdb0057pfWG4l0VursvLd5Q/eAw==",
       "dependencies": {
         "commander": "^10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1827,7 +1827,7 @@
     "gpt-tokenizer": "^2.1.1",
     "gulp": "^5.0.0",
     "https-browserify": "^1.0.0",
-    "liquidjs": "^10.2.0",
+    "liquidjs": "^10.25.0",
     "n-readlines": "^1.0.1",
     "puppeteer-core": "^22.13.1",
     "recursive-readdir": "^2.2.3",
@@ -1875,4 +1875,3 @@
     }
   }
 }
-


### PR DESCRIPTION
- Updated liquidjs from 10.24.0 to 10.25.0
- Addresses path traversal fallback vulnerability (high severity)
- Bumped minimum version constraint from ^10.2.0 to ^10.25.0