### PR TITLE
Fix Dependabot security vulnerability in basic-ftp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4610,9 +4610,9 @@
       "dev": true
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1858,7 +1858,7 @@
   },
   "overrides": {
     "axios": "1.15.0",
-    "basic-ftp": "5.2.2",
+    "basic-ftp": "^5.3.0",
     "tmp": "^0.2.4",
     "@octokit/request": "^8.4.1",
     "@octokit/plugin-paginate-rest": "^9.2.2",


### PR DESCRIPTION
- Updated basic-ftp override from 5.2.2 to ^5.3.0
- Addresses GHSA high-severity advisory: DoS via unbounded memory consumption in Client.list()
- Transitive dependency via release-it > proxy-agent > pac-proxy-agent
  > get-uri