### PR TITLE
Reclassify empty Dataverse response from system error to info telemetry

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -32,7 +32,6 @@
   "There's a problem on the back end": "There's a problem on the back end",
   "Try again": "Try again",
   "We encountered an error preparing the files for edit.": "We encountered an error preparing the files for edit.",
-  "Response data is empty": "Response data is empty",
   "Failed to fetch some files.": "Failed to fetch some files.",
   "Failed to get file ready for edit: {0}": "Failed to get file ready for edit: {0}",
   "Saving your file ...": "Saving your file ...",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -1084,9 +1084,6 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++95e154398a4bc0091aa4d6b607472ac5a89e41fbc84a3a49f823314d6de9eebc">
       <source xml:lang="en">Replace</source>
     </trans-unit>
-    <trans-unit id="++CODE++b62120c5416487f4c793d75aee7fea083971e5ac665a3f35767023f408f482e5">
-      <source xml:lang="en">Response data is empty</source>
-    </trans-unit>
     <trans-unit id="++CODE++b87504a6b179044cf99d39cf641f47aa5e76c4c5b949413ec33953ec35c10ac4">
       <source xml:lang="en">Results opened in SARIF viewer successfully.</source>
     </trans-unit>

--- a/src/common/ErrorConstants.ts
+++ b/src/common/ErrorConstants.ts
@@ -24,8 +24,6 @@ export const ERROR_CONSTANTS = {
     SERVER_ERROR_PERMISSION_DENIED:
         "There was a permissions problem with the server",
     SERVER_ERROR_PERMISSION_DENIED_DESC: "Please try again in a minute or two",
-    EMPTY_RESPONSE: "There was no response",
-    EMPTY_RESPONSE_DESC: "Try again",
     THRESHOLD_LIMIT_EXCEEDED: "Threshold for dataverse api",
     THRESHOLD_LIMIT_EXCEEDED_DESC:
         "You’ve exceeded the threshold rate limit for the Dataverse API",

--- a/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts
+++ b/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts
@@ -135,5 +135,6 @@ export enum webExtensionTelemetryEventNames {
     WEB_EXTENSION_REQUEST_RETRY = "WebExtensionRequestRetry",
     WEB_EXTENSION_WEBFILE_NOT_FOUND = "WebExtensionWebfileNotFound",
     WEB_EXTENSION_SERVERLOGIC_NOT_FOUND = "WebExtensionServerlogicNotFound",
-    WEB_EXTENSION_OPTIONAL_ENTITY_NOT_FOUND = "WebExtensionOptionalEntityNotFound"
+    WEB_EXTENSION_OPTIONAL_ENTITY_NOT_FOUND = "WebExtensionOptionalEntityNotFound",
+    WEB_EXTENSION_EMPTY_DATAVERSE_RESPONSE = "WebExtensionEmptyDataverseResponse"
 }

--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -161,8 +161,12 @@ async function fetchFromDataverseAndCreateFiles(
             }
 
             if (result[Constants.ODATA_COUNT] !== 0 && data.length === 0) {
-                console.error(vscode.l10n.t("Response data is empty"));
-                throw new Error(ERROR_CONSTANTS.EMPTY_RESPONSE);
+                makeRequestCall = false;
+                WebExtensionContext.telemetry.sendInfoTelemetry(
+                    webExtensionTelemetryEventNames.WEB_EXTENSION_EMPTY_DATAVERSE_RESPONSE,
+                    { entityName }
+                );
+                break;
             }
 
             WebExtensionContext.telemetry.sendAPISuccessTelemetry(


### PR DESCRIPTION
## Summary
When a Dataverse read returns `@odata.count > 0` but no rows in the page (`data.length === 0`), the fetch path previously threw `EMPTY_RESPONSE`. That throw was caught by the inner `catch` in `fetchFromDataverseAndCreateFiles` and logged as `webExtensionFetchDataverseCreateFilesSystemError` so a benign empty-response condition was being counted as a **system error**, inflating read-failure counts in reliability telemetry (~2.5K/month).

## Change
- Replace the `throw` with an **info-level** telemetry event `WEB_EXTENSION_EMPTY_DATAVERSE_RESPONSE` and `break` out of the paging loop.
- Preserves the exact original behavior: same loop-abort, same empty return value, no user-facing dialog (the old throw never surfaced one it was swallowed by the inner catch).
- Removes the now-unused `EMPTY_RESPONSE` / `EMPTY_RESPONSE_DESC` constants.

## Behavior impact
**No functional or user-visible change.** The only difference is telemetry classification: this case moves from a reliability **system error** to an **info** observation. Control flow, return value, and file-creation are identical.

## Files
- `src/web/client/dal/remoteFetchProvider.ts` info log + break instead of throw
- `src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts` new `WEB_EXTENSION_EMPTY_DATAVERSE_RESPONSE` event
- `src/common/ErrorConstants.ts` remove orphaned constants