### PR TITLE
fix(metadata-diff): ignore CRLF vs LF line-ending differences

### DIFF
--- a/src/client/power-pages/actions-hub/handlers/metadata-diff/MetadataDiffUtils.ts
+++ b/src/client/power-pages/actions-hub/handlers/metadata-diff/MetadataDiffUtils.ts
@@ -13,7 +13,7 @@ import { POWERPAGES_SITE_FOLDER } from "../../../../../common/constants";
 import { showProgressWithNotification } from "../../../../../common/utilities/Utils";
 import { FileComparisonStatus, IFileComparisonResult } from "../../models/IFileComparisonResult";
 import { SiteVisibility } from "../../models/SiteVisibility";
-import { getAllFiles } from "../../ActionsHubUtils";
+import { getAllFiles, isBinaryFile } from "../../ActionsHubUtils";
 import MetadataDiffContext from "../../MetadataDiffContext";
 import PacContext from "../../../../pac/PacContext";
 
@@ -413,6 +413,41 @@ export function compareFiles(
 }
 
 /**
+ * Normalizes line endings in a text buffer so that CRLF and lone CR are treated
+ * the same as LF. CR (0x0D) and LF (0x0A) are single-byte ASCII characters that
+ * never appear as UTF-8 continuation bytes, so decoding as UTF-8 before normalizing
+ * is safe for multi-byte content.
+ * @param content The file content buffer
+ * @returns The content as a string with normalized (LF) line endings
+ */
+function normalizeLineEndings(content: Buffer): string {
+    return content.toString("utf8").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * Determines whether two file contents are equal for diff purposes.
+ * Binary files are compared byte-for-byte. Text files are first compared
+ * byte-for-byte and, if that fails, compared again after normalizing line
+ * endings so that files differing only by CRLF vs LF are not reported as modified.
+ * @param localContent The local file content buffer
+ * @param remoteContent The remote file content buffer
+ * @param relativePath The relative path of the file (used to detect binary files)
+ * @returns True if the contents are considered equal, false otherwise
+ */
+function areFileContentsEqual(localContent: Buffer, remoteContent: Buffer, relativePath: string): boolean {
+    if (localContent.equals(remoteContent)) {
+        return true;
+    }
+
+    // SVG is text-based, so treat it as text (includeSvg=false) for content comparison
+    if (isBinaryFile(relativePath, false)) {
+        return false;
+    }
+
+    return normalizeLineEndings(localContent) === normalizeLineEndings(remoteContent);
+}
+
+/**
  * Compares two file maps and adds results to the results array.
  * File path comparison is case-insensitive to handle Windows file system behavior.
  * @param remoteFiles Map of remote files (relative path -> absolute path)
@@ -449,7 +484,7 @@ function compareFileMaps(
             const remoteContent = fs.readFileSync(remotePath);
             const localContent = fs.readFileSync(localEntry.absolutePath);
 
-            if (!remoteContent.equals(localContent)) {
+            if (!areFileContentsEqual(localContent, remoteContent, localEntry.originalPath)) {
                 // Check if we already have a result for this path (case-insensitive)
                 if (!results.some(r => r.relativePath.toLowerCase() === lowerCasePath)) {
                     results.push({

--- a/src/client/test/integration/power-pages/actions-hub/handlers/metadata-diff/MetadataDiffUtils.test.ts
+++ b/src/client/test/integration/power-pages/actions-hub/handlers/metadata-diff/MetadataDiffUtils.test.ts
@@ -286,6 +286,35 @@ describe("MetadataDiffUtils", () => {
             expect(results.length).to.equal(0);
         });
 
+        it("should not report text files differing only by CRLF vs LF line endings", () => {
+            fs.writeFileSync(path.join(remotePath, "script.js"), "line1\r\nline2\r\nline3\r\n");
+            fs.writeFileSync(path.join(localPath, "script.js"), "line1\nline2\nline3\n");
+
+            const results = compareFiles(remotePath, localPath);
+
+            expect(results.length).to.equal(0);
+        });
+
+        it("should still report text files with genuine content differences when line endings also differ", () => {
+            fs.writeFileSync(path.join(remotePath, "script.js"), "line1\r\nline2\r\n");
+            fs.writeFileSync(path.join(localPath, "script.js"), "line1\nCHANGED\n");
+
+            const results = compareFiles(remotePath, localPath);
+
+            expect(results.length).to.equal(1);
+            expect(results[0].status).to.equal(FileComparisonStatus.MODIFIED);
+        });
+
+        it("should still byte-compare binary files (CRLF vs LF is a real difference)", () => {
+            fs.writeFileSync(path.join(remotePath, "image.png"), Buffer.from("a\r\nb"));
+            fs.writeFileSync(path.join(localPath, "image.png"), Buffer.from("a\nb"));
+
+            const results = compareFiles(remotePath, localPath);
+
+            expect(results.length).to.equal(1);
+            expect(results[0].status).to.equal(FileComparisonStatus.MODIFIED);
+        });
+
         it("should use case-insensitive path comparison", () => {
             // Create files with different case - on Windows these would be the same file
             fs.writeFileSync(path.join(remotePath, "File.TXT"), "remote");


### PR DESCRIPTION
## Problem

The Power Pages **Actions Hub metadata diff** compares local files against the environment-downloaded site using a raw byte-level `Buffer.equals`. Files downloaded from the environment use Windows **CRLF** line endings, while local workspace files often use Unix **LF**. As a result, files whose visible content is identical were flagged as `modified` and cluttered both the diff tree and the exported JSON.

In a real export (`cms-portal`, 52 files), **39 of 49 "modified" files differed only by CRLF↔LF** — after normalizing `\r\n→\n` they were byte-identical. Only ~9 were genuine changes.

## Fix

- Added `normalizeLineEndings(buffer)` — converts CRLF and lone CR to LF.
- Added `areFileContentsEqual(local, remote, relativePath)`:
  - Fast exact byte compare first.
  - **Binary** files (via `isBinaryFile`, SVG treated as text) keep exact byte comparison.
  - **Text** files fall back to comparing line-ending–normalized content.
- `compareFileMaps` now uses `areFileContentsEqual(...)` instead of `remoteContent.equals(localContent)`.

## Tests

Added cases to `MetadataDiffUtils.test.ts`:
- Text file differing only by CRLF vs LF → **not** modified.
- Text file with a genuine change (mixed endings) → still modified.
- Binary file differing by CRLF vs LF bytes → still modified.

Validated the compiled `compareFiles` against these scenarios (incl. SVG-as-text). `tsc` and ESLint are clean on the changed files.

## Notes

Only text files get line-ending normalization; binary files retain exact byte comparison. The full desktop integration harness (Electron VS Code) was not run in this environment; behavior was verified against the compiled function directly.