### PR TITLE
Fix Dependabot security vulnerability in follow-redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7441,15 +7441,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/package.json
+++ b/package.json
@@ -1886,6 +1886,7 @@
     "picomatch@2": "^2.3.2",
     "picomatch@4": "^4.0.4",
     "flatted": "^3.4.2",
-    "defu": "^6.1.5"
+    "defu": "^6.1.5",
+    "follow-redirects": "1.16.0"
   }
 }


### PR DESCRIPTION
- Added follow-redirects 1.16.0 override in package.json
- Addresses alert # 170: follow-redirects leaks custom auth headers to cross-domain redirect targets (medium severity)
- Updated from 1.15.11 to 1.16.0 across axios and http-proxy chains