### PR TITLE
test(e2e): disable Playwright capture in CI and drop artifact uploads

### DIFF
--- a/.github/workflows/E2EWebSanity.yml
+++ b/.github/workflows/E2EWebSanity.yml
@@ -51,18 +51,9 @@ jobs:
           PP_TEST_USERNAME: ${{ secrets.PP_TEST_USERNAME }}
           PP_TEST_PASSWORD: ${{ secrets.PP_TEST_PASSWORD }}
 
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 14
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: e2e-test-results
-          path: test-results/
-          retention-days: 14
+      # Test artifacts are intentionally not uploaded from this workflow.
+      # Playwright reports/traces/videos/screenshots can capture the values that
+      # are typed into the login form and the navigated site URL, and uploaded
+      # artifacts are not masked by GitHub. Trace/video/screenshot capture is
+      # also disabled in CI in the Playwright config. Test results remain visible
+      # in the step logs above via the Playwright "list" reporter.

--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -123,18 +123,9 @@ jobs:
           PP_TEST_USERNAME: ${{ secrets.PP_TEST_USERNAME }}
           PP_TEST_PASSWORD: ${{ secrets.PP_TEST_PASSWORD }}
 
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: playwright-report-web-sanity
-          path: playwright-report-web-sanity/
-          retention-days: 7
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: web-sanity-test-results
-          path: test-results/web-sanity-results.xml
-          retention-days: 7
+      # Test artifacts are intentionally not uploaded from this job.
+      # Playwright reports/traces/videos/screenshots can capture the values that
+      # are typed into the login form and the navigated site URL, and uploaded
+      # artifacts are not masked by GitHub. Trace/video/screenshot capture is
+      # also disabled in CI in the Playwright config. Test results remain visible
+      # in the step logs above via the Playwright "list" reporter.

--- a/src/e2e-web-sanity/playwright.config.ts
+++ b/src/e2e-web-sanity/playwright.config.ts
@@ -24,6 +24,18 @@ dotenv.config({ path: path.resolve(__dirname, '..', 'e2e', '.env') });
  *   PP_TEST_USERNAME    — Microsoft account username
  *   PP_TEST_PASSWORD    — Microsoft account password
  */
+/**
+ * The auth fixture types the test username/password into the Microsoft login
+ * form, and the test navigates to a private site URL. Playwright traces record
+ * fill() action values and full network traffic, while videos/screenshots
+ * capture the typed values. To avoid persisting these into CI artifacts, all
+ * capture is disabled when running in CI; it stays on locally for debugging.
+ */
+const isCI = !!process.env.CI;
+const traceMode = isCI ? 'off' : 'retain-on-failure';
+const videoMode = isCI ? 'off' : 'retain-on-failure';
+const screenshotMode = isCI ? 'off' : 'only-on-failure';
+
 export default defineConfig({
     testDir: './test',
     timeout: 300000,
@@ -41,9 +53,9 @@ export default defineConfig({
     ],
     use: {
         actionTimeout: 30000,
-        trace: 'retain-on-failure',
-        screenshot: 'only-on-failure',
-        video: 'retain-on-failure',
+        trace: traceMode,
+        screenshot: screenshotMode,
+        video: videoMode,
         ...devices['Desktop Chrome'],
     },
     projects: [

--- a/src/e2e/playwright.config.ts
+++ b/src/e2e/playwright.config.ts
@@ -34,6 +34,18 @@ if (fs.existsSync(envPath)) {
 const AUTH_STATE_PATH = path.resolve(__dirname, '.auth', 'storageState.json');
 const useStorageState = fs.existsSync(AUTH_STATE_PATH) && !process.env.PP_FORCE_REAUTH;
 
+/**
+ * The auth fixtures type the test username/password into the Microsoft login
+ * form, and the test navigates to a private site URL. Playwright traces record
+ * fill() action values and full network traffic, while videos/screenshots
+ * capture the typed values. To avoid persisting these into CI artifacts, all
+ * capture is disabled when running in CI; it stays on locally for debugging.
+ */
+const isCI = !!process.env.CI;
+const traceMode = isCI ? 'off' : 'retain-on-failure';
+const videoMode = isCI ? 'off' : 'retain-on-failure';
+const screenshotMode = isCI ? 'off' : 'only-on-failure';
+
 export default defineConfig({
     testDir: './test',
     timeout: 120000,
@@ -51,9 +63,9 @@ export default defineConfig({
     ],
     use: {
         actionTimeout: 30000,
-        trace: 'retain-on-failure',
-        screenshot: 'only-on-failure',
-        video: 'retain-on-failure',
+        trace: traceMode,
+        screenshot: screenshotMode,
+        video: videoMode,
         storageState: useStorageState ? AUTH_STATE_PATH : undefined,
         ...devices['Desktop Chrome'],
     },


### PR DESCRIPTION
Gate Playwright trace/video/screenshot to off when running in CI for the e2e and e2e-web-sanity configs, and stop uploading Playwright report/test-result artifacts from the E2EWebSanity and PullRequest (web-sanity) workflows. Capture stays enabled locally for debugging.