### PR TITLE
Surface bulkhead executionSlots and retryCount in telemetry

### DIFF
--- a/src/web/client/dal/concurrencyHandler.ts
+++ b/src/web/client/dal/concurrencyHandler.ts
@@ -51,10 +51,16 @@ export class ConcurrencyHandler {
             });
         } catch (e) {
             if (e instanceof BulkheadRejectedError) {
+                // Pass an Error object so sendErrorTelemetry actually persists
+                // executionSlots/retryCount into the event payload — without it,
+                // the telemetry layer drops the message string entirely and the
+                // event lands in Kusto with only {eventName, methodName}.
+                const msg = `executionSlots: ${this._bulkhead.executionSlots}, retryCount: ${retryCount}`;
                 WebExtensionContext.telemetry.sendErrorTelemetry(
                     webExtensionTelemetryEventNames.WEB_EXTENSION_BULKHEAD_QUEUE_FULL,
                     this.handleRequest.name,
-                    `executionSlots: ${this._bulkhead.executionSlots}, retryCount: ${retryCount}`,
+                    msg,
+                    new Error(msg)
                 );
                 throw new Error(ERROR_CONSTANTS.BULKHEAD_LIMITS_EXCEEDED);
             } else {

--- a/src/web/client/test/integration/concurrencyHandler.test.ts
+++ b/src/web/client/test/integration/concurrencyHandler.test.ts
@@ -57,14 +57,15 @@ describe("ConcurrencyHandler", () => {
 
             // Should only attempt once - no retries for BulkheadRejectedError
             assert.calledOnce(fetchStub);
-            // Should log error telemetry for bulkhead rejection
+            // Should log error telemetry for bulkhead rejection with an Error
+            // object so executionSlots/retryCount actually land in the payload.
             assert.calledOnce(sendErrorTelemetryStub);
-            assert.calledWith(
-                sendErrorTelemetryStub,
-                webExtensionTelemetryEventNames.WEB_EXTENSION_BULKHEAD_QUEUE_FULL,
-                "handleRequest",
-                sinon.match.string
-            );
+            const call = sendErrorTelemetryStub.getCalls()[0];
+            expect(call.args[0]).to.equal(webExtensionTelemetryEventNames.WEB_EXTENSION_BULKHEAD_QUEUE_FULL);
+            expect(call.args[1]).to.equal("handleRequest");
+            expect(call.args[2]).to.match(/executionSlots:.*retryCount:/);
+            expect(call.args[3]).to.be.instanceOf(Error);
+            expect((call.args[3] as Error).message).to.equal(call.args[2] as string);
         });
 
         it("should pass request info and init to fetch", async () => {


### PR DESCRIPTION
## Summary
`webExtensionBulkheadQueueFull` events currently land in Kusto with only `{eventName, methodName}` — the `executionSlots` and `retryCount` string built at the call site is silently dropped because `sendErrorTelemetry` only persists `errorMessage` to the payload when an `Error` object is also passed (same instrumentation-gap pattern fixed earlier for `getSaveParametersError`).

This PR passes an `Error` object so the message lands in telemetry, and tightens the existing test to verify the new argument shape.

## Why
4,037 bulkhead events / 30d are firing today with no diagnostic detail. Combined with the related `webExtensionFetchDataverseCreateFilesSystemError` count (10,733 of which are the bulkhead-class duplicates), this represents ~14.7K telemetry events where we currently can't tell which retry attempt or how saturated the bulkhead was. Critical signal for sizing the eventual fan-out fix on the four affected tenants.

No user-facing behavior change. Pure telemetry instrumentation.

## Test plan
- [ ] `npm test` (unit) — passes locally (95/95)
- [ ] `npm run test-web-integration` — should run cleanly in CI; the existing `should not retry BulkheadRejectedError and throw immediately` test is updated to verify the new 4th arg is an `Error` matching the message string
- [ ] After deploy, query Kusto: `webExtensionBulkheadQueueFull` events should now carry non-empty `errorMessage` containing `"executionSlots: N, retryCount: M"`
- [ ] Use the new payload to confirm: most bulkhead rejections happen at saturation (`executionSlots: 0`) vs queue-fill, and what retry attempt typically triggers them