### PR TITLE
chore(deps): auto-fix Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -306,16 +306,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@azure/msal-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -668,12 +658,13 @@
       }
     },
     "node_modules/@fluid-internal/client-utils": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.91.0.tgz",
-      "integrity": "sha512-uK+pgdchD6faMuBEsQAiXENZ/PSSb5nREWs11QqhRb+wxLpkEGA3oEWCcaBKg1YdVnvWYX2AyaQXzK4VtMEGEQ==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.93.0.tgz",
+      "integrity": "sha512-MDyY1AvEjikQc6VkIVSabtJ0lbdaRb7JO6IT7lGBRM2NP/G6voBubxFzqtepNedUoGAeX7LA2XsiDKjKLfXQxg==",
+      "license": "MIT",
       "dependencies": {
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
         "@types/events_pkg": "npm:@types/events@^3.0.0",
         "base64-js": "^1.5.1",
         "buffer": "^6.0.3",
@@ -681,53 +672,84 @@
         "sha.js": "^2.4.12"
       }
     },
-    "node_modules/@fluidframework/aqueduct": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.91.0.tgz",
-      "integrity": "sha512-FQU5bRtEDcRDNc7rZEChxarx61sUqaXPBrXstLs9Tu9TIwt49HtmaOZQjgoffHESU7Gn7r6/dMxYta9kN/o74A==",
+    "node_modules/@fluid-internal/presence-definitions": {
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluid-internal/presence-definitions/-/presence-definitions-2.93.0.tgz",
+      "integrity": "sha512-vjXtSAa5esUEPrLUC8eu27rBu0Xzb3iPP3lEv/L814Fk7K9Adxo8YjYi9NlDUx6tRICoSEwHDEmtRUk49F2xhQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/container-runtime": "~2.91.0",
-        "@fluidframework/container-runtime-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/map": "~2.91.0",
-        "@fluidframework/request-handler": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/shared-object-base": "~2.91.0",
-        "@fluidframework/synthesize": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
-        "@fluidframework/tree": "~2.91.0"
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/id-compressor": "~2.93.0"
+      }
+    },
+    "node_modules/@fluid-internal/presence-runtime": {
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluid-internal/presence-runtime/-/presence-runtime-2.93.0.tgz",
+      "integrity": "sha512-+0OxxX5c+oHStOT/hDQk6Hi5kvnVG4TT6502WEq0lrooJmu59K0AvFcHJamPnDJcSi3UMlAYBlz+TgwL+lQdVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluid-internal/presence-definitions": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/container-runtime-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/id-compressor": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0"
+      }
+    },
+    "node_modules/@fluidframework/aqueduct": {
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.93.0.tgz",
+      "integrity": "sha512-ey2fufY4I6gxT+xEGyfCtpnX+8VePgM2QbTCCYumLEl5pO0DqQ9tHDcTkMWsETG8Pj+MJrMNiax+lFw4+IUbMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/container-runtime": "~2.93.0",
+        "@fluidframework/container-runtime-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/map": "~2.93.0",
+        "@fluidframework/request-handler": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/shared-object-base": "~2.93.0",
+        "@fluidframework/synthesize": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
+        "@fluidframework/tree": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/azure-client": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.91.0.tgz",
-      "integrity": "sha512-FwQOO5vgpSS1OcRKxY/t3o1izq2y9zzNhrNezUutqMnvx+SzkCHTtITdfpepF5UPBmrutX7bzAyr0j1cGnTglg==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.93.0.tgz",
+      "integrity": "sha512-T9IlOQ8gqkkiw46ViYugNBp2sazTQec2A3Ym+i3MsuL1tdjVI2g+vKmJiGXTP00S9LVD7hRqmjq7QsM52wVuAQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/container-loader": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/driver-utils": "~2.91.0",
-        "@fluidframework/fluid-static": "~2.91.0",
-        "@fluidframework/routerlicious-driver": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0"
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/container-loader": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/driver-utils": "~2.93.0",
+        "@fluidframework/fluid-static": "~2.93.0",
+        "@fluidframework/routerlicious-driver": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/common-definitions": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-1.1.0.tgz",
-      "integrity": "sha512-WQYtG9tkx2j7i1JSXPvwLnQsqCOZAghMj0aGciqjZVNppUly/XBpAjb4V6FEUCEjxCScPKhyE+1rhV1ep52NgA=="
+      "integrity": "sha512-WQYtG9tkx2j7i1JSXPvwLnQsqCOZAghMj0aGciqjZVNppUly/XBpAjb4V6FEUCEjxCScPKhyE+1rhV1ep52NgA==",
+      "license": "MIT"
     },
     "node_modules/@fluidframework/common-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-3.1.0.tgz",
       "integrity": "sha512-KpBQqpZKAHCKFMoxtAdrgqL1nIJhT7r2IRGmS3Rm5CMTLsegQ8ifX5lFvd6IbjeWmvLz1qLsY3eS5HBYqy9CVQ==",
+      "license": "MIT",
       "dependencies": {
         "@fluidframework/common-definitions": "^1.1.0",
         "@types/events": "^3.0.0",
@@ -739,63 +761,52 @@
       }
     },
     "node_modules/@fluidframework/container-definitions": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.91.0.tgz",
-      "integrity": "sha512-PSlKySbwCBlHe9dne0wUOQvbNJIfLVaRImPzRNKOkyYIYDH1OgOddHjvdf4eWJ7XiG7iK8eNwqrraYiAsUSlZQ==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.93.0.tgz",
+      "integrity": "sha512-IONxKLpMeffu4ffuQxmPfOSvQssGc60q/RcGET+I3BUqWjugfT2cgwkmLPWAlOF4XPhBzicxbEzrSbb98drk5Q==",
+      "license": "MIT",
       "dependencies": {
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0"
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/container-loader": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.91.0.tgz",
-      "integrity": "sha512-usBsVTMed4dx+nhWrlCzx0P+5Mj47nZTCx06hOV8HQMl42wNIda5HTs6dEGnOx/0Scj8Zsp+y+5/vGOyd/6BGw==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.93.0.tgz",
+      "integrity": "sha512-VNgukB7m6Ex95PUfbAZ+q9DGsk0c/EvMXrWXWl08s9B3ufD/BuTjVk/KFFATpxqZI0a6nWIxrsUOOhVj0WtBsQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/driver-utils": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
-        "@types/events_pkg": "npm:@types/events@^3.0.0",
-        "@ungap/structured-clone": "^1.2.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/driver-utils": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "debug": "^4.3.4",
         "double-ended-queue": "^2.1.0-0",
         "events_pkg": "npm:events@^3.1.0",
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@fluidframework/container-loader/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@fluidframework/container-runtime": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.91.0.tgz",
-      "integrity": "sha512-JS/F1OJf1+ud5B5flZk5RCIuUH5B/NIRc0OLJUhtmrej+x8COgxneqntNZIOXPlIn7P3N2I90kXPTGMEf1PbVg==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.93.0.tgz",
+      "integrity": "sha512-W8397HxbdiAAJf42cUt2X0i2j89C+vfHtYzgjpUYXgghGvJtVsNz6iNpER5ZewZccWbznpW460Cl9ekmF0M1jg==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/container-runtime-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/driver-utils": "~2.91.0",
-        "@fluidframework/id-compressor": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/container-runtime-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/driver-utils": "~2.93.0",
+        "@fluidframework/id-compressor": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "@tylerbu/sorted-btree-es6": "^2.1.1",
         "double-ended-queue": "^2.1.0-0",
         "lz4js": "^0.2.0",
@@ -804,224 +815,192 @@
       }
     },
     "node_modules/@fluidframework/container-runtime-definitions": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.91.0.tgz",
-      "integrity": "sha512-80Qr6KLZinJHiiuNfQBeVKOYLhC/aqvq6ELf4cFx5ZI20ER/oACk/GWKIP1v3DUNB90EHJhEBPEDjxRQHV6Ipw==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.93.0.tgz",
+      "integrity": "sha512-4siG1WOE+fDz0Z3K+3IApJbHmt49KPHdefmcQOl6JQeDAbRVoDWvmuiST8Fd3CRdlFZiXiIM98Usr437PPtbKg==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0"
-      }
-    },
-    "node_modules/@fluidframework/container-runtime/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/core-interfaces": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.91.0.tgz",
-      "integrity": "sha512-6xwz+lMhSi48iwgGbLUt0wWzxeTxi3m6gYswQPy0I3j4+3mMOqlslq9E4W407yJBBU9uW3+dyOxY1gXtDKNVVQ=="
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.93.0.tgz",
+      "integrity": "sha512-SQBfM1NPG4AH65rq2NwQS7aPs/JWLAFH40BNp22aFdJZu7Ww5vO+8SnNdPw+8N9Vb7MSvwrWOSSDLhOF1F9gkQ==",
+      "license": "MIT"
     },
     "node_modules/@fluidframework/core-utils": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.91.0.tgz",
-      "integrity": "sha512-7KKCKZVWBoeTWd45ub15DpfwdNXYmjB8WPGkp/0XNnerff2VhqNAX9hPgyHJ2LtfQBvLvl80KLsM3HFQoajszw=="
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.93.0.tgz",
+      "integrity": "sha512-Lf17CciaqTE3ePRoWsNUn8c3sRdncO5nqd8FSwKIs2TyS1jMUVPFE7NWz42JTeW1hJkxFopNElOn34SHGCTmoA==",
+      "license": "MIT"
     },
     "node_modules/@fluidframework/datastore": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.91.0.tgz",
-      "integrity": "sha512-n6wWmSOihAjUQ41o5YTX/6hbxz4BDWQSlNE8JQ5KbzMXSdNONR1c3qgMDTMVnipyMpL0meQ+r9g1XqSIVC+xPg==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.93.0.tgz",
+      "integrity": "sha512-MeKpQgh1Epbzp0K8DYzSSPFcPuP7m3J1AZsCJT+IEer61j01MXuslps6NJg07At5oPKTgbZPukffyp5QQEA3vA==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/driver-utils": "~2.91.0",
-        "@fluidframework/id-compressor": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/driver-utils": "~2.93.0",
+        "@fluidframework/id-compressor": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "uuid": "^11.1.0"
       }
     },
     "node_modules/@fluidframework/datastore-definitions": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.91.0.tgz",
-      "integrity": "sha512-rvgzDBBgmXfNxOZuzpQhWQW4wt4H7QnWf7OvpVjLAxTVE5xiwHJSkC9BT+Lk8TcKAO4dBflaU5MuXrcTAKSs6w==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.93.0.tgz",
+      "integrity": "sha512-cwsOYccBsZTurYrELQKXqKVdiSmbc9CdPsta5Ywd8WwEwJSlAYCdDxnr15XlgySsbf1CYyeGc2dYiktONO5aNA==",
+      "license": "MIT",
       "dependencies": {
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/id-compressor": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0"
-      }
-    },
-    "node_modules/@fluidframework/datastore/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/id-compressor": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/driver-base": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.91.0.tgz",
-      "integrity": "sha512-ykfRBuhOJjYGG82oEAFke/X2q7jNenEpVOFOi+4F6jAEyHWFOg5jGAZ+BUw/Vg1hH253l5tnQ/TZR1WzmAf3+Q==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.93.0.tgz",
+      "integrity": "sha512-k9K8hXBKrMWXEwpKJczoir4ZWX708vSqzsSA1xO7OmhCD8eG4pithlhgc3s/kkyrfSd/FrdgcxFI83Rrr4+HqA==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/driver-utils": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0"
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/driver-utils": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/driver-definitions": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.91.0.tgz",
-      "integrity": "sha512-fA22NT4nffz1HVt9nz0qogFReU2Q3Xq6tA8OHbQuzGOQa9KFO7D2cc6Ew1iR97hz8zaQ9PlxHB1PZZd3rjH/Dg==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.93.0.tgz",
+      "integrity": "sha512-z/60uov84QRpFSF7itMDCPAdRAvlRSMGzXUK44+sUnJmYIYvTpcZZpdwSwoJK/YzgdmHfsIpGDSS4JVqLY8DUw==",
+      "license": "MIT",
       "dependencies": {
-        "@fluidframework/core-interfaces": "~2.91.0"
+        "@fluidframework/core-interfaces": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/driver-utils": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.91.0.tgz",
-      "integrity": "sha512-i4StJPxwmB6p7k2TuzC0WOBv1JVuEXzNvGaqGsk6IlbV6mg2DGYqq1ZO+/uiXviMxFmHDG5Db3aiAL4qbsweMQ==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.93.0.tgz",
+      "integrity": "sha512-+UlnmgSt7lybc8Z+kVICF12LAAisgyDjxmCB1BEooClT+B/EFSSjqN6MZlFrgQjzz03Go6uEMg1mO6PQL1ajyQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "lz4js": "^0.2.0",
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@fluidframework/driver-utils/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@fluidframework/fluid-static": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.91.0.tgz",
-      "integrity": "sha512-xpTCRtMUpvTqNh8dmMJEyQEMTlMXk3arrc02UFt3eDRgUwtscf2fdCubEhWO+YZd4JlXA1MTARj3Lb4rs1o47A==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.93.0.tgz",
+      "integrity": "sha512-lj2qSaCU8GYFOSYs8RtRqCGYgrwnZsH5MqGiA7sbY1junNqfLOIyFgYmtLkFQVWwnnKUq1pn3yRVfMsEBYBzoA==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/aqueduct": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/container-loader": "~2.91.0",
-        "@fluidframework/container-runtime": "~2.91.0",
-        "@fluidframework/container-runtime-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/request-handler": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/shared-object-base": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
-        "@fluidframework/tree": "~2.91.0"
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluid-internal/presence-definitions": "~2.93.0",
+        "@fluid-internal/presence-runtime": "~2.93.0",
+        "@fluidframework/aqueduct": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/container-loader": "~2.93.0",
+        "@fluidframework/container-runtime": "~2.93.0",
+        "@fluidframework/container-runtime-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/request-handler": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/shared-object-base": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
+        "@fluidframework/tree": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/gitresources": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-7.0.0.tgz",
-      "integrity": "sha512-APAxqCF/+2ljC8th0PoXzdUAo2EJapdTk9KNm6dp7dFD5hxYWoscFqdyu5K+bvMxmhrIpGd0f//nbb7rZq7bog=="
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-7.0.1.tgz",
+      "integrity": "sha512-sFEdPL46Hz/xuP51nwT19JubSeb3fBBrNQXwnRLCcmaX+fXdxg7rkyVLTgue0swgdJ73Oh98eTYpxplkq+FSJA==",
+      "license": "MIT"
     },
     "node_modules/@fluidframework/id-compressor": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.91.0.tgz",
-      "integrity": "sha512-98ercIoe6Dyzm+DivwKCLGQuA0Tal01cljDHBqMwr3MMop2Um9bG2uKC26QUovtmsCh4harcdQPSQD1pprgrbg==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.93.0.tgz",
+      "integrity": "sha512-o5QxIPxIsSgf+g+4TF5FZUsT4oOBVrrAw368o5gb9Z9bKgj97ZYN2cOMMFR/6assm9/bBSdMN/X/XWQ2E/T85w==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "@tylerbu/sorted-btree-es6": "^2.1.1",
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@fluidframework/id-compressor/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@fluidframework/map": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.91.0.tgz",
-      "integrity": "sha512-4xQuts7KPdfqEnDKBqEHLsur+tF+bMCzhyW1jgwSOSmk98gyGTg8EROQZvD1mXJ563eLlVBqpDT4QRKiDddsZw==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.93.0.tgz",
+      "integrity": "sha512-lJsXQfsVFNVSrzxZxI29P1w9ynk6ibQSzP5Lbmd68PMREgHSojmHPacaWOrS1aj5UHSEPoOiUJvNCPqR3YqtTw==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/driver-utils": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/shared-object-base": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/driver-utils": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/shared-object-base": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "path-browserify": "^1.0.1"
       }
     },
     "node_modules/@fluidframework/merge-tree": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.91.0.tgz",
-      "integrity": "sha512-GjQzHNdIUGukEMgHQm2nyW2dfyW0IrYYKP62fHPyM1I2y1QTKpFwO+BY8fnDoU0J1AlJz3Aa+93ErxTF3Bhz7w==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.93.0.tgz",
+      "integrity": "sha512-4St+flclqexpKU3dIA0cxfHu+ZL7S9nNEl8MK64YcOHzBbufMcF9gzloQAoM+HYtnf5GSi0X9LIcvUOTKYiFJQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/shared-object-base": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0"
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/shared-object-base": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/protocol-base": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-7.0.0.tgz",
-      "integrity": "sha512-LUSTKQBJVnemMLMQUuoszHvl46XBfflI8U9R8kW+12T2W/Vvt+ldML7203MvNg4E/sFScGfqqZS5OzYn0z1TIw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-7.0.1.tgz",
+      "integrity": "sha512-WfMf+vN0OmUHl0xJIsY6jnnsF5p27apMRd38pC9TlMx1URt+3C2fV4WLEybn2wYEGepYcK03ZMqe6I+DXt7/6g==",
+      "license": "MIT",
       "dependencies": {
         "@fluidframework/common-utils": "^3.1.0",
-        "@fluidframework/gitresources": "7.0.0",
+        "@fluidframework/gitresources": "7.0.1",
         "@fluidframework/protocol-definitions": "^3.2.0",
         "events_pkg": "npm:events@^3.1.0"
       }
@@ -1029,108 +1008,102 @@
     "node_modules/@fluidframework/protocol-definitions": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-3.2.0.tgz",
-      "integrity": "sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA=="
+      "integrity": "sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==",
+      "license": "MIT"
     },
     "node_modules/@fluidframework/request-handler": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.91.0.tgz",
-      "integrity": "sha512-oCXivpYpXra1KNqNScmv6EcxgNuYf5m8Fpps0/upzrLt6R5HQH2CCgXS8rTnATV6N3qLEuZjdAcSD/bhWvbjSw==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.93.0.tgz",
+      "integrity": "sha512-vB9Ez4Ea0vhkuE+Pk76QZZ1Wrk+MgEG4rb3tshp4SQwsVrt7wt5GE9GcJAFiTo2TQ+XRJ3/Bqp4N3BZQLeqR3g==",
+      "license": "MIT",
       "dependencies": {
-        "@fluidframework/container-runtime-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0"
+        "@fluidframework/container-runtime-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/routerlicious-driver": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.91.0.tgz",
-      "integrity": "sha512-axlC95W4yHEfQ7cGzRNHjmFfbjkd67HbOUUxcCgVz/JKtCe11ffRj4xNKjcLJMRe6z80t1I4S9o7VJqGIogn5Q==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.93.0.tgz",
+      "integrity": "sha512-vgYV7rd+TN346h8lgMvogTN7cSZgTNjvLF/O8KSHN1vpz6mCzWxC08vhkLsjZ5iNXTSSjxVzZWJQr4Y3AWql5w==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/driver-base": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/driver-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/driver-base": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/driver-utils": "~2.93.0",
         "@fluidframework/server-services-client": "^7.0.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
-        "cross-fetch": "^3.1.5",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "json-stringify-safe": "5.0.1",
-        "socket.io-client": "~4.7.5"
+        "socket.io-client": "^4.8.3"
       }
     },
     "node_modules/@fluidframework/runtime-definitions": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.91.0.tgz",
-      "integrity": "sha512-j+xle17EmP9McjGY8I9tOGF1098poBZIHdsClnvLw+/wmSpvUXgf8dS0WZwbK0TGeAo6yH9bqFhfkSWcPDU+NQ==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.93.0.tgz",
+      "integrity": "sha512-rVCksJGTvZiyVh13gajo/YL7TbCEqHJEcYTt9tdxvr/zY5oHOhP6QdLVBjB6aF7X7P1yh26tkJeY2pfVJeJ9aQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/id-compressor": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0"
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/id-compressor": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/runtime-utils": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.91.0.tgz",
-      "integrity": "sha512-I6CY6zZWWTbPYrEWZ8MrM68GfI2Ys6/LKgEcCOCcUI/IlFoObpsq+vU2/2C63FR0DDAp3JlwR4XLrGnX8WDp6A==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.93.0.tgz",
+      "integrity": "sha512-CCKrM2zSJX7ub3Qjn3XM4kQmDfYia9ozPJPCWBqrpavZWW6TafzKbFHbjswfu88th2cRLK0Tl6vYv0xyLdKArg==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/container-runtime-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/driver-utils": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/container-runtime-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/driver-utils": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "semver-ts": "^1.0.3"
       }
     },
     "node_modules/@fluidframework/sequence": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.91.0.tgz",
-      "integrity": "sha512-i94M2qbDJaIedC7u9QfkhUdfJLzax+OKeQrDUET3YYl4KsO5kWXmg5vOdV425pb8ZkSdl3VehdGPDGtkt7pkYA==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.93.0.tgz",
+      "integrity": "sha512-DYxR8BauxdHU5HThL4rj4sCzLDMUSFPNAapYnbj7FIEOPfONTV8Do65sHDF2VsEu42aSW2r4lCQXLqdB3nAN6A==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/merge-tree": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/shared-object-base": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/merge-tree": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/shared-object-base": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "double-ended-queue": "^2.1.0-0",
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@fluidframework/sequence/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@fluidframework/server-services-client": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-7.0.0.tgz",
-      "integrity": "sha512-gzEvH6wNpRuMsyZhY22JrOHbTFsPGSzjLIlAWmnT7UT0znYGCDaMC39WPbOLLm7O8JSvmUblGe2Vx8N1+gCOgQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-7.0.1.tgz",
+      "integrity": "sha512-39T7SZba2JdrkkOYqcGr8ZEg+SqPtxVTsHM02CI1yrvZPL78jog0iGcNRe8BrPyTCH0Xw9QOqpJND4/QbV/l4Q==",
+      "license": "MIT",
       "dependencies": {
         "@fluidframework/common-utils": "^3.1.0",
-        "@fluidframework/gitresources": "7.0.0",
-        "@fluidframework/protocol-base": "7.0.0",
+        "@fluidframework/gitresources": "7.0.1",
+        "@fluidframework/protocol-base": "7.0.1",
         "@fluidframework/protocol-definitions": "^3.2.0",
         "axios": "^1.8.4",
         "crc-32": "1.2.0",
@@ -1146,120 +1119,85 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
       "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@fluidframework/server-services-client/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@fluidframework/shared-object-base": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.91.0.tgz",
-      "integrity": "sha512-9JyWC0BMb333kY4YWQf8YNK1hBEDy2yZvSNqFh8mzkS9Zn7eSFSz+oOSAWdEXTlgjXUidiY1BqH6kk2YQP8zog==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.93.0.tgz",
+      "integrity": "sha512-QgfLI9mkJ5gGlMzbvn1FGTsMImBKpkmS4+IMx6b60dBaCAZu2fVTrC4eKR4PD4xP6eVlipg/1cW67CJPomq2AQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/id-compressor": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/id-compressor": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@fluidframework/shared-object-base/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@fluidframework/synthesize": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.91.0.tgz",
-      "integrity": "sha512-ZiRpnSPDjZ+gQD94Mwbb5NA9EjvffTvcT/DiUyIKR7gA9ymYmSY9BEEsaGM3cJcfXNS4X/RzPKOD1A50O1K6kA==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.93.0.tgz",
+      "integrity": "sha512-2GApeGBuhwLqXS9/BDgezPqe5SVvrhNxauRMi2ziIaVh2jyNvwX2jE2FkfFyZzJFjQU01KWsZPXwC0h1sqYXDQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluidframework/core-utils": "~2.91.0"
+        "@fluidframework/core-utils": "~2.93.0"
       }
     },
     "node_modules/@fluidframework/telemetry-utils": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.91.0.tgz",
-      "integrity": "sha512-BcbD9bpdIFjpGjn7k4G7PY3ILr57H/T6u/ucFDy0jCX51JOVxSH1sHZ8KI4FFAecfKUhkhLj1nNm4Kzgoucu+A==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.93.0.tgz",
+      "integrity": "sha512-I0UDO8QgD6B81kCf3DCI/qfhqXBcY3brVnYbpSITehatykMskIKbL6rKDccB3Fwjq3xpA6gtdJlE6/Z1Y4wdwQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
         "debug": "^4.3.4",
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@fluidframework/telemetry-utils/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@fluidframework/tree": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.91.0.tgz",
-      "integrity": "sha512-z7yaos09EJ7koUXhsDVGTMfLdrXlNhvQhHnm0S+QsEdTdUnC+QKaEMLUIjPneDYTfoHqcUNwwraOnXkKDnaQwA==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.93.0.tgz",
+      "integrity": "sha512-X/k0nuD0Qg8MkYjRvwlx11UJ3bdUTwlJmg2ELOeaVoek50PuHFQeZv5T3tqVwsTl4EOkr9WZ2wKVo6ecTcxeKA==",
+      "license": "MIT",
       "dependencies": {
-        "@fluid-internal/client-utils": "~2.91.0",
-        "@fluidframework/container-runtime": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/datastore-definitions": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/id-compressor": "~2.91.0",
-        "@fluidframework/runtime-definitions": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/shared-object-base": "~2.91.0",
-        "@fluidframework/telemetry-utils": "~2.91.0",
+        "@fluid-internal/client-utils": "~2.93.0",
+        "@fluidframework/container-runtime": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/datastore-definitions": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/id-compressor": "~2.93.0",
+        "@fluidframework/runtime-definitions": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/shared-object-base": "~2.93.0",
+        "@fluidframework/telemetry-utils": "~2.93.0",
+        "@fluidframework/type-factory": "~2.93.0",
         "@sinclair/typebox": "^0.34.13",
         "@tylerbu/sorted-btree-es6": "^2.1.1",
-        "@types/ungap__structured-clone": "^1.2.0",
-        "@ungap/structured-clone": "^1.2.0",
         "semver-ts": "^1.0.3",
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@fluidframework/tree/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
+    "node_modules/@fluidframework/type-factory": {
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/type-factory/-/type-factory-2.93.0.tgz",
+      "integrity": "sha512-Er0jL6zkXqSsio1qgpFEU2A/7TyLfnIKtfSI1Volq9zVblgA7paq4essF4R05ZMmuJTvKnODRlOy3b3acQiL2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluidframework/telemetry-utils": "~2.93.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -1806,18 +1744,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@microsoft/generator-powerpages/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nevware21/ts-async": {
@@ -2611,9 +2537,10 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.48",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "2.0.0",
@@ -2681,7 +2608,8 @@
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "3.0.1",
@@ -2743,7 +2671,8 @@
     "node_modules/@tylerbu/sorted-btree-es6": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@tylerbu/sorted-btree-es6/-/sorted-btree-es6-2.1.1.tgz",
-      "integrity": "sha512-M0EHlEW9Aaz0P8NT/pC1E6wAfuWY7TpvF4U1Ha3wE87KEhiiahnFbHbzmwGsLxm7ma70A/L94cu5pqvickF2nw=="
+      "integrity": "sha512-M0EHlEW9Aaz0P8NT/pC1E6wAfuWY7TpvF4U1Ha3wE87KEhiiahnFbHbzmwGsLxm7ma70A/L94cu5pqvickF2nw==",
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "4.3.20",
@@ -2792,13 +2721,15 @@
     "node_modules/@types/events": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
-      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+      "license": "MIT"
     },
     "node_modules/@types/events_pkg": {
       "name": "@types/events",
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
-      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+      "license": "MIT"
     },
     "node_modules/@types/expect": {
       "version": "1.20.4",
@@ -2935,11 +2866,6 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
       "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
       "dev": true
-    },
-    "node_modules/@types/ungap__structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz",
-      "integrity": "sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA=="
     },
     "node_modules/@types/unzip-stream": {
       "version": "0.3.4",
@@ -3211,7 +3137,8 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true
     },
     "node_modules/@vscode/extension-telemetry": {
       "version": "0.6.2",
@@ -3603,10 +3530,11 @@
       "dev": true
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5654,6 +5582,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
       "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "exit-on-epipe": "~1.0.1",
         "printj": "~1.1.0"
@@ -5670,14 +5599,6 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6187,7 +6108,8 @@
     "node_modules/double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ=="
+      "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6338,37 +6260,23 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
-      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1",
+        "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1",
-        "xmlhttprequest-ssl": "~2.0.0"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
       }
     },
     "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6389,6 +6297,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
       "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -6929,6 +6838,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
@@ -6968,6 +6878,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
       "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
       }
@@ -7423,21 +7334,22 @@
       "dev": true
     },
     "node_modules/fluid-framework": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.91.0.tgz",
-      "integrity": "sha512-cntC4aycI7pWFlChEbHHeZ6DiS40JWZcsTGnOJp6HJp8hJpK3TDTgVlJoCAQTFH5+a5K8A0aXN0zKcMeMMWJyw==",
+      "version": "2.93.0",
+      "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.93.0.tgz",
+      "integrity": "sha512-wYwgU2l49smG30NOrCy1UblHzcO01IW1z/P2riS+9ZgbKwhKn1a0unLTQma2QMXXhAUlQOZod+byzcu6uD9U/A==",
+      "license": "MIT",
       "dependencies": {
-        "@fluidframework/container-definitions": "~2.91.0",
-        "@fluidframework/container-loader": "~2.91.0",
-        "@fluidframework/core-interfaces": "~2.91.0",
-        "@fluidframework/core-utils": "~2.91.0",
-        "@fluidframework/driver-definitions": "~2.91.0",
-        "@fluidframework/fluid-static": "~2.91.0",
-        "@fluidframework/map": "~2.91.0",
-        "@fluidframework/runtime-utils": "~2.91.0",
-        "@fluidframework/sequence": "~2.91.0",
-        "@fluidframework/shared-object-base": "~2.91.0",
-        "@fluidframework/tree": "~2.91.0"
+        "@fluidframework/container-definitions": "~2.93.0",
+        "@fluidframework/container-loader": "~2.93.0",
+        "@fluidframework/core-interfaces": "~2.93.0",
+        "@fluidframework/core-utils": "~2.93.0",
+        "@fluidframework/driver-definitions": "~2.93.0",
+        "@fluidframework/fluid-static": "~2.93.0",
+        "@fluidframework/map": "~2.93.0",
+        "@fluidframework/runtime-utils": "~2.93.0",
+        "@fluidframework/sequence": "~2.93.0",
+        "@fluidframework/shared-object-base": "~2.93.0",
+        "@fluidframework/tree": "~2.93.0"
       }
     },
     "node_modules/flush-write-stream": {
@@ -10496,16 +10408,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -10727,7 +10629,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -10788,12 +10691,10 @@
       }
     },
     "node_modules/jsrsasign": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.1.tgz",
-      "integrity": "sha512-6w95OOXH8DNeGxakqLndBEqqwQ6A70zGaky1oxfg8WVLWOnghTfJsc5Tknx+Z88MHSb1bGLcqQHImOF8Lk22XA==",
-      "funding": {
-        "url": "https://github.com/kjur/jsrsasign#donations"
-      }
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.3.tgz",
+      "integrity": "sha512-nPnK5D/4lv0Dwr7TlzrKtAd8JlLZwFTqTUUB3NQCbtdobcRcohGFxjbPySDVh74iWUudcCsapYT6OxoyhJLhhA==",
+      "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -11427,7 +11328,8 @@
     "node_modules/lz4js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz",
-      "integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg=="
+      "integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==",
+      "license": "ISC"
     },
     "node_modules/macos-release": {
       "version": "3.4.0",
@@ -12582,6 +12484,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13967,10 +13870,11 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -14335,6 +14239,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
       "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "license": "Apache-2.0",
       "bin": {
         "printj": "bin/printj.njs"
       },
@@ -16251,6 +16156,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/semver-ts/-/semver-ts-1.0.3.tgz",
       "integrity": "sha512-RMf2+Nbd0Hiq5u8LADzqnSRb09Vu1UKOLFw9P9nm8XY3JPeFjv3DLVYBZjPWFHUxBVz7ktIVGR3xFjYilHlXng==",
+      "license": "ISC",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16301,6 +16207,7 @@
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
       "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1",
@@ -16597,7 +16504,8 @@
     "node_modules/sillyname": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
-      "integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
+      "integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g==",
+      "license": "MIT"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -16727,39 +16635,25 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
-      "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.2",
-        "engine.io-client": "~6.5.2",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
         "socket.io-parser": "~4.2.4"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
-    "node_modules/socket.io-client/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
       "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1"
@@ -17592,6 +17486,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
       "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
       "dependencies": {
         "isarray": "^2.0.5",
         "safe-buffer": "^5.2.1",
@@ -17604,7 +17499,8 @@
     "node_modules/to-buffer/node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -17640,7 +17536,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/traverse": {
       "version": "0.3.9",
@@ -18046,6 +17943,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -18637,7 +18535,8 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/webpack": {
       "version": "5.105.4",
@@ -18877,6 +18776,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -19177,9 +19077,9 @@
       }
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "engines": {
         "node": ">=0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -1887,6 +1887,7 @@
     "picomatch@4": "^4.0.4",
     "flatted": "^3.4.2",
     "defu": "^6.1.5",
-    "follow-redirects": "1.16.0"
+    "follow-redirects": "1.16.0",
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
Re-opened from #1559 under a human author so the Microsoft CLA bot will evaluate.

---

## Summary

Fixes all 33+ open Dependabot security alerts (32 moderate, 1 high) in a single consolidated PR.

## Alerts Addressed

### 1. brace-expansion (GHSA-f886-m6hf-6m8v) — Moderate
- **Old version:** 1.1.12  **→  New version:** 1.1.14
- **Path:** `@vscode/vsce > minimatch@3.1.5 > brace-expansion`
- **Issue:** Zero-step sequence causes process hang and memory exhaustion
- **Fix:** Updated via `npm audit fix`

### 2. path-to-regexp (GHSA-j3q9-mxjg-w52f, GHSA-27v5-c462-wpq7) — High
- **Old version:** 8.3.0  **→  New version:** 8.4.2
- **Path:** `@vscode/test-web > @koa/router > path-to-regexp`
- **Issue:** DoS via sequential optional groups and multiple wildcards
- **Fix:** Updated via `npm audit fix`

### 3. uuid (GHSA-w5hq-g745-h8pq) — Moderate
- **Old versions:** 8.3.2, 9.0.1, 11.1.0  **→  New version:** 14.0.0
- **Affected packages:** `@azure/msal-node`, all `@fluidframework/*` packages, `@microsoft/generator-powerpages`, `istanbul-lib-processinfo` (via `nyc`)
- **Issue:** Missing buffer bounds check in v3/v5/v6 when buf is provided
- **Fix:** Added `"uuid": "^14.0.0"` to `overrides` in `package.json` to force all transitive instances to the patched version

### Additional updates (via npm audit fix)
- `@fluidframework/azure-client` and `fluid-framework`: 2.91.0 → 2.93.0 (resolves uuid@11 transitives)
- Various other `@fluidframework/*` packages: 2.91.0 → 2.93.0
- `@fluidframework/server-services-client`: 7.0.0 → 7.0.1

## Verification
- ✅ `npm audit` reports **0 vulnerabilities** after fixes
- ✅ `npm run build` passes (pre-existing telemetry-generated module warning is unrelated)
- ✅ `npm test` passes — all 95 unit tests pass