### PR TITLE
Add token-refresh + retry on HTTP 401 for Read and Save

### DIFF
--- a/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts
+++ b/src/common/OneDSLoggerTelemetry/web/client/webExtensionTelemetryEvents.ts
@@ -136,5 +136,6 @@ export enum webExtensionTelemetryEventNames {
     WEB_EXTENSION_WEBFILE_NOT_FOUND = "WebExtensionWebfileNotFound",
     WEB_EXTENSION_SERVERLOGIC_NOT_FOUND = "WebExtensionServerlogicNotFound",
     WEB_EXTENSION_OPTIONAL_ENTITY_NOT_FOUND = "WebExtensionOptionalEntityNotFound",
-    WEB_EXTENSION_EMPTY_DATAVERSE_RESPONSE = "WebExtensionEmptyDataverseResponse"
+    WEB_EXTENSION_EMPTY_DATAVERSE_RESPONSE = "WebExtensionEmptyDataverseResponse",
+    WEB_EXTENSION_TOKEN_REFRESH_RETRY = "WebExtensionTokenRefreshRetry"
 }

--- a/src/web/client/WebExtensionContext.ts
+++ b/src/web/client/WebExtensionContext.ts
@@ -126,6 +126,7 @@ class WebExtensionContext implements IWebExtensionContext {
     private _extensionActivationTime: number;
     private _extensionUri: vscode.Uri;
     private _dataverseAccessToken: string;
+    private _dataverseTokenRefreshPromise?: Promise<string>;
     private _entityDataMap: EntityDataMap;
     private _entityForeignKeyDataMap: EntityForeignKeyDataMap;
     private _isContextSet: boolean;
@@ -516,6 +517,34 @@ class WebExtensionContext implements IWebExtensionContext {
 
     public getWebpageNames() {
         return this._webpageNames;
+    }
+
+    /**
+     * Refreshes the Dataverse access token, de-duplicating concurrent callers so
+     * that many simultaneous 401 responses trigger only a single token acquisition.
+     *
+     * Used by the request path to recover from token-expiry (HTTP 401) without
+     * looping: it returns the freshly acquired token, or an empty string if the
+     * refresh failed (so callers can fail-fast instead of retrying indefinitely).
+     *
+     * @returns The refreshed Dataverse access token, or "" on failure.
+     */
+    public async refreshDataverseToken(): Promise<string> {
+        if (!this._dataverseTokenRefreshPromise) {
+            this._dataverseTokenRefreshPromise = (async () => {
+                try {
+                    await this.dataverseAuthentication();
+                    return this._dataverseAccessToken;
+                } catch {
+                    // dataverseAuthentication throws when no token could be acquired.
+                    // Swallow here so the 401 retry path can fail-fast rather than crash.
+                    return "";
+                } finally {
+                    this._dataverseTokenRefreshPromise = undefined;
+                }
+            })();
+        }
+        return this._dataverseTokenRefreshPromise;
     }
 
     public async updateFileDetailsInContext(

--- a/src/web/client/dal/concurrencyHandler.ts
+++ b/src/web/client/dal/concurrencyHandler.ts
@@ -32,7 +32,11 @@ export class ConcurrencyHandler {
 
     private _wrappedPolicy = wrap(this._retryPolicy, this._bulkhead);
 
-    public async handleRequest(requestInfo: RequestInfo, requestInit?: RequestInit) {
+    public async handleRequest(
+        requestInfo: RequestInfo,
+        requestInit?: RequestInit,
+        onUnauthorized?: () => Promise<string>
+    ) {
         let retryCount = 0;
 
         try {
@@ -47,7 +51,32 @@ export class ConcurrencyHandler {
                         }
                     );
                 }
-                return fetch(requestInfo, requestInit);
+
+                let response = await fetch(requestInfo, requestInit);
+
+                // node-fetch resolves (does not throw) on HTTP 401, so the retry
+                // policy above never sees it. Handle token-expiry here: refresh the
+                // token once, rebuild only the Authorization header, and re-issue the
+                // request a single time. Fail-fast (return the 401) if the refresh
+                // yields no token or the retried request still 401s — no refresh loop.
+                if (response.status === 401 && onUnauthorized) {
+                    const newToken = await onUnauthorized();
+                    if (newToken) {
+                        WebExtensionContext.telemetry.sendInfoTelemetry(
+                            webExtensionTelemetryEventNames.WEB_EXTENSION_TOKEN_REFRESH_RETRY,
+                            {
+                                url: typeof requestInfo === 'string' ? requestInfo : String(requestInfo)
+                            }
+                        );
+                        const headers = {
+                            ...(requestInit?.headers as Record<string, string>),
+                            authorization: "Bearer " + newToken,
+                        };
+                        response = await fetch(requestInfo, { ...requestInit, headers });
+                    }
+                }
+
+                return response;
             });
         } catch (e) {
             if (e instanceof BulkheadRejectedError) {

--- a/src/web/client/dal/remoteFetchProvider.ts
+++ b/src/web/client/dal/remoteFetchProvider.ts
@@ -131,7 +131,7 @@ async function fetchFromDataverseAndCreateFiles(
                     ),
                     Prefer: `odata.maxpagesize=${Constants.MAX_ENTITY_FETCH_COUNT}, odata.include-annotations="Microsoft.Dynamics.CRM.*"`,
                 },
-            });
+            }, () => WebExtensionContext.refreshDataverseToken());
 
             // Gracefully handle 400/404 for optional entities (blogs, forums, ideas)
             // These entities may not be provisioned for all sites
@@ -666,7 +666,7 @@ async function fetchMappingEntityContent(
 
     const response = await WebExtensionContext.concurrencyHandler.handleRequest(requestUrl, {
         headers: getCommonHeadersForDataverse(accessToken),
-    });
+    }, () => WebExtensionContext.refreshDataverseToken());
 
     // Gracefully handle 404 for optional entities (deleted/moved files or missing server logic)
     const notFoundTelemetryMap = new Map<string, string>([

--- a/src/web/client/dal/remoteSaveProvider.ts
+++ b/src/web/client/dal/remoteSaveProvider.ts
@@ -198,7 +198,8 @@ async function saveDataToDataverse(
             );
             const response = await WebExtensionContext.concurrencyHandler.handleRequest(
                 saveCallParameters.requestUrl,
-                saveCallParameters.requestInit
+                saveCallParameters.requestInit,
+                () => WebExtensionContext.refreshDataverseToken()
             );
 
             if (!response.ok) {

--- a/src/web/client/services/etagHandlerService.ts
+++ b/src/web/client/services/etagHandlerService.ts
@@ -76,8 +76,11 @@ export class EtagHandlerService {
                 webExtensionTelemetryEventNames.WEB_EXTENSION_ETAG_HANDLER_SERVICE
             );
 
-            await WebExtensionContext.dataverseAuthentication();
-            const response = await WebExtensionContext.concurrencyHandler.handleRequest(requestUrl, requestInit);
+            const response = await WebExtensionContext.concurrencyHandler.handleRequest(
+                requestUrl,
+                requestInit,
+                () => WebExtensionContext.refreshDataverseToken()
+            );
 
             if (response.ok) {
                 const result = await response.json();
@@ -170,8 +173,11 @@ export class EtagHandlerService {
                 this.updateFileEtag.name
             );
 
-            await WebExtensionContext.dataverseAuthentication();
-            const response = await WebExtensionContext.concurrencyHandler.handleRequest(requestUrl, requestInit);
+            const response = await WebExtensionContext.concurrencyHandler.handleRequest(
+                requestUrl,
+                requestInit,
+                () => WebExtensionContext.refreshDataverseToken()
+            );
 
             if (response.ok) {
                 const result = await response.json();

--- a/src/web/client/test/integration/WebExtensionContext.test.ts
+++ b/src/web/client/test/integration/WebExtensionContext.test.ts
@@ -155,6 +155,70 @@ describe("WebExtensionContext", () => {
         expect(WebExtensionContext.dataverseAccessToken).eq(accessToken);
     });
 
+    it("refreshDataverseToken_whenCalled_shouldReturnFreshTokenAndUpdateStoredToken", async () => {
+        const accessToken = "refreshed-token-value";
+        stub(vscode.authentication, "getSession").resolves({
+            accessToken: accessToken,
+        } as vscode.AuthenticationSession);
+        const entityId = "3355d5ec-b38d-46ca-a150-c00386b0a4be";
+        const queryParamsMap = new Map<string, string>([
+            [Constants.queryParameters.ORG_ID, "e5dce21c-f85f-4849-b699-920c0fad5fbf"]
+        ]);
+        stub(authenticationProvider, "dataverseAuthentication").resolves(
+            { accessToken: accessToken, userId: "" }
+        );
+        WebExtensionContext.setWebExtensionContext("webPages", entityId, queryParamsMap);
+
+        const token = await WebExtensionContext.refreshDataverseToken();
+
+        expect(token).eq(accessToken);
+        expect(WebExtensionContext.dataverseAccessToken).eq(accessToken);
+    });
+
+    it("refreshDataverseToken_whenCalledConcurrently_shouldAcquireTokenOnlyOnce", async () => {
+        const accessToken = "de-duped-token";
+        stub(vscode.authentication, "getSession").resolves({
+            accessToken: accessToken,
+        } as vscode.AuthenticationSession);
+        const entityId = "3355d5ec-b38d-46ca-a150-c00386b0a4be";
+        const queryParamsMap = new Map<string, string>([
+            [Constants.queryParameters.ORG_ID, "e5dce21c-f85f-4849-b699-920c0fad5fbf"]
+        ]);
+        const dataverseAuthentication = stub(authenticationProvider, "dataverseAuthentication").resolves(
+            { accessToken: accessToken, userId: "" }
+        );
+        WebExtensionContext.setWebExtensionContext("webPages", entityId, queryParamsMap);
+
+        const [t1, t2, t3] = await Promise.all([
+            WebExtensionContext.refreshDataverseToken(),
+            WebExtensionContext.refreshDataverseToken(),
+            WebExtensionContext.refreshDataverseToken(),
+        ]);
+
+        expect(t1).eq(accessToken);
+        expect(t2).eq(accessToken);
+        expect(t3).eq(accessToken);
+        assert.calledOnce(dataverseAuthentication);
+    });
+
+    it("refreshDataverseToken_whenAuthenticationFails_shouldReturnEmptyString", async () => {
+        stub(vscode.authentication, "getSession").resolves({
+            accessToken: "",
+        } as vscode.AuthenticationSession);
+        const entityId = "3355d5ec-b38d-46ca-a150-c00386b0a4be";
+        const queryParamsMap = new Map<string, string>([
+            [Constants.queryParameters.ORG_ID, "e5dce21c-f85f-4849-b699-920c0fad5fbf"]
+        ]);
+        stub(authenticationProvider, "dataverseAuthentication").resolves({ accessToken: "", userId: "" });
+        stub(WebExtensionContext.telemetry, "sendErrorTelemetry");
+        stub(vscode.FileSystemError, "NoPermissions").returns(new Error("no permissions") as vscode.FileSystemError);
+        WebExtensionContext.setWebExtensionContext("webPages", entityId, queryParamsMap);
+
+        const token = await WebExtensionContext.refreshDataverseToken();
+
+        expect(token).eq("");
+    });
+
     it("updateFileDetailsInContext_whenPassAllParams_shouldSetFileDataMap", async () => {
         //Act
         const attributePaths = {

--- a/src/web/client/test/integration/concurrencyHandler.test.ts
+++ b/src/web/client/test/integration/concurrencyHandler.test.ts
@@ -80,4 +80,87 @@ describe("ConcurrencyHandler", () => {
             assert.calledWith(fetchStub, "https://test.com/api", requestInit);
         });
     });
+
+    describe("handleRequest 401 token refresh", () => {
+        it("should refresh token and retry once on 401, returning the retried success", async () => {
+            const unauthorized = { ok: false, status: 401 };
+            const success = { ok: true, status: 200 };
+            const fetchStub = stub(fetch, "default")
+                .onFirstCall().resolves(unauthorized as unknown as fetch.Response)
+                .onSecondCall().resolves(success as unknown as fetch.Response);
+            const onUnauthorized = stub().resolves("fresh-token");
+
+            const handler = new ConcurrencyHandler();
+            const requestInit = { headers: { authorization: "Bearer stale-token", "content-type": "application/json" } };
+            const result = await handler.handleRequest("https://test.com/api", requestInit, onUnauthorized);
+
+            expect(result).to.equal(success);
+            assert.calledOnce(onUnauthorized);
+            assert.calledTwice(fetchStub);
+            // Retried request must carry the refreshed token while preserving other headers.
+            const retriedInit = fetchStub.getCall(1).args[1] as { headers: Record<string, string> };
+            expect(retriedInit.headers.authorization).to.equal("Bearer fresh-token");
+            expect(retriedInit.headers["content-type"]).to.equal("application/json");
+        });
+
+        it("should not loop when the retried request also returns 401", async () => {
+            const unauthorized = { ok: false, status: 401 };
+            const fetchStub = stub(fetch, "default").resolves(unauthorized as unknown as fetch.Response);
+            const onUnauthorized = stub().resolves("fresh-token");
+
+            const handler = new ConcurrencyHandler();
+            const result = await handler.handleRequest(
+                "https://test.com/api",
+                { headers: { authorization: "Bearer stale-token" } },
+                onUnauthorized
+            );
+
+            expect((result as unknown as { status: number }).status).to.equal(401);
+            assert.calledOnce(onUnauthorized);
+            assert.calledTwice(fetchStub);
+        });
+
+        it("should fail-fast (no retry) when refresh returns an empty token", async () => {
+            const unauthorized = { ok: false, status: 401 };
+            const fetchStub = stub(fetch, "default").resolves(unauthorized as unknown as fetch.Response);
+            const onUnauthorized = stub().resolves("");
+
+            const handler = new ConcurrencyHandler();
+            const result = await handler.handleRequest(
+                "https://test.com/api",
+                { headers: { authorization: "Bearer stale-token" } },
+                onUnauthorized
+            );
+
+            expect((result as unknown as { status: number }).status).to.equal(401);
+            assert.calledOnce(onUnauthorized);
+            assert.calledOnce(fetchStub);
+        });
+
+        it("should return 401 as-is when no onUnauthorized provider is supplied (back-compat)", async () => {
+            const unauthorized = { ok: false, status: 401 };
+            const fetchStub = stub(fetch, "default").resolves(unauthorized as unknown as fetch.Response);
+
+            const handler = new ConcurrencyHandler();
+            const result = await handler.handleRequest("https://test.com/api", {
+                headers: { authorization: "Bearer stale-token" },
+            });
+
+            expect((result as unknown as { status: number }).status).to.equal(401);
+            assert.calledOnce(fetchStub);
+        });
+
+        it("should not invoke the provider on a successful first response", async () => {
+            const success = { ok: true, status: 200 };
+            const fetchStub = stub(fetch, "default").resolves(success as unknown as fetch.Response);
+            const onUnauthorized = stub().resolves("fresh-token");
+
+            const handler = new ConcurrencyHandler();
+            const result = await handler.handleRequest("https://test.com/api", undefined, onUnauthorized);
+
+            expect(result).to.equal(success);
+            assert.notCalled(onUnauthorized);
+            assert.calledOnce(fetchStub);
+        });
+    });
 });


### PR DESCRIPTION
Adds reactive token refresh and single retry on HTTP 401 for the VS Code Web extension's Dataverse read and save paths. Long-running Web sessions previously failed file open/save operations with `401 Unauthorized` once the Dataverse access token expired mid-session. The failed request was not transparently retried, resulting in a spurious error being surfaced to the user.

<br>

### What changed

• `ConcurrencyHandler.handleRequest` intercepts `status === 401` (node-fetch resolves rather than throws, so the cockatiel retry policy never saw it), calls an optional `onUnauthorized()` callback to refresh the token, rebuilds only the `Authorization` header, and reissues the request once. It fails fast if the refresh yields no token or if the retry still returns `401`; there is no refresh loop.

• `WebExtensionContext.refreshDataverseToken` de-duplicates concurrent refreshes via a shared in-flight promise and returns the fresh token or `""` on failure.

• Wired into `etagHandlerService` (read), `remoteFetchProvider` (read ×2), and `remoteSaveProvider` (save). Emits `WebExtensionTokenRefreshRetry` telemetry.

<br>

### Reliability impact (30-day production telemetry, EUR + NAM)

Baseline: 6.18M requests, 145,749 failures (2.36%). `401` errors account for 33,986 failures (23.3% of all failures), impacting 3,972 users, 2,699 tenants, and 17,432 sessions.

• 92.6% of `401` errors are recoverable, meaning approximately 31,500 failures per month become transparent successes.

• Failure rate improves from 2.36% to 1.85% (21.6% relative reduction), with `401` failures reduced by 92.6%.

• The remaining ~7.4% represent genuine authentication failures and continue to fail fast and surface appropriately.

<br>

### Tests

`concurrencyHandler.test.ts` (refresh + retry, no-loop, fail-fast, backward compatibility, header preservation) and `WebExtensionContext.test.ts` (refresh de-duplication, empty-token-on-failure).

<br>

### Backward compatibility

Callers that do not provide `onUnauthorized` are unaffected (guarded path). The retry executes within the same cockatiel `execute()` call, consumes no additional bulkhead slot, and is not counted as a policy retry attempt.