### PR TITLE
Fix Dependabot security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "gpt-tokenizer": "^2.1.1",
         "gulp": "^5.0.0",
         "https-browserify": "^1.0.0",
-        "liquidjs": "^10.25.0",
+        "liquidjs": "^10.25.5",
         "n-readlines": "^1.0.1",
         "puppeteer-core": "^22.13.1",
         "recursive-readdir": "^2.2.3",
@@ -4601,9 +4601,10 @@
       "dev": true
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
+      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -11100,9 +11101,10 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.25.2",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.2.tgz",
-      "integrity": "sha512-ZbgcjEjGNlAIjqhuMzymO3lCpHgmVMftKfrq4/YLLxmKaFFeQMXRGrJTqKX7OXX1hKVPUDpTIrvL7lxt3X/hmw==",
+      "version": "10.25.5",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.5.tgz",
+      "integrity": "sha512-GKiKeZjJDdVoQAu+S9rzkYsYnYhcep5W3WwZXgb5f+yq484P/k9JqamBbGYu+LBEixcUAXZr2jogdAIjB3ki1w==",
+      "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1832,7 +1832,7 @@
     "gpt-tokenizer": "^2.1.1",
     "gulp": "^5.0.0",
     "https-browserify": "^1.0.0",
-    "liquidjs": "^10.25.0",
+    "liquidjs": "^10.25.5",
     "n-readlines": "^1.0.1",
     "puppeteer-core": "^22.13.1",
     "recursive-readdir": "^2.2.3",


### PR DESCRIPTION
- Update liquidjs 10.25.2 -> 10.25.5 (alerts # 162-# 165)
- Update basic-ftp 5.2.0 -> 5.2.1 (alert # 166)