### PR TITLE
Move MCP config from .vscode to repo root

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "servers": {
+  "mcpServers": {
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"


### PR DESCRIPTION
- Relocate MCP server configuration from .vscode/mcp.json to .mcp.json
- Rename top-level key from "servers" to "mcpServers" for broader MCP client compatibility
- Keeps existing github and microsoft-docs HTTP server entries unchanged