### PR TITLE
fix: prevent auth panel command-not-found race (#1601)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -304,6 +304,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/@azure/msal-node/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "powerplatform-vscode",
   "displayName": "Power Platform Tools",
   "description": "Tooling to create Power Platform solutions & packages, manage Power Platform environments and edit Power Apps Portals",
-  "version": "1.0.1-issue-1601",
+  "version": "1.0.1-dev",
   "enabledApiProposals": [
     "fileSearchProvider",
     "textSearchProvider"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "powerplatform-vscode",
   "displayName": "Power Platform Tools",
   "description": "Tooling to create Power Platform solutions & packages, manage Power Platform environments and edit Power Apps Portals",
-  "version": "1.0.1-dev",
+  "version": "1.0.1-issue-1601",
   "enabledApiProposals": [
     "fileSearchProvider",
     "textSearchProvider"
@@ -188,7 +188,7 @@
         "view": "pacCLI.authPanel",
         "contents": "%pacCLI.authPanel.welcome.whenInteractiveSupported%",
         "when": "!virtualWorkspace && pacCLI.authPanel.interactiveLoginSupported",
-        "enablement": "!microsoft.powerplatform.authPanel.isInitializing"
+        "enablement": "pacCLI.panelsRegistered && !microsoft.powerplatform.authPanel.isInitializing"
       },
       {
         "view": "pacCLI.authPanel",
@@ -1005,7 +1005,7 @@
         },
         {
           "command": "pacCLI.authPanel.newAuthProfile",
-          "when": "pacCLI.authPanel.interactiveLoginSupported"
+          "when": "pacCLI.authPanel.interactiveLoginSupported && pacCLI.panelsRegistered"
         },
         {
           "command": "microsoft.powerplatform.pages.actionsHub.newAuthProfile",
@@ -1271,22 +1271,22 @@
       "view/title": [
         {
           "command": "pacCLI.authPanel.newAuthProfile",
-          "when": "!virtualWorkspace && view == pacCLI.authPanel && pacCLI.authPanel.interactiveLoginSupported",
+          "when": "!virtualWorkspace && view == pacCLI.authPanel && pacCLI.authPanel.interactiveLoginSupported && pacCLI.panelsRegistered",
           "group": "navigation@0"
         },
         {
           "command": "pacCLI.authPanel.refresh",
-          "when": "!virtualWorkspace && view == pacCLI.authPanel",
+          "when": "!virtualWorkspace && view == pacCLI.authPanel && pacCLI.panelsRegistered",
           "group": "navigation@1"
         },
         {
           "command": "pacCLI.authPanel.clearAuthProfile",
-          "when": "!virtualWorkspace && view == pacCLI.authPanel",
+          "when": "!virtualWorkspace && view == pacCLI.authPanel && pacCLI.panelsRegistered",
           "group": "navigation@2"
         },
         {
           "command": "pacCLI.envAndSolutionsPanel.refresh",
-          "when": "!virtualWorkspace && view == pacCLI.envAndSolutionsPanel",
+          "when": "!virtualWorkspace && view == pacCLI.envAndSolutionsPanel && pacCLI.panelsRegistered",
           "group": "navigation"
         },
         {
@@ -1869,6 +1869,9 @@
   },
   "overrides": {
     "uuid": "$uuid",
+    "@azure/msal-node": {
+      "uuid": "^11.0.0"
+    },
     "axios": "1.16.0",
     "basic-ftp": "5.3.1",
     "fast-uri": "3.1.2",

--- a/src/client/lib/AuthPanelView.ts
+++ b/src/client/lib/AuthPanelView.ts
@@ -19,6 +19,11 @@ export class AuthTreeView implements vscode.TreeDataProvider<AuthProfileTreeItem
         public readonly dataSource: () => Promise<PacAuthListOutput>,
         pacWrapper: PacWrapper) {
 
+        // Seed the loading flag so the "Add Auth Profile" welcome button starts disabled. getChildren()
+        // also manages this key, but it only runs once the view is first made visible, so without seeding
+        // here the button briefly renders enabled while the initial `pac auth list` is still in flight.
+        vscode.commands.executeCommand('setContext', 'microsoft.powerplatform.authPanel.isInitializing', true);
+
         const watchPath = GetAuthProfileWatchPattern();
         if (watchPath) {
             const watcher = vscode.workspace.createFileSystemWatcher(watchPath);

--- a/src/client/lib/PacActivityBarUI.ts
+++ b/src/client/lib/PacActivityBarUI.ts
@@ -25,6 +25,11 @@ export function RegisterBasicPanels(pacWrapper: PacWrapper): vscode.Disposable[]
         pacWrapper,
         () => pacWrapper.activeOrg());
 
+    // Gates the declarative view/title buttons in package.json so they can't be clicked before
+    // their commands are registered (above), which on first run is delayed by slow CLI
+    // acquisition. Avoids "command 'pacCLI.authPanel.refresh' not found" (issue #1601).
+    vscode.commands.executeCommand("setContext", "pacCLI.panelsRegistered", true);
+
     return [authPanel, envAndSolutionPanel];
 }
 


### PR DESCRIPTION
The auth panel's buttons are contributed declaratively in package.json and render as soon as the Power Platform view is shown, but their commands are registered imperatively in activate() only after CLI acquisition completes. On first install that gap is long enough for a click to hit "command 'pacCLI.authPanel.refresh' not found".

Gate the title-bar and welcome-view buttons on a new pacCLI.panelsRegistered context key that is set once the tree views (and their commands) are registered. Also seed authPanel.isInitializing in the AuthTreeView constructor so the "Add Auth Profile" welcome button stays disabled while the initial pac auth list is still loading instead of flashing enabled.

Also scope the global uuid override so @azure/msal-node keeps a CommonJS-compatible uuid (v11) instead of the ESM-only v14 the override otherwise forces, which broke `gulp ci` with ERR_REQUIRE_ESM.

Fixes #1601 