### PR TITLE
Tighten Dependabot auto-fix prompt: truthful counts, minimal diffs

### DIFF
--- a/.github/workflows/dependabot-autofix.yml
+++ b/.github/workflows/dependabot-autofix.yml
@@ -109,7 +109,7 @@ jobs:
 
           PROMPT=$(cat <<PROMPT_EOF
           You are running inside a GitHub Actions job. Follow the skill
-          below to fix ALL currently open Dependabot alerts for the
+          below to fix all currently open Dependabot alerts for the
           repository \`${REPO}\` in a SINGLE consolidated pull request.
 
           Environment already set up for you:
@@ -124,28 +124,95 @@ jobs:
               \`gh pr create\`.
 
           Mandatory rules:
-            1. Use \`gh api repos/${REPO}/dependabot/alerts --paginate --jq '.[] | select(.state=="open")'\`
-               to enumerate open alerts. Authenticate that call with
-               \`GH_TOKEN=\$COPILOT_GITHUB_TOKEN gh api ...\` since the App token
-               typically cannot read Dependabot alerts.
-            2. If there are ZERO open alerts, do not commit, do not push,
-               do not open a PR. Print "NO_OPEN_ALERTS" and exit.
-            3. Apply fixes for ALL open alerts on branch \`${BRANCH}\`
-               following Steps 1-6 of the skill. Produce one logical commit
-               (or several, your choice) on that branch only.
-            4. Run \`npm run build\` AND \`npm test\`. If either fails after
-               your fixes, DO NOT push and DO NOT open a PR. Print
+
+            1. ALERT ENUMERATION — source of truth.
+               Run exactly:
+                 GH_TOKEN=\$COPILOT_GITHUB_TOKEN gh api \\\\
+                   "repos/${REPO}/dependabot/alerts?state=open&per_page=100" \\\\
+                   --paginate \\\\
+                   --jq '.[] | {number, ghsa: .security_advisory.ghsa_id, pkg: .dependency.package.name, ecosystem: .dependency.package.ecosystem, severity: .security_vulnerability.severity, scope: .dependency.scope, manifest: .dependency.manifest_path, summary: .security_advisory.summary, vulnerable: .security_vulnerability.vulnerable_version_range, patched: .security_vulnerability.first_patched_version.identifier}'
+               Save the raw output to \`alerts.json\`. The PR description
+               and the count of "alerts fixed" MUST be built one-to-one
+               from this list. Do NOT count transitive-path occurrences
+               of the same alert number as separate alerts. Do NOT
+               inflate counts based on how many \`node_modules/**\`
+               entries appear in \`package-lock.json\`.
+
+            2. ZERO ALERTS — exit cleanly.
+               If step 1 returns an empty list, do not commit, do not
+               push, do not open a PR. Print "NO_OPEN_ALERTS" and exit.
+
+            3. MINIMUM VIABLE FIX — prefer the smallest blast radius.
+               For each alert, pick the least-invasive strategy in this
+               strict preference order and record your choice in the PR
+               body:
+                 a. Transitive dependency → add/extend an entry in the
+                    \`overrides\` block of \`package.json\` pinning the
+                    vulnerable package to the first patched version.
+                    This is the preferred fix.
+                 b. Direct dependency → bump that specific dependency in
+                    \`package.json\` to the first patched version.
+                 c. Only if (a) and (b) are infeasible (e.g. override
+                    breaks peer-dep resolution, or a parent package
+                    pins the vulnerable version), escalate to bumping a
+                    parent package. In that case, justify the escalation
+                    in the PR body and keep the parent bump as narrow
+                    as possible (patch > minor > major).
+               Never run \`npm audit fix\` or \`npm audit fix --force\` as
+               a shortcut — they produce sprawling diffs with unrelated
+               upgrades. Use \`npm install\` / \`npm update\` targeted at
+               the specific package(s) you are fixing.
+
+            4. DIFF DISCIPLINE.
+               After the lockfile is regenerated, run:
+                 git diff --stat origin/main
+               If any of the following are true, STOP, revert with
+               \`git checkout -- package.json package-lock.json\`, and
+               try a narrower strategy from rule 3:
+                 - package.json changed a dependency that is NOT on the
+                   alert list (except for adding entries to \`overrides\`).
+                 - Any dependency bumped a MAJOR version that is not
+                   strictly required to reach the first patched version.
+
+            5. VERIFY.
+               Run \`npm run build\` AND \`npm test\`. If either fails,
+               do NOT push and do NOT open a PR. Print
                "BUILD_OR_TEST_FAILED" and exit non-zero.
-            5. When build and tests pass:
-                 - \`git push -u origin ${BRANCH}\` (uses \$GH_TOKEN).
-                 - \`gh pr create --base main --head ${BRANCH} \\\\
-                       --title "chore(deps): auto-fix Dependabot alerts" \\\\
-                       --body "<summary of alerts addressed, per-package old→new versions, CVE IDs, and any overrides added>"\`.
-                 - Print the PR URL.
-            6. Never manually edit integrity hashes in package-lock.json
+
+            6. OPEN THE PR (verification passed).
+               - \`git push -u origin ${BRANCH}\` (uses \$GH_TOKEN).
+               - Build the PR title and body strictly from \`alerts.json\`:
+                   * Title: \`chore(deps): fix N open Dependabot alert(s)\`
+                     where N = number of distinct entries in \`alerts.json\`.
+                   * Body format:
+                       ## Summary
+                       Fixes N open Dependabot alert(s) as enumerated by
+                       \`gh api repos/${REPO}/dependabot/alerts?state=open\`.
+                       ## Alerts addressed
+                       For each entry in \`alerts.json\`, one bullet:
+                         - \`<pkg>\` (#<number>, <severity>, <ghsa>) —
+                           vulnerable \`<vulnerable>\` → patched \`<patched>\`.
+                           Strategy: override | direct-bump | parent-bump.
+                           Rationale if parent-bump: <one line>.
+                       ## Collateral changes
+                       List any other dep bumps that \`npm install\` cascaded
+                       (e.g. peer updates) and explain why they were
+                       necessary. If there are none, say "None".
+                       ## Verification
+                       - \`npm run build\`: PASS
+                       - \`npm test\`: PASS
+               - Open the PR with \`gh pr create --base main --head ${BRANCH}\`
+                 using that title and body.
+               - Print the PR URL.
+
+            7. COMMIT / AUTHORSHIP HYGIENE.
+               Never manually edit integrity hashes in package-lock.json
                (see skill). Use \`npm install\`, \`npm update\`, or a clean
-               reinstall to let npm compute them.
-            7. Never use \`--allow-all\` semantics; stick to the tools you
+               reinstall to let npm compute them. Do not add any
+               \`Co-authored-by:\` trailer.
+
+            8. PERMISSIONS.
+               Never use \`--allow-all\` semantics; stick to the tools you
                already have permission to use.
 
           ----- SKILL START -----


### PR DESCRIPTION
## Context

The first scheduled run of the Dependabot auto-fix workflow (PR #1559) revealed two prompt-level problems:

1. **Inflated alert count.** The PR body claimed *"33+ open Dependabot alerts (32 moderate, 1 high)"*, but at the time of the run the Dependabot API only had **one** open alert (\`uuid\`, # 172). The count appears to have come from multiplying by the number of transitive \`node_modules/**/uuid\` occurrences in \`package-lock.json\` rather than reading the alerts list.
2. **Scope creep.** The agent reached for \`npm audit fix\`, which pulled in unrelated bumps: \`brace-expansion\` and \`path-to-regexp\` (whose alerts had been auto-dismissed weeks earlier) and ~20 \`@fluidframework/*\` packages from \`2.91.0\` → \`2.93.0\`. The final diff was ~500 lines, vastly larger than the single open alert required.

## Changes to the prompt in `.github/workflows/dependabot-autofix.yml`

1. **Alert enumeration is the single source of truth.** The agent runs one specific `gh api` query, persists the output to `alerts.json`, and builds the PR title + body 1-for-1 from that list. It is forbidden from treating transitive-path occurrences as separate alerts.
2. **Strict preference order for fixes:** (a) `overrides` in `package.json`, (b) direct-dependency bump, (c) parent-package bump only if (a)/(b) are infeasible, and only with a justification in the PR body. `npm audit fix` / `npm audit fix --force` are explicitly forbidden.
3. **Diff discipline.** After regenerating the lockfile, the agent runs `git diff --stat origin/main` and aborts if `package.json` touches deps not on the alert list (other than adding overrides), or if any dep crosses a MAJOR version unnecessarily.
4. **Structured PR body.** Title becomes `chore(deps): fix N open Dependabot alert(s)` where N matches the alert count. Body has fixed sections: Summary, Alerts addressed (one bullet per alert with the chosen strategy), Collateral changes (or `"None"`), Verification.
5. **Reaffirm no `Co-authored-by:` trailers** (these caused CLA friction on the first run when the bot`s identity was added as a co-author).

## Test plan
After merge, trigger the workflow manually via `workflow_dispatch` and check:
- The count in the PR title matches `gh api repos/microsoft/powerplatform-vscode/dependabot/alerts?state=open | jq length`.
- The `git diff --stat` only touches files/packages listed in the alert set, plus justified collateral.
- The PR body has the four required sections and one bullet per alert.