### PR TITLE
Forward errorMessage in WebExtensionApiRequest telemetry

### DIFF
--- a/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryInterface.ts
+++ b/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryInterface.ts
@@ -45,6 +45,7 @@ export interface IWebExtensionAPITelemetryData extends IWebExtensionTelemetryDat
         'isSuccessful'?: string;
         'status'?: string;
         'methodName'?: string;
+        'errorMessage'?: string;
     },
     measurements: {
         'durationInMillis': number;

--- a/src/web/client/telemetry/webExtensionTelemetry.ts
+++ b/src/web/client/telemetry/webExtensionTelemetry.ts
@@ -95,17 +95,25 @@ export class WebExtensionTelemetry {
 
         eventName = eventName ?? webExtensionTelemetryEventNames.WEB_EXTENSION_API_REQUEST;
 
+        const properties: IWebExtensionAPITelemetryData['properties'] = {
+            url: sanitizeURL(URL),
+            entity: entity,
+            httpMethod: httpMethod,
+            entityFileExtensionType: entityFileExtensionType,
+            isSuccessful: (isSuccessful === undefined) ? "" : (isSuccessful ? "true" : "false"),
+            status: status,
+            methodName: methodName
+        };
+        if (errorMessage) {
+            // Defensive truncation: formatHttpErrorMessage already caps at 500, but
+            // other callers may pass raw error.message of unbounded length.
+            properties.errorMessage = errorMessage.length > 500
+                ? errorMessage.substring(0, 500) + "..."
+                : errorMessage;
+        }
         const telemetryData: IWebExtensionAPITelemetryData = {
             eventName: eventName,
-            properties: {
-                url: sanitizeURL(URL),
-                entity: entity,
-                httpMethod: httpMethod,
-                entityFileExtensionType: entityFileExtensionType,
-                isSuccessful: (isSuccessful === undefined) ? "" : (isSuccessful ? "true" : "false"),
-                status: status,
-                methodName: methodName
-            },
+            properties: properties,
             measurements: {
                 durationInMillis: (duration) ? duration : 0
             }

--- a/src/web/client/test/integration/webExtensionTelemetry.test.ts
+++ b/src/web/client/test/integration/webExtensionTelemetry.test.ts
@@ -280,7 +280,8 @@ describe("webExtensionTelemetry", () => {
             entityFileExtensionType: entityFileExtensionType,
             methodName: "sendAPITelemetry_whenErrorMessageIsPassed_shouldCallSendTelemetryException",
             isSuccessful: "true",
-            status: "200"
+            status: "200",
+            errorMessage: errorMessage
         };
 
         //Action

--- a/src/web/client/test/integration/webExtensionTelemetry.test.ts
+++ b/src/web/client/test/integration/webExtensionTelemetry.test.ts
@@ -515,7 +515,8 @@ describe("webExtensionTelemetry", () => {
             entityFileExtensionType: entityFileExtensionType,
             isSuccessful: "false",
             status: "200",
-            methodName: "sendAPIFailureTelemetry_withErrorMessage_shouldCallSendTelemetryException"
+            methodName: "sendAPIFailureTelemetry_withErrorMessage_shouldCallSendTelemetryException",
+            errorMessage: errorMessage
         };
 
         const measurements = {


### PR DESCRIPTION
## Summary
- **`sendAPITelemetry` discards `errorMessage`** today: the parameter is accepted and used to build a `traceError` invocation, but it never lands in `properties`, so every `WebExtensionApiRequestFailure` event in Kusto is missing the underlying error detail (status text, response body, OData error code).
- The save flow already builds a useful message via `createHttpResponseError` / `formatHttpErrorMessage` (with the truncated Dataverse response body) and forwards it through `sendAPIFailureTelemetry` -> `sendAPITelemetry`. This PR plumbs that string into the telemetry payload.
- Adds `errorMessage?: string` to `IWebExtensionAPITelemetryData.properties`. `sendAPITelemetry` now sets the field only when present (so success-path events stay clean) and applies a defensive 500-char cap for non-HTTP callers that may pass a raw unbounded `error.message`.


## Test plan
- [ ] `npm test` (unit, blast-radius check) - 95/95 passing locally
- [ ] `npm run test-web-integration` - blocked locally by VS Code Insiders editor lock; CI should run cleanly
- [ ] Existing telemetry test `sendAPITelemetry_whenErrorMessageIsPassed_shouldCallSendTelemetryException` updated to assert `errorMessage` is now in `properties`
- [ ] Existing telemetry test `sendAPITelemetry_whenErrorMessageNotPassed_shouldCallSendTelemetryException` unchanged (validates `errorMessage` is omitted when not provided)
- [ ] After deploy, query Kusto: `WebExtensionApiRequestFailure` events should carry non-empty `errorMessage` containing the truncated response body for HTTP failures
- [ ] After deploy, run the OData error-code bucketing query above to size the dominant save-400 cause