### PR TITLE
Fix undici Dependabot alerts via release-it override bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15588,10 +15588,11 @@
       }
     },
     "node_modules/release-it/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -1895,7 +1895,7 @@
     "diff": "^8.0.3",
     "undici": "^7.28.0",
     "release-it": {
-      "undici": "^6.24.0"
+      "undici": "^6.27.0"
     },
     "@vscode/vsce": {
       "minimatch": "3.1.5",


### PR DESCRIPTION
## Why

Dependabot flagged three open alerts on `undici` (1 medium, 2 low). All trace to the same dev-only transitive dependency, where `release-it` resolved `undici` 6.24.1, which is below the patched 6.27.0.

## What changed

The repo already pins a top-level `undici` override at `^7.28.0`, but `release-it`'s nested override was stuck at `^6.24.0`. I bumped that nested override to `^6.27.0`, so npm resolves the patched 6.27.0 release for that tree. The top-level 7.28.0 copy is unaffected.

- `release-it > undici`: 6.24.1 -> 6.27.0
- top-level `undici`: 7.28.0 (unchanged)

This closes:
- CVE-2026-9679 (medium) - HTTP header injection via Set-Cookie percent-decoding
- CVE-2026-6733 (low) - HTTP response queue poisoning via keep-alive socket reuse
- CVE-2026-11525 (low) - Set-Cookie SameSite attribute downgrade

## Notes

`undici` here is dev-only (pulled in by `release-it`), so there is no runtime/extension impact. Patch-level bump within the 6.x line, so no breaking changes expected. Verified with `npm install` (0 vulnerabilities), `npm run build`, and the unit suite (102 passing).