### PR TITLE
Fix web save flow error telemetry and dedupe dialog spam

### DIFF
--- a/src/web/client/dal/remoteSaveProvider.ts
+++ b/src/web/client/dal/remoteSaveProvider.ts
@@ -28,6 +28,16 @@ interface ISaveCallParameters {
     requestUrl: string;
 }
 
+// Tracks fsPaths that have already triggered the get-save-parameters error
+// dialog/telemetry in this session. Subsequent failures for the same fsPath
+// are silenced to avoid 4.6x dialog/telemetry spam per session.
+const failedSaveParameterPaths = new Set<string>();
+
+// Test-only export to reset the dedup set between cases.
+export function _resetFailedSaveParameterPaths() {
+    failedSaveParameterPaths.clear();
+}
+
 export async function saveData(fileUri: vscode.Uri) {
     const dataMap: Map<string, FileData> =
         WebExtensionContext.fileDataMap.getFileMap;
@@ -112,11 +122,14 @@ async function getSaveParameters(
             attributePath.source,
             requestUrl
         );
-    } else {
+    } else if (!failedSaveParameterPaths.has(fileUri.fsPath)) {
+        failedSaveParameterPaths.add(fileUri.fsPath);
+        const errorMessage = `${BAD_REQUEST}: missing attributePath for entity '${entityName ?? "unknown"}' at '${fileUri.fsPath}'`;
         WebExtensionContext.telemetry.sendErrorTelemetry(
             webExtensionTelemetryEventNames.WEB_EXTENSION_GET_SAVE_PARAMETERS_ERROR,
             getSaveParameters.name,
-            BAD_REQUEST
+            errorMessage,
+            new Error(errorMessage)
         ); // no API request is made in this case since we do not know in which column should we save the value
         showErrorDialog(
             vscode.l10n.t("Unable to complete the request"),

--- a/src/web/client/test/integration/remoteSaveProvider.test.ts
+++ b/src/web/client/test/integration/remoteSaveProvider.test.ts
@@ -6,7 +6,7 @@
 import vscode from "vscode";
 import * as fetch from "node-fetch";
 import sinon, { stub, assert } from "sinon";
-import { saveData } from "../../dal/remoteSaveProvider";
+import { saveData, _resetFailedSaveParameterPaths } from "../../dal/remoteSaveProvider";
 import * as schemaHelperUtil from "../../utilities/schemaHelperUtil";
 import WebExtensionContext from "../../../client/WebExtensionContext";
 import { expect } from "chai";
@@ -20,6 +20,7 @@ import * as errorHandler from "../../../../common/utilities/errorHandlerUtil";
 describe("remoteSaveProvider", () => {
     afterEach(() => {
         sinon.restore();
+        _resetFailedSaveParameterPaths();
     });
     it("saveData_whenFetchRetrnsOKAndIsWebFileV2IsFalse_shouldCallAllSuccessTelemetryMethods", async () => {
         //Act
@@ -149,13 +150,55 @@ describe("remoteSaveProvider", () => {
         );
         assert.calledOnce(showErrorDialog);
         assert.calledOnce(sendErrorTelemetry);
-        assert.calledOnceWithExactly(
-            sendErrorTelemetry,
-            webExtensionTelemetryEventNames.WEB_EXTENSION_GET_SAVE_PARAMETERS_ERROR,
-            "getSaveParameters",
-            BAD_REQUEST
+        const sendErrorTelemetryCall = sendErrorTelemetry.getCalls()[0];
+        expect(sendErrorTelemetryCall.args[0]).eq(
+            webExtensionTelemetryEventNames.WEB_EXTENSION_GET_SAVE_PARAMETERS_ERROR
+        );
+        expect(sendErrorTelemetryCall.args[1]).eq("getSaveParameters");
+        expect(sendErrorTelemetryCall.args[2] as string).contains(BAD_REQUEST);
+        expect(sendErrorTelemetryCall.args[2] as string).contains("missing attributePath");
+        expect(sendErrorTelemetryCall.args[3]).instanceOf(Error);
+        expect((sendErrorTelemetryCall.args[3] as Error).message).eq(
+            sendErrorTelemetryCall.args[2] as string
         );
         assert.calledOnce(vscodeParse);
+    });
+
+    it("saveData_whenAttributePathIsNullAndCalledMultipleTimes_shouldShowDialogAndSendTelemetryOnlyOnce", async () => {
+        const fileUri: vscode.Uri = { fsPath: "dedupuri" } as vscode.Uri;
+
+        stub(vscode.Uri, "parse").returns({
+            fsPath: "dedupuri",
+        } as vscode.Uri);
+        stub(schemaHelperUtil, "isWebFileV2").returns(false);
+        WebExtensionContext.fileDataMap.setEntity(
+            "",
+            "",
+            "entityName",
+            "",
+            "",
+            "",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            null as any,
+            true,
+            "pdf"
+        );
+
+        stub(urlBuilderUtil, "getRequestURL").returns(
+            "https://orgedfe4d6c.crm10.dynamics.com"
+        );
+        const sendErrorTelemetry = stub(
+            WebExtensionContext.telemetry,
+            "sendErrorTelemetry"
+        );
+        const showErrorDialog = stub(errorHandler, "showErrorDialog");
+
+        await saveData(fileUri);
+        await saveData(fileUri);
+        await saveData(fileUri);
+
+        assert.calledOnce(showErrorDialog);
+        assert.calledOnce(sendErrorTelemetry);
     });
 
     it("saveData_shouldCallAllSuccessTelemetryMethods_whenFetchReturnsNotOKAndIsWebFileV2IsFalse", async () => {

--- a/src/web/client/utilities/urlBuilderUtil.ts
+++ b/src/web/client/utilities/urlBuilderUtil.ts
@@ -22,6 +22,7 @@ import { getAttributePath, getEntity, getEntityFetchQuery } from "./schemaHelper
 import { getWorkSpaceName } from "./commonUtil";
 import * as Constants from "../common/constants";
 import { webExtensionTelemetryEventNames } from "../../../common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents";
+import { createHttpResponseError, isHttpResponseError } from "./errorHandlerUtil";
 
 export const getParameterizedRequestUrlTemplate = (
     useSingleEntityUrl: boolean
@@ -309,7 +310,7 @@ export async function getOrCreateSharedWorkspace(config: any) {
         )
 
         if (!createWorkspaceResponse.ok) {
-            throw new Error(JSON.stringify(createWorkspaceResponse));
+            throw await createHttpResponseError(createWorkspaceResponse);
         }
 
         WebExtensionContext.telemetry.sendAPISuccessTelemetry(
@@ -323,22 +324,22 @@ export async function getOrCreateSharedWorkspace(config: any) {
         return await createWorkspaceResponse.json();
     } catch (error) {
         const errorMsg = (error as Error)?.message;
-        if ((error as Response)?.status > 0) {
+        if (isHttpResponseError(error) && error.httpDetails) {
             WebExtensionContext.telemetry.sendAPIFailureTelemetry(
                 requestUrl.href,
                 config.entityName,
-                Constants.httpMethod.GET,
+                Constants.httpMethod.POST,
                 new Date().getTime() - requestSentAtTime,
                 getOrCreateSharedWorkspace.name,
                 errorMsg,
                 '',
-                (error as Response)?.status.toString()
+                error.httpDetails.statusCode.toString()
             );
         } else {
             WebExtensionContext.telemetry.sendErrorTelemetry(
                 webExtensionTelemetryEventNames.WEB_EXTENSION_FETCH_GET_OR_CREATE_SHARED_WORK_SPACE_ERROR,
                 getOrCreateSharedWorkspace.name,
-                Constants.WEB_EXTENSION_FETCH_GET_OR_CREATE_SHARED_WORK_SPACE_ERROR,
+                errorMsg,
                 error as Error
             );
         }


### PR DESCRIPTION
## Summary
- **`webExtensionFetchGetOrCreateSharedWorkSpaceError`** — propagate real `error.message`/`name`/`stack` instead of a wrapper string. Replaces the broken `throw new Error(JSON.stringify(response))` (Response objects don't serialize, producing `Error("{}")`) with `createHttpResponseError`, and routes HTTP failures through `sendAPIFailureTelemetry` with a real status code via `isHttpResponseError`. Matches the proven pattern in `remoteFetchProvider.ts`.
- **`webExtensionGetSaveParametersError`** — populate the payload with `entityName` + `fsPath`. Previously the catch site logged only `BAD_REQUEST` as the third arg with no `Error` object, so 100% of events carried empty `errorName`/`errorMessage`/stack and RCA was impossible.
- **Dedupe** — suppress repeat dialog/telemetry for the same `fsPath` within a VS Code Web session via a module-level `Set<string>`. Removes the ~4.6x per-session spam users hit on save retry. State naturally clears on extension deactivate (page reload / tab close).

Drives `webExtensionGetSaveParametersError` from ~1,398/30d (inflated by retries) toward ~301/30d (true unique-affected-files), and unblocks RCA on `webExtensionFetchGetOrCreateSharedWorkSpaceError` (1,030 affected users / 30d) which has been completely opaque.

## Test plan
- [ ] `npm run test-web-integration` (blocked locally by VS Code Insiders editor lock; CI should run cleanly)
- [ ] After deployment, query Kusto: `webExtensionGetSaveParametersError` events should carry non-empty `errorName`/`errorMessage` and the message should contain `"missing attributePath"`
- [ ] After deployment, verify event count for `webExtensionGetSaveParametersError` drops ~5x (per-fsPath dedupe)
- [ ] After deployment, query Kusto: `webExtensionFetchGetOrCreateSharedWorkSpaceError` events should now carry the underlying error message + status code (HTTP failures should appear in `webExtensionApiRequestFailure` with status code instead)
- [ ] Manual: trigger a save with attribute removed → dialog appears once; retry save N times → dialog/telemetry only fires on first attempt; reload window → dialog reappears on first attempt