### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/E2EWebSanity.yml
+++ b/.github/workflows/E2EWebSanity.yml
@@ -25,12 +25,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -52,7 +52,7 @@ jobs:
           PP_TEST_PASSWORD: ${{ secrets.PP_TEST_PASSWORD }}
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report
@@ -60,7 +60,7 @@ jobs:
           retention-days: 14
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: e2e-test-results

--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -27,12 +27,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Setup .NET 9
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.0.x"
 
@@ -40,7 +40,7 @@ jobs:
         run: dotnet --list-sdks
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -54,29 +54,41 @@ jobs:
         env:
           AZ_DevOps_Read_PAT: ${{ secrets.AZ_DevOps_Read_PAT }}
 
+      - name: Install xvfb
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y xvfb x11-xserver-utils
+
       - name: Run Debugger integration tests
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: |
-            npm run test-integration
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum npm run test-integration
+
+      - name: Run Debugger integration tests
+        if: runner.os != 'Linux'
+        run: npm run test-integration
 
       - name: Run Web integration tests
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: |
-            npm run test-web-integration
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum npm run test-web-integration
+
+      - name: Run Web integration tests
+        if: runner.os != 'Linux'
+        run: npm run test-web-integration
 
       - name: Run Desktop integration tests
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: |
-            npm run test-desktop-int
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum npm run test-desktop-int
+
+      - name: Run Desktop integration tests
+        if: runner.os != 'Linux'
+        run: npm run test-desktop-int
 
       - name: Run Common integration tests
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: |
-            npm run test-common-int
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum npm run test-common-int
+
+      - name: Run Common integration tests
+        if: runner.os != 'Linux'
+        run: npm run test-common-int
 
   web-sanity:
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'release/stable'
@@ -85,12 +97,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -112,7 +124,7 @@ jobs:
           PP_TEST_PASSWORD: ${{ secrets.PP_TEST_PASSWORD }}
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-web-sanity
@@ -120,7 +132,7 @@ jobs:
           retention-days: 7
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: web-sanity-test-results

--- a/.github/workflows/Snapshot.yml
+++ b/.github/workflows/Snapshot.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18
 

--- a/.github/workflows/dependabot-autofix.yml
+++ b/.github/workflows/dependabot-autofix.yml
@@ -54,19 +54,19 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: 2740120
           private-key: ${{ secrets.POWER_PAGES_PUBLIC_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -269,7 +269,7 @@ jobs:
 
       - name: Upload Copilot session transcript
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: copilot-session-${{ github.run_id }}
           path: |

--- a/.github/workflows/loc-update.yml
+++ b/.github/workflows/loc-update.yml
@@ -19,20 +19,20 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: 2740120
           private-key: ${{ secrets.POWER_PAGES_PUBLIC_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/translations-export.yml
+++ b/.github/workflows/translations-export.yml
@@ -22,20 +22,20 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: 2740120
           private-key: ${{ secrets.POWER_PAGES_PUBLIC_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
GitHub Actions is warning that Node.js 20 actions are deprecated and will be forced to Node.js 24 in June 2026. This updates the workflows to use action majors that declare Node 24 runtimes while preserving the repository's configured build and test Node versions.

## Changes
- Update `checkout`, `setup-node`, `upload-artifact`, `create-github-app-token`, and `setup-dotnet` usages to Node 24-compatible majors.
- Replace `coactions/setup-xvfb@v1` in `PullRequest.yml` with direct `xvfb-run` usage on Linux and direct test commands on macOS/Windows because that action only declares a Node 16 runtime.

## Validation
- Workflow YAML parsed successfully for all workflow files.
- No deprecated workflow action references remain for the updated actions.