### PR TITLE
Fix BYOC comparison report tab counts

### DIFF
--- a/src/client/power-pages/actions-hub/handlers/metadata-diff/GenerateHtmlReportHandler.ts
+++ b/src/client/power-pages/actions-hub/handlers/metadata-diff/GenerateHtmlReportHandler.ts
@@ -11,6 +11,7 @@ import { Constants } from "../../Constants";
 import { traceInfo, traceError } from "../../TelemetryHelper";
 import { isBinaryFile } from "../../ActionsHubUtils";
 import { WebsiteDataModel } from "../../../../../common/services/Constants";
+import { POWERPAGES_SITE_FOLDER } from "../../../../../common/constants";
 
 /**
  * Maximum file size in bytes to include content in the report (5MB)
@@ -307,6 +308,10 @@ const componentTypeDisplayNames: Record<string, string> = {
     "others": "Others"
 };
 
+const componentTypeAliases: Record<string, string> = {
+    "site-languages": "website-languages"
+};
+
 /**
  * Ordered list of component types for consistent tab ordering
  */
@@ -336,11 +341,13 @@ const componentTypeOrder: string[] = [
 export function getComponentTypeFromPath(relativePath: string): string {
     // Normalize path separators
     const normalizedPath = relativePath.replace(/\\/g, "/");
-    const firstFolder = normalizedPath.split("/")[0];
+    const pathSegments = normalizedPath.split("/").filter(Boolean);
+    const firstFolder = pathSegments[0] === POWERPAGES_SITE_FOLDER ? pathSegments[1] : pathSegments[0];
+    const componentType = componentTypeAliases[firstFolder] || firstFolder;
 
     // Check if it's a known component type
-    if (componentTypeDisplayNames[firstFolder] && firstFolder !== "others") {
-        return firstFolder;
+    if (componentTypeDisplayNames[componentType] && componentType !== "others") {
+        return componentType;
     }
 
     return "others";

--- a/src/client/test/integration/power-pages/actions-hub/handlers/metadata-diff/GenerateHtmlReportHandler.test.ts
+++ b/src/client/test/integration/power-pages/actions-hub/handlers/metadata-diff/GenerateHtmlReportHandler.test.ts
@@ -261,6 +261,16 @@ describe("GenerateHtmlReportHandler", () => {
             expect(getComponentTypeFromPath("web-pages\\home\\home.html")).to.equal("web-pages");
             expect(getComponentTypeFromPath("content-snippets\\header\\header.html")).to.equal("content-snippets");
         });
+
+        it("should ignore .powerpages-site prefix when determining component type", () => {
+            expect(getComponentTypeFromPath(".powerpages-site/web-pages/home/home.html")).to.equal("web-pages");
+            expect(getComponentTypeFromPath(".powerpages-site\\content-snippets\\header\\header.html")).to.equal("content-snippets");
+        });
+
+        it("should map site-languages folder to the Site Languages tab", () => {
+            expect(getComponentTypeFromPath("site-languages/English.websitelanguage.yml")).to.equal("website-languages");
+            expect(getComponentTypeFromPath(".powerpages-site/site-languages/English.websitelanguage.yml")).to.equal("website-languages");
+        });
     });
 
     describe("getComponentTypeDisplayName", () => {


### PR DESCRIPTION
BYOC metadata paths in generated site comparison reports include `.powerpages-site/`, so component tab grouping treated every file as an unknown top-level folder and left the expected tabs at 0. This normalizes the report grouping path before tab classification so BYOC metadata changes are counted under their component tabs.

## Changes
- Strip the `.powerpages-site/` prefix when resolving component types for HTML report tabs.
- Map `site-languages` paths to the existing Site Languages tab key.
- Add regression coverage for prefixed BYOC paths and the folder alias.

## Validation
- `npm run build`
- `npm run compile-tests`
- `npm run test-desktop-int` via the desktop test runner with a short `--user-data-dir` to avoid the macOS IPC path-length limit.