### PR TITLE
URI handler (1/3): route-map refactor + deep-link constants

### DIFF
--- a/src/client/test/integration/uriHandler.test.ts
+++ b/src/client/test/integration/uriHandler.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { UriHandler } from "../../uriHandler/uriHandler";
+import { URI_CONSTANTS } from "../../uriHandler/constants/uriConstants";
+import { PacWrapper } from "../../pac/PacWrapper";
+
+// Shape used to stub the private route targets on the prototype without resorting to `any`.
+type UriHandlerRoutes = {
+    pcfInit: () => Promise<void>;
+    handleOpenPowerPages: (uri: vscode.Uri) => Promise<void>;
+};
+
+describe("UriHandler routing", () => {
+    let sandbox: sinon.SinonSandbox;
+    let pcfInitStub: sinon.SinonStub;
+    let openStub: sinon.SinonStub;
+    let handler: UriHandler;
+
+    const makeUri = (path: string): vscode.Uri =>
+        vscode.Uri.parse(`vscode://${URI_CONSTANTS.EXTENSION_ID}${path}`);
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        const prototype = UriHandler.prototype as unknown as UriHandlerRoutes;
+        pcfInitStub = sandbox.stub(prototype, "pcfInit").resolves();
+        openStub = sandbox.stub(prototype, "handleOpenPowerPages").resolves();
+        handler = new UriHandler({} as PacWrapper);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("dispatches /pcfInit to the PCF init handler", async () => {
+        await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.PCF_INIT));
+
+        expect(pcfInitStub.calledOnce).to.be.true;
+        expect(openStub.called).to.be.false;
+    });
+
+    it("dispatches /open to the open Power Pages handler", async () => {
+        await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.OPEN));
+
+        expect(openStub.calledOnce).to.be.true;
+        expect(pcfInitStub.called).to.be.false;
+    });
+
+    it("ignores reserved deep-link paths that are not yet wired up", async () => {
+        await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.AGENTIC_CREATE));
+        await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.PAC_CREATE));
+
+        expect(pcfInitStub.called).to.be.false;
+        expect(openStub.called).to.be.false;
+    });
+
+    it("ignores unknown paths without throwing", async () => {
+        await handler.handleUri(makeUri("/someUnknownPath"));
+
+        expect(pcfInitStub.called).to.be.false;
+        expect(openStub.called).to.be.false;
+    });
+});

--- a/src/client/test/unit/uriConstants.test.ts
+++ b/src/client/test/unit/uriConstants.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import { URI_CONSTANTS } from "../../uriHandler/constants/uriConstants";
+
+// These constants form the versioned deep-link contract between the Power Pages
+// home page and the VS Code extension. They are asserted here so that any accidental
+// rename or removal is caught before it can break an already-shipped deep link.
+describe("URI_CONSTANTS deep-link contract", () => {
+    it("keeps the existing open and pcfInit paths unchanged", () => {
+        expect(URI_CONSTANTS.PATHS.PCF_INIT).to.equal("/pcfInit");
+        expect(URI_CONSTANTS.PATHS.OPEN).to.equal("/open");
+    });
+
+    it("registers the agentic and PAC create paths", () => {
+        expect(URI_CONSTANTS.PATHS.AGENTIC_CREATE).to.equal("/agenticCreate");
+        expect(URI_CONSTANTS.PATHS.PAC_CREATE).to.equal("/pacCreate");
+    });
+
+    it("exposes the shared context parameter names", () => {
+        expect(URI_CONSTANTS.PARAMETERS.ENV_ID).to.equal("envid");
+        expect(URI_CONSTANTS.PARAMETERS.ORG_URL).to.equal("orgurl");
+        expect(URI_CONSTANTS.PARAMETERS.REGION).to.equal("region");
+        expect(URI_CONSTANTS.PARAMETERS.TENANT_ID).to.equal("tenantid");
+        expect(URI_CONSTANTS.PARAMETERS.SOURCE).to.equal("source");
+        expect(URI_CONSTANTS.PARAMETERS.AGENT_HOST).to.equal("agenthost");
+        expect(URI_CONSTANTS.PARAMETERS.VERSION).to.equal("v");
+    });
+
+    it("defines the versioned contract and known enumerated values", () => {
+        expect(URI_CONSTANTS.CONTRACT_VERSION.CURRENT).to.equal("1");
+        expect(URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME).to.equal("powerPagesHome");
+        expect(URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT).to.equal("copilot");
+        expect(URI_CONSTANTS.AGENT_HOST_VALUES.CLAUDE).to.equal("claude");
+        expect(URI_CONSTANTS.AGENT_HOST_VALUES.AUTO).to.equal("auto");
+    });
+});

--- a/src/client/uriHandler/constants/uriConstants.ts
+++ b/src/client/uriHandler/constants/uriConstants.ts
@@ -10,7 +10,9 @@ export const URI_CONSTANTS = {
     EXTENSION_ID: 'microsoft-IsvExpTools.powerplatform-vscode',
     PATHS: {
         PCF_INIT: '/pcfInit',
-        OPEN: '/open'
+        OPEN: '/open',
+        AGENTIC_CREATE: '/agenticCreate',
+        PAC_CREATE: '/pacCreate'
     },
     PARAMETERS: {
         WEBSITE_ID: 'websiteid',
@@ -20,10 +22,26 @@ export const URI_CONSTANTS = {
         SITE_NAME: 'sitename',
         WEBSITE_NAME: 'websitename',
         SITE_URL: 'siteurl',
-        WEBSITE_PREVIEW_URL: 'websitepreviewurl'
+        WEBSITE_PREVIEW_URL: 'websitepreviewurl',
+        REGION: 'region',
+        TENANT_ID: 'tenantid',
+        SOURCE: 'source',
+        AGENT_HOST: 'agenthost',
+        VERSION: 'v'
     },
     SCHEMA_VALUES: {
         PORTAL_SCHEMA_V2: 'portalschemav2'
+    },
+    SOURCE_VALUES: {
+        POWER_PAGES_HOME: 'powerPagesHome'
+    },
+    AGENT_HOST_VALUES: {
+        COPILOT: 'copilot',
+        CLAUDE: 'claude',
+        AUTO: 'auto'
+    },
+    CONTRACT_VERSION: {
+        CURRENT: '1'
     },
     MODEL_VERSIONS: {
         VERSION_1: 1,
@@ -40,4 +58,6 @@ export const URI_CONSTANTS = {
 export const enum UriPath {
     PcfInit = '/pcfInit',
     Open = '/open',
+    AgenticCreate = '/agenticCreate',
+    PacCreate = '/pacCreate',
 }

--- a/src/client/uriHandler/uriHandler.ts
+++ b/src/client/uriHandler/uriHandler.ts
@@ -11,16 +11,34 @@ import { URI_HANDLER_STRINGS } from "./constants/uriStrings";
 import { uriHandlerTelemetryEventNames } from "./telemetry/uriHandlerTelemetryEvents";
 import { UriHandlerUtils, UriParameters } from "./utils/uriHandlerUtils";
 
+/**
+ * Signature for a deep-link route handler. Each registered URI path maps to one handler.
+ */
+type UriRouteHandler = (uri: vscode.Uri) => Promise<void>;
+
 export function RegisterUriHandler(pacWrapper: PacWrapper): vscode.Disposable {
     const uriHandler = new UriHandler(pacWrapper);
     return vscode.window.registerUriHandler(uriHandler);
 }
 
-class UriHandler implements vscode.UriHandler {
+export class UriHandler implements vscode.UriHandler {
     private readonly pacWrapper: PacWrapper;
+    private readonly routes: ReadonlyMap<string, UriRouteHandler>;
 
     constructor(pacWrapper: PacWrapper) {
         this.pacWrapper = pacWrapper;
+        this.routes = this.buildRoutes();
+    }
+
+    /**
+     * Builds the deep-link routing table (URI path -> handler). Register new deep-link
+     * paths here so `handleUri` can dispatch to them.
+     */
+    private buildRoutes(): ReadonlyMap<string, UriRouteHandler> {
+        return new Map<string, UriRouteHandler>([
+            [UriPath.PcfInit, () => this.pcfInit()],
+            [UriPath.Open, (uri) => this.handleOpenPowerPages(uri)],
+        ]);
     }
 
     // URIs targeting our extension are in the format
@@ -28,11 +46,14 @@ class UriHandler implements vscode.UriHandler {
     // vscode://microsoft-IsvExpTools.powerplatform-vscode/pcfInit
     // vscode://microsoft-IsvExpTools.powerplatform-vscode/open?websiteid=xxx&envid=yyy&orgurl=zzz&schema=PortalSchemaV2
     public async handleUri(uri: vscode.Uri): Promise<void> {
-        if (uri.path === UriPath.PcfInit) {
-            return this.pcfInit();
-        } else if (uri.path === UriPath.Open) {
-            return this.handleOpenPowerPages(uri);
+        const route = this.routes.get(uri.path);
+        if (route) {
+            await route(uri);
+            return;
         }
+        // Unrecognized paths are intentionally ignored for forward compatibility. Reserved
+        // deep-link paths (URI_CONSTANTS.PATHS.AGENTIC_CREATE / PAC_CREATE) will be wired up
+        // in a follow-up change.
     }
 
     async pcfInit(): Promise<void> {


### PR DESCRIPTION
**PR 1 of 3 — Phase 0–1 foundation for the Power Pages → VS Code "create" deep links.** Behavior-preserving refactor; no user-facing change.

## Why
We're adding two new deep links launched from the **Power Pages home page** that open VS Code into a create experience:
- `vscode://…/agenticCreate` — agentic flow (terminal CLI agent host carrying the Power Pages plugin)
- `vscode://…/pacCreate` — PAC CLI flow

Before wiring any of that behavior, this PR lays the routing + contract foundation so the follow-ups stay small and reviewable. Everything in the full effort ships **dark** (ECS-gated, off by default); this PR alone changes no behavior at all.

## What changed
- **`uriHandler/uriHandler.ts`** — replaced the `handleUri` `if/else` chain with a `ReadonlyMap<string, UriRouteHandler>` route table built in the constructor and dispatched by `uri.path`. Unknown paths are a no-op (forward-compatible). Exported the `UriHandler` class so it's unit-addressable. `/open` and `/pcfInit` dispatch to the exact same code as before.
- **`uriHandler/constants/uriConstants.ts`** — added the versioned, secret-free deep-link contract: new paths (`/agenticCreate`, `/pacCreate`), params (`region`, `tenantid`, `source`, `agenthost`, `v`), value/version constants (`SOURCE_VALUES`, `AGENT_HOST_VALUES`, `CONTRACT_VERSION`), and the matching `UriPath` enum members. No handlers consume the new paths yet.

## Tests
- **`test/unit/uriConstants.test.ts`** (new) — pure/no-`vscode` unit coverage of the contract constants.
- **`test/integration/uriHandler.test.ts`** (new) — asserts `/open` and `/pcfInit` still route to their handlers and unknown paths are ignored.

## Design notes
- The `vscode://` URL is treated as a **versioned contract** (`v=1`) so the Power Pages home page and the extension can evolve independently.
- Route-map dispatch makes adding a path a one-line registration (used by PRs 2–3) instead of growing a conditional.

## Validation
`gulp lint` clean · `compile-tests` clean · `npm test` **106 passing** · `npm run build` OK.

## Risk / rollout
Effectively zero: no new path is wired to behavior in this PR, and the two existing paths are dispatched identically. New paths become active only in PR 3, behind ECS gates that default **off**.

## Stack (merge in order)
1. **this PR (#1625)** → `main` — router refactor + deep-link constants
2. #1626 → auth/environment service extraction
3. #1627 → dark, ECS-gated create handlers + telemetry

> Branches are pushed from the fork `amitjoshi438/powerplatform-vscode`; since intermediate branches can't be pushed upstream, #1626/#1627 target `main` and show cumulative diffs until earlier PRs merge (each body names its focus commit). They auto-rebase to a clean single-commit diff and flip to *ready* once the preceding PR merges.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>