### PR TITLE
Fix Copilot CLI --secret-env-vars to expose the real token env vars

### DIFF
--- a/.github/workflows/dependabot-autofix.yml
+++ b/.github/workflows/dependabot-autofix.yml
@@ -227,7 +227,7 @@ jobs:
             -s \
             --no-ask-user \
             --allow-tool 'shell(npm:*), shell(npx:*), shell(gh:*), shell(git:*), shell(node:*), write, read' \
-            --secret-env-vars 'COPILOT_CLI_PAT' \
+            --secret-env-vars 'COPILOT_GITHUB_TOKEN,GH_TOKEN' \
             --share ./copilot-session.md \
             | tee copilot-output.txt
 


### PR DESCRIPTION
## Problem

In PR #1568 the agent fell back to `npm audit` instead of the Dependabot REST API, and its PR body explicitly says:

> *"COPILOT_GITHUB_TOKEN was not available in this environment, so npm audit was used as the vulnerability source of truth"*

## Root cause

In `.github/workflows/dependabot-autofix.yml`:

- The step env exposes the secret as `COPILOT_GITHUB_TOKEN` (line 97) and `GH_TOKEN` (line 100).
- But `--secret-env-vars` was set to `COPILOT_CLI_PAT`, which is the **secret name**, not the **env var name**.

`--secret-env-vars` controls which env vars from the parent process get forwarded to Copilot CLI`s tool sub-shells (and redacted from logs). Because neither real env var was listed, none reached the agent`s shells, so the `gh api repos/.../dependabot/alerts` call from rule 1 of the prompt failed and the agent fell back to `npm audit`.

## Fix

Pass the actual env var names:

```diff
- --secret-env-vars COPILOT_CLI_PAT \
+ --secret-env-vars COPILOT_GITHUB_TOKEN,GH_TOKEN \
```

## Test plan

After merge, trigger via `workflow_dispatch` and confirm:
- The agent reads alerts via `gh api .../dependabot/alerts` and writes `alerts.json` (rule 1 of the prompt).
- The PR body no longer contains the `npm audit` fallback disclaimer.