### PR TITLE
URI handler (2/3): extract shared auth/environment service

### DIFF
--- a/src/client/test/integration/authEnvironment.test.ts
+++ b/src/client/test/integration/authEnvironment.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { AuthEnvironmentService } from "../../uriHandler/utils/authEnvironment";
+import { UriParameters } from "../../uriHandler/utils/uriHandlerUtils";
+import { PacWrapper } from "../../pac/PacWrapper";
+
+type ProgressReporter = vscode.Progress<{ message?: string; increment?: number }>;
+type ProgressTask = (progress: ProgressReporter, token: vscode.CancellationToken) => Thenable<void>;
+
+// Minimal stubbed surface of PacWrapper that the service depends on.
+interface PacWrapperStub {
+    activeOrg: sinon.SinonStub;
+    orgSelect: sinon.SinonStub;
+    authCreateNewAuthProfileForOrg: sinon.SinonStub;
+    resetPacProcess: sinon.SinonStub;
+}
+
+describe("AuthEnvironmentService", () => {
+    let sandbox: sinon.SinonSandbox;
+    let pacWrapperStub: PacWrapperStub;
+    let service: AuthEnvironmentService;
+    let warningStub: sinon.SinonStub;
+
+    const uriParams = {
+        environmentId: "env-1",
+        orgUrl: "https://org.crm.dynamics.com/"
+    } as unknown as UriParameters;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        pacWrapperStub = {
+            activeOrg: sandbox.stub(),
+            orgSelect: sandbox.stub().resolves(),
+            authCreateNewAuthProfileForOrg: sandbox.stub().resolves(),
+            resetPacProcess: sandbox.stub().resolves()
+        };
+
+        // Run the progress task immediately with a no-op reporter.
+        sandbox.stub(vscode.window, "withProgress").callsFake(
+            ((_options: vscode.ProgressOptions, task: ProgressTask): Thenable<void> =>
+                task({ report: () => undefined }, new vscode.CancellationTokenSource().token)
+            ) as unknown as typeof vscode.window.withProgress
+        );
+
+        warningStub = sandbox.stub(vscode.window, "showWarningMessage");
+        sandbox.stub(vscode.window, "showInformationMessage");
+
+        service = new AuthEnvironmentService(pacWrapperStub as unknown as PacWrapper);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("does not prompt when already authenticated to the requested environment", async () => {
+        pacWrapperStub.activeOrg.resolves({
+            Status: "Success",
+            Results: { EnvironmentId: "env-1" }
+        });
+
+        await service.prepareAuthenticationAndEnvironment(uriParams, {});
+
+        expect(warningStub.called).to.be.false;
+        expect(pacWrapperStub.orgSelect.called).to.be.false;
+        expect(pacWrapperStub.authCreateNewAuthProfileForOrg.called).to.be.false;
+    });
+
+    it("switches environment when the active org points at a different environment", async () => {
+        pacWrapperStub.activeOrg
+            .onFirstCall().resolves({ Status: "Success", Results: { EnvironmentId: "env-1" } })
+            .onSecondCall().resolves({ Status: "Success", Results: { EnvironmentId: "other-env" } })
+            .onThirdCall().resolves({ Status: "Success", Results: { EnvironmentId: "env-1" } });
+        warningStub.resolves("Yes");
+
+        await service.prepareAuthenticationAndEnvironment(uriParams, {});
+
+        expect(pacWrapperStub.orgSelect.calledOnceWith("https://org.crm.dynamics.com/")).to.be.true;
+    });
+
+    it("resetPacProcessSafely swallows reset errors", async () => {
+        pacWrapperStub.resetPacProcess.rejects(new Error("reset boom"));
+
+        await service.resetPacProcessSafely({});
+
+        expect(pacWrapperStub.resetPacProcess.calledOnce).to.be.true;
+    });
+
+    it("resetPacProcessAndThrow resets and rethrows the original error", async () => {
+        const original = new Error("boom");
+        let thrown: unknown;
+
+        try {
+            await service.resetPacProcessAndThrow(original, {}, "message", "error_type");
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).to.equal(original);
+        expect(pacWrapperStub.resetPacProcess.calledOnce).to.be.true;
+    });
+});

--- a/src/client/test/integration/uriHandler.test.ts
+++ b/src/client/test/integration/uriHandler.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { UriHandler } from "../../uriHandler/uriHandler";
+import { URI_CONSTANTS } from "../../uriHandler/constants/uriConstants";
+import { PacWrapper } from "../../pac/PacWrapper";
+
+// Shape used to stub the private route targets on the prototype without resorting to `any`.
+type UriHandlerRoutes = {
+    pcfInit: () => Promise<void>;
+    handleOpenPowerPages: (uri: vscode.Uri) => Promise<void>;
+};
+
+describe("UriHandler routing", () => {
+    let sandbox: sinon.SinonSandbox;
+    let pcfInitStub: sinon.SinonStub;
+    let openStub: sinon.SinonStub;
+    let handler: UriHandler;
+
+    const makeUri = (path: string): vscode.Uri =>
+        vscode.Uri.parse(`vscode://${URI_CONSTANTS.EXTENSION_ID}${path}`);
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        const prototype = UriHandler.prototype as unknown as UriHandlerRoutes;
+        pcfInitStub = sandbox.stub(prototype, "pcfInit").resolves();
+        openStub = sandbox.stub(prototype, "handleOpenPowerPages").resolves();
+        handler = new UriHandler({} as PacWrapper);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("dispatches /pcfInit to the PCF init handler", async () => {
+        await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.PCF_INIT));
+
+        expect(pcfInitStub.calledOnce).to.be.true;
+        expect(openStub.called).to.be.false;
+    });
+
+    it("dispatches /open to the open Power Pages handler", async () => {
+        await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.OPEN));
+
+        expect(openStub.calledOnce).to.be.true;
+        expect(pcfInitStub.called).to.be.false;
+    });
+
+    it("ignores reserved deep-link paths that are not yet wired up", async () => {
+        await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.AGENTIC_CREATE));
+        await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.PAC_CREATE));
+
+        expect(pcfInitStub.called).to.be.false;
+        expect(openStub.called).to.be.false;
+    });
+
+    it("ignores unknown paths without throwing", async () => {
+        await handler.handleUri(makeUri("/someUnknownPath"));
+
+        expect(pcfInitStub.called).to.be.false;
+        expect(openStub.called).to.be.false;
+    });
+});

--- a/src/client/test/unit/uriConstants.test.ts
+++ b/src/client/test/unit/uriConstants.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import { URI_CONSTANTS } from "../../uriHandler/constants/uriConstants";
+
+// These constants form the versioned deep-link contract between the Power Pages
+// home page and the VS Code extension. They are asserted here so that any accidental
+// rename or removal is caught before it can break an already-shipped deep link.
+describe("URI_CONSTANTS deep-link contract", () => {
+    it("keeps the existing open and pcfInit paths unchanged", () => {
+        expect(URI_CONSTANTS.PATHS.PCF_INIT).to.equal("/pcfInit");
+        expect(URI_CONSTANTS.PATHS.OPEN).to.equal("/open");
+    });
+
+    it("registers the agentic and PAC create paths", () => {
+        expect(URI_CONSTANTS.PATHS.AGENTIC_CREATE).to.equal("/agenticCreate");
+        expect(URI_CONSTANTS.PATHS.PAC_CREATE).to.equal("/pacCreate");
+    });
+
+    it("exposes the shared context parameter names", () => {
+        expect(URI_CONSTANTS.PARAMETERS.ENV_ID).to.equal("envid");
+        expect(URI_CONSTANTS.PARAMETERS.ORG_URL).to.equal("orgurl");
+        expect(URI_CONSTANTS.PARAMETERS.REGION).to.equal("region");
+        expect(URI_CONSTANTS.PARAMETERS.TENANT_ID).to.equal("tenantid");
+        expect(URI_CONSTANTS.PARAMETERS.SOURCE).to.equal("source");
+        expect(URI_CONSTANTS.PARAMETERS.AGENT_HOST).to.equal("agenthost");
+        expect(URI_CONSTANTS.PARAMETERS.VERSION).to.equal("v");
+    });
+
+    it("defines the versioned contract and known enumerated values", () => {
+        expect(URI_CONSTANTS.CONTRACT_VERSION.CURRENT).to.equal("1");
+        expect(URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME).to.equal("powerPagesHome");
+        expect(URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT).to.equal("copilot");
+        expect(URI_CONSTANTS.AGENT_HOST_VALUES.CLAUDE).to.equal("claude");
+        expect(URI_CONSTANTS.AGENT_HOST_VALUES.AUTO).to.equal("auto");
+    });
+});

--- a/src/client/uriHandler/constants/uriConstants.ts
+++ b/src/client/uriHandler/constants/uriConstants.ts
@@ -10,7 +10,9 @@ export const URI_CONSTANTS = {
     EXTENSION_ID: 'microsoft-IsvExpTools.powerplatform-vscode',
     PATHS: {
         PCF_INIT: '/pcfInit',
-        OPEN: '/open'
+        OPEN: '/open',
+        AGENTIC_CREATE: '/agenticCreate',
+        PAC_CREATE: '/pacCreate'
     },
     PARAMETERS: {
         WEBSITE_ID: 'websiteid',
@@ -20,10 +22,26 @@ export const URI_CONSTANTS = {
         SITE_NAME: 'sitename',
         WEBSITE_NAME: 'websitename',
         SITE_URL: 'siteurl',
-        WEBSITE_PREVIEW_URL: 'websitepreviewurl'
+        WEBSITE_PREVIEW_URL: 'websitepreviewurl',
+        REGION: 'region',
+        TENANT_ID: 'tenantid',
+        SOURCE: 'source',
+        AGENT_HOST: 'agenthost',
+        VERSION: 'v'
     },
     SCHEMA_VALUES: {
         PORTAL_SCHEMA_V2: 'portalschemav2'
+    },
+    SOURCE_VALUES: {
+        POWER_PAGES_HOME: 'powerPagesHome'
+    },
+    AGENT_HOST_VALUES: {
+        COPILOT: 'copilot',
+        CLAUDE: 'claude',
+        AUTO: 'auto'
+    },
+    CONTRACT_VERSION: {
+        CURRENT: '1'
     },
     MODEL_VERSIONS: {
         VERSION_1: 1,
@@ -40,4 +58,6 @@ export const URI_CONSTANTS = {
 export const enum UriPath {
     PcfInit = '/pcfInit',
     Open = '/open',
+    AgenticCreate = '/agenticCreate',
+    PacCreate = '/pacCreate',
 }

--- a/src/client/uriHandler/uriHandler.ts
+++ b/src/client/uriHandler/uriHandler.ts
@@ -10,6 +10,7 @@ import { UriPath } from "./constants/uriConstants";
 import { URI_HANDLER_STRINGS } from "./constants/uriStrings";
 import { uriHandlerTelemetryEventNames } from "./telemetry/uriHandlerTelemetryEvents";
 import { UriHandlerUtils, UriParameters } from "./utils/uriHandlerUtils";
+import { AuthEnvironmentService } from "./utils/authEnvironment";
 
 /**
  * Signature for a deep-link route handler. Each registered URI path maps to one handler.
@@ -24,9 +25,11 @@ export function RegisterUriHandler(pacWrapper: PacWrapper): vscode.Disposable {
 export class UriHandler implements vscode.UriHandler {
     private readonly pacWrapper: PacWrapper;
     private readonly routes: ReadonlyMap<string, UriRouteHandler>;
+    private readonly authEnvironmentService: AuthEnvironmentService;
 
     constructor(pacWrapper: PacWrapper) {
         this.pacWrapper = pacWrapper;
+        this.authEnvironmentService = new AuthEnvironmentService(pacWrapper);
         this.routes = this.buildRoutes();
     }
 
@@ -124,7 +127,7 @@ export class UriHandler implements vscode.UriHandler {
             this.validateRequiredParameters(uriParams, telemetryData);
 
             // Prepare authentication and environment
-            await this.prepareAuthenticationAndEnvironment(uriParams, telemetryData);
+            await this.authEnvironmentService.prepareAuthenticationAndEnvironment(uriParams, telemetryData);
 
             // Handle the download process
             await this.handleSiteDownload(uriParams, telemetryData, startTime);
@@ -231,170 +234,6 @@ export class UriHandler implements vscode.UriHandler {
     }
 
     /**
-     * Handle authentication and environment setup
-     */
-    private async prepareAuthenticationAndEnvironment(uriParams: UriParameters, telemetryData: Record<string, string>): Promise<void> {
-        await vscode.window.withProgress(
-            {
-                location: vscode.ProgressLocation.Notification,
-                title: URI_HANDLER_STRINGS.TITLES.POWER_PAGES,
-                cancellable: false
-            },
-            async (progress) => {
-                progress.report({
-                    message: URI_HANDLER_STRINGS.PROGRESS.PREPARING,
-                    increment: 10
-                });
-
-                progress.report({
-                    message: URI_HANDLER_STRINGS.PROGRESS.VALIDATING_AUTH,
-                    increment: 20
-                });
-
-                // Check and handle authentication
-                await this.ensureAuthentication(uriParams, telemetryData, progress);
-
-                progress.report({
-                    message: URI_HANDLER_STRINGS.PROGRESS.CHECKING_ENV,
-                    increment: 20
-                });
-
-                // Check and handle environment switching
-                await this.ensureCorrectEnvironment(uriParams, telemetryData, progress);
-
-                progress.report({
-                    message: URI_HANDLER_STRINGS.PROGRESS.READY_TO_SELECT,
-                    increment: 30
-                });
-
-                // Brief delay to let user see the final progress message
-                await new Promise(resolve => setTimeout(resolve, 500));
-            }
-        );
-    }
-
-    /**
-     * Ensure user is authenticated with PAC CLI
-     */
-    private async ensureAuthentication(uriParams: UriParameters, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
-        let authInfo;
-        try {
-            authInfo = await this.pacWrapper.activeOrg();
-        } catch (error) {
-            await this.resetPacProcessAndThrow(error, telemetryData, 'Failed to check authentication status', 'auth_check_failed');
-        }
-
-        if (!authInfo || authInfo.Status !== "Success") {
-            oneDSLoggerWrapper.getLogger().traceInfo(
-                uriHandlerTelemetryEventNames.URI_HANDLER_AUTH_REQUIRED,
-                { ...telemetryData, authStatus: authInfo?.Status || 'none' }
-            );
-
-            progress.report({
-                message: URI_HANDLER_STRINGS.PROGRESS.AUTH_REQUIRED,
-                increment: 10
-            });
-
-            const authRequired = await vscode.window.showWarningMessage(
-                URI_HANDLER_STRINGS.PROMPTS.AUTH_REQUIRED,
-                { modal: true },
-                URI_HANDLER_STRINGS.BUTTONS.YES,
-                URI_HANDLER_STRINGS.BUTTONS.NO
-            );
-
-            if (authRequired === URI_HANDLER_STRINGS.BUTTONS.YES) {
-                try {
-                    progress.report({
-                        message: URI_HANDLER_STRINGS.PROGRESS.AUTHENTICATING,
-                        increment: 10
-                    });
-
-                    await this.pacWrapper.authCreateNewAuthProfileForOrg(uriParams.orgUrl!);
-
-                    const newAuthInfo = await this.pacWrapper.activeOrg();
-                    if (!newAuthInfo || newAuthInfo.Status !== "Success") {
-                        throw new Error(URI_HANDLER_STRINGS.ERRORS.AUTH_FAILED);
-                    }
-
-                    oneDSLoggerWrapper.getLogger().traceInfo(
-                        uriHandlerTelemetryEventNames.URI_HANDLER_AUTH_COMPLETED,
-                        { ...telemetryData, newAuthStatus: newAuthInfo.Status }
-                    );
-                } catch (authError) {
-                    await this.resetPacProcessAndThrow(authError, telemetryData, 'Authentication operation failed', 'auth_operation_failed');
-                }
-            } else {
-                vscode.window.showInformationMessage(URI_HANDLER_STRINGS.INFO.DOWNLOAD_CANCELLED_AUTH);
-                oneDSLoggerWrapper.getLogger().traceInfo(
-                    uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
-                    { ...telemetryData, reason: 'user_cancelled_auth' }
-                );
-                throw new Error(URI_HANDLER_STRINGS.ERRORS.USER_CANCELLED_AUTH);
-            }
-        }
-    }
-
-    /**
-     * Ensure we're connected to the correct environment
-     */
-    private async ensureCorrectEnvironment(uriParams: UriParameters, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
-        let currentAuthInfo;
-        try {
-            currentAuthInfo = await this.pacWrapper.activeOrg();
-        } catch (error) {
-            await this.resetPacProcessAndThrow(error, telemetryData, 'Failed to check current environment', 'env_check_failed');
-        }
-
-        if (currentAuthInfo?.Status === "Success" && currentAuthInfo.Results?.EnvironmentId !== uriParams.environmentId) {
-            oneDSLoggerWrapper.getLogger().traceInfo(
-                uriHandlerTelemetryEventNames.URI_HANDLER_ENV_SWITCH_REQUIRED,
-                {
-                    ...telemetryData,
-                    currentEnvId: currentAuthInfo.Results?.EnvironmentId || 'unknown',
-                    requestedEnvId: uriParams.environmentId
-                }
-            );
-
-            const switchEnv = await vscode.window.showWarningMessage(
-                URI_HANDLER_STRINGS.PROMPTS.ENV_SWITCH_REQUIRED,
-                { modal: true },
-                URI_HANDLER_STRINGS.BUTTONS.YES,
-                URI_HANDLER_STRINGS.BUTTONS.NO
-            );
-
-            if (switchEnv === URI_HANDLER_STRINGS.BUTTONS.YES) {
-                try {
-                    progress.report({
-                        message: URI_HANDLER_STRINGS.PROGRESS.SWITCHING_ENV,
-                        increment: 10
-                    });
-
-                    await this.pacWrapper.orgSelect(uriParams.orgUrl!);
-
-                    const verifyAuthInfo = await this.pacWrapper.activeOrg();
-                    if (verifyAuthInfo?.Status !== "Success" || verifyAuthInfo.Results?.EnvironmentId !== uriParams.environmentId) {
-                        throw new Error(URI_HANDLER_STRINGS.ERRORS.ENV_SWITCH_FAILED);
-                    }
-
-                    oneDSLoggerWrapper.getLogger().traceInfo(
-                        uriHandlerTelemetryEventNames.URI_HANDLER_ENV_SWITCH_COMPLETED,
-                        { ...telemetryData, switchedToEnvId: verifyAuthInfo.Results?.EnvironmentId }
-                    );
-                } catch (error) {
-                    await this.resetPacProcessAndThrow(error, telemetryData, 'Error switching environment', 'env_switch_error');
-                }
-            } else {
-                vscode.window.showInformationMessage(URI_HANDLER_STRINGS.INFO.DOWNLOAD_CANCELLED_ENV);
-                oneDSLoggerWrapper.getLogger().traceInfo(
-                    uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
-                    { ...telemetryData, reason: 'user_cancelled_env_switch' }
-                );
-                throw new Error(URI_HANDLER_STRINGS.ERRORS.USER_CANCELLED_ENV_SWITCH);
-            }
-        }
-    }
-
-    /**
      * Handle the site download process
      */
     private async handleSiteDownload(uriParams: UriParameters, telemetryData: Record<string, string>, startTime: number): Promise<void> {
@@ -478,43 +317,8 @@ export class UriHandler implements vscode.UriHandler {
                 { ...telemetryData, error: 'download_failed' }
             );
 
-            await this.resetPacProcessSafely(telemetryData);
+            await this.authEnvironmentService.resetPacProcessSafely(telemetryData);
             throw error;
-        }
-    }
-
-    /**
-     * Reset PAC process and throw error
-     */
-    private async resetPacProcessAndThrow(error: unknown, telemetryData: Record<string, string>, message: string, errorType: string): Promise<never> {
-        oneDSLoggerWrapper.getLogger().traceError(
-            uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
-            message,
-            error instanceof Error ? error : new Error(String(error)),
-            { ...telemetryData, error: errorType }
-        );
-
-        await this.resetPacProcessSafely(telemetryData);
-        throw error;
-    }
-
-    /**
-     * Safely reset PAC process without throwing
-     */
-    private async resetPacProcessSafely(telemetryData: Record<string, string>): Promise<void> {
-        try {
-            await this.pacWrapper.resetPacProcess();
-            oneDSLoggerWrapper.getLogger().traceInfo(
-                uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
-                { ...telemetryData, message: 'PAC process reset after failure' }
-            );
-        } catch (resetError) {
-            oneDSLoggerWrapper.getLogger().traceError(
-                uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
-                'Failed to reset PAC process after failure',
-                resetError instanceof Error ? resetError : new Error(String(resetError)),
-                { ...telemetryData, error: 'pac_reset_failed' }
-            );
         }
     }
 

--- a/src/client/uriHandler/uriHandler.ts
+++ b/src/client/uriHandler/uriHandler.ts
@@ -11,16 +11,34 @@ import { URI_HANDLER_STRINGS } from "./constants/uriStrings";
 import { uriHandlerTelemetryEventNames } from "./telemetry/uriHandlerTelemetryEvents";
 import { UriHandlerUtils, UriParameters } from "./utils/uriHandlerUtils";
 
+/**
+ * Signature for a deep-link route handler. Each registered URI path maps to one handler.
+ */
+type UriRouteHandler = (uri: vscode.Uri) => Promise<void>;
+
 export function RegisterUriHandler(pacWrapper: PacWrapper): vscode.Disposable {
     const uriHandler = new UriHandler(pacWrapper);
     return vscode.window.registerUriHandler(uriHandler);
 }
 
-class UriHandler implements vscode.UriHandler {
+export class UriHandler implements vscode.UriHandler {
     private readonly pacWrapper: PacWrapper;
+    private readonly routes: ReadonlyMap<string, UriRouteHandler>;
 
     constructor(pacWrapper: PacWrapper) {
         this.pacWrapper = pacWrapper;
+        this.routes = this.buildRoutes();
+    }
+
+    /**
+     * Builds the deep-link routing table (URI path -> handler). Register new deep-link
+     * paths here so `handleUri` can dispatch to them.
+     */
+    private buildRoutes(): ReadonlyMap<string, UriRouteHandler> {
+        return new Map<string, UriRouteHandler>([
+            [UriPath.PcfInit, () => this.pcfInit()],
+            [UriPath.Open, (uri) => this.handleOpenPowerPages(uri)],
+        ]);
     }
 
     // URIs targeting our extension are in the format
@@ -28,11 +46,14 @@ class UriHandler implements vscode.UriHandler {
     // vscode://microsoft-IsvExpTools.powerplatform-vscode/pcfInit
     // vscode://microsoft-IsvExpTools.powerplatform-vscode/open?websiteid=xxx&envid=yyy&orgurl=zzz&schema=PortalSchemaV2
     public async handleUri(uri: vscode.Uri): Promise<void> {
-        if (uri.path === UriPath.PcfInit) {
-            return this.pcfInit();
-        } else if (uri.path === UriPath.Open) {
-            return this.handleOpenPowerPages(uri);
+        const route = this.routes.get(uri.path);
+        if (route) {
+            await route(uri);
+            return;
         }
+        // Unrecognized paths are intentionally ignored for forward compatibility. Reserved
+        // deep-link paths (URI_CONSTANTS.PATHS.AGENTIC_CREATE / PAC_CREATE) will be wired up
+        // in a follow-up change.
     }
 
     async pcfInit(): Promise<void> {

--- a/src/client/uriHandler/utils/authEnvironment.ts
+++ b/src/client/uriHandler/utils/authEnvironment.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { PacWrapper } from "../../pac/PacWrapper";
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryEvents";
+import { URI_HANDLER_STRINGS } from "../constants/uriStrings";
+import { UriParameters } from "./uriHandlerUtils";
+
+/**
+ * Encapsulates the PAC CLI authentication and environment-selection steps shared by the
+ * Power Pages deep-link flows. Extracted from `UriHandler` so that each deep-link handler
+ * (`/open` today, `/pacCreate` and `/agenticCreate` in follow-ups) can reuse the exact same
+ * auth/environment/reset behavior without duplicating it.
+ */
+export class AuthEnvironmentService {
+    private readonly pacWrapper: PacWrapper;
+
+    constructor(pacWrapper: PacWrapper) {
+        this.pacWrapper = pacWrapper;
+    }
+
+    /**
+     * Handle authentication and environment setup, reporting progress to the user.
+     */
+    public async prepareAuthenticationAndEnvironment(uriParams: UriParameters, telemetryData: Record<string, string>): Promise<void> {
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: URI_HANDLER_STRINGS.TITLES.POWER_PAGES,
+                cancellable: false
+            },
+            async (progress) => {
+                progress.report({
+                    message: URI_HANDLER_STRINGS.PROGRESS.PREPARING,
+                    increment: 10
+                });
+
+                progress.report({
+                    message: URI_HANDLER_STRINGS.PROGRESS.VALIDATING_AUTH,
+                    increment: 20
+                });
+
+                // Check and handle authentication
+                await this.ensureAuthentication(uriParams, telemetryData, progress);
+
+                progress.report({
+                    message: URI_HANDLER_STRINGS.PROGRESS.CHECKING_ENV,
+                    increment: 20
+                });
+
+                // Check and handle environment switching
+                await this.ensureCorrectEnvironment(uriParams, telemetryData, progress);
+
+                progress.report({
+                    message: URI_HANDLER_STRINGS.PROGRESS.READY_TO_SELECT,
+                    increment: 30
+                });
+
+                // Brief delay to let user see the final progress message
+                await new Promise(resolve => setTimeout(resolve, 500));
+            }
+        );
+    }
+
+    /**
+     * Ensure user is authenticated with PAC CLI
+     */
+    private async ensureAuthentication(uriParams: UriParameters, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
+        let authInfo;
+        try {
+            authInfo = await this.pacWrapper.activeOrg();
+        } catch (error) {
+            await this.resetPacProcessAndThrow(error, telemetryData, 'Failed to check authentication status', 'auth_check_failed');
+        }
+
+        if (!authInfo || authInfo.Status !== "Success") {
+            oneDSLoggerWrapper.getLogger().traceInfo(
+                uriHandlerTelemetryEventNames.URI_HANDLER_AUTH_REQUIRED,
+                { ...telemetryData, authStatus: authInfo?.Status || 'none' }
+            );
+
+            progress.report({
+                message: URI_HANDLER_STRINGS.PROGRESS.AUTH_REQUIRED,
+                increment: 10
+            });
+
+            const authRequired = await vscode.window.showWarningMessage(
+                URI_HANDLER_STRINGS.PROMPTS.AUTH_REQUIRED,
+                { modal: true },
+                URI_HANDLER_STRINGS.BUTTONS.YES,
+                URI_HANDLER_STRINGS.BUTTONS.NO
+            );
+
+            if (authRequired === URI_HANDLER_STRINGS.BUTTONS.YES) {
+                try {
+                    progress.report({
+                        message: URI_HANDLER_STRINGS.PROGRESS.AUTHENTICATING,
+                        increment: 10
+                    });
+
+                    await this.pacWrapper.authCreateNewAuthProfileForOrg(uriParams.orgUrl!);
+
+                    const newAuthInfo = await this.pacWrapper.activeOrg();
+                    if (!newAuthInfo || newAuthInfo.Status !== "Success") {
+                        throw new Error(URI_HANDLER_STRINGS.ERRORS.AUTH_FAILED);
+                    }
+
+                    oneDSLoggerWrapper.getLogger().traceInfo(
+                        uriHandlerTelemetryEventNames.URI_HANDLER_AUTH_COMPLETED,
+                        { ...telemetryData, newAuthStatus: newAuthInfo.Status }
+                    );
+                } catch (authError) {
+                    await this.resetPacProcessAndThrow(authError, telemetryData, 'Authentication operation failed', 'auth_operation_failed');
+                }
+            } else {
+                vscode.window.showInformationMessage(URI_HANDLER_STRINGS.INFO.DOWNLOAD_CANCELLED_AUTH);
+                oneDSLoggerWrapper.getLogger().traceInfo(
+                    uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
+                    { ...telemetryData, reason: 'user_cancelled_auth' }
+                );
+                throw new Error(URI_HANDLER_STRINGS.ERRORS.USER_CANCELLED_AUTH);
+            }
+        }
+    }
+
+    /**
+     * Ensure we're connected to the correct environment
+     */
+    private async ensureCorrectEnvironment(uriParams: UriParameters, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
+        let currentAuthInfo;
+        try {
+            currentAuthInfo = await this.pacWrapper.activeOrg();
+        } catch (error) {
+            await this.resetPacProcessAndThrow(error, telemetryData, 'Failed to check current environment', 'env_check_failed');
+        }
+
+        if (currentAuthInfo?.Status === "Success" && currentAuthInfo.Results?.EnvironmentId !== uriParams.environmentId) {
+            oneDSLoggerWrapper.getLogger().traceInfo(
+                uriHandlerTelemetryEventNames.URI_HANDLER_ENV_SWITCH_REQUIRED,
+                {
+                    ...telemetryData,
+                    currentEnvId: currentAuthInfo.Results?.EnvironmentId || 'unknown',
+                    requestedEnvId: uriParams.environmentId
+                }
+            );
+
+            const switchEnv = await vscode.window.showWarningMessage(
+                URI_HANDLER_STRINGS.PROMPTS.ENV_SWITCH_REQUIRED,
+                { modal: true },
+                URI_HANDLER_STRINGS.BUTTONS.YES,
+                URI_HANDLER_STRINGS.BUTTONS.NO
+            );
+
+            if (switchEnv === URI_HANDLER_STRINGS.BUTTONS.YES) {
+                try {
+                    progress.report({
+                        message: URI_HANDLER_STRINGS.PROGRESS.SWITCHING_ENV,
+                        increment: 10
+                    });
+
+                    await this.pacWrapper.orgSelect(uriParams.orgUrl!);
+
+                    const verifyAuthInfo = await this.pacWrapper.activeOrg();
+                    if (verifyAuthInfo?.Status !== "Success" || verifyAuthInfo.Results?.EnvironmentId !== uriParams.environmentId) {
+                        throw new Error(URI_HANDLER_STRINGS.ERRORS.ENV_SWITCH_FAILED);
+                    }
+
+                    oneDSLoggerWrapper.getLogger().traceInfo(
+                        uriHandlerTelemetryEventNames.URI_HANDLER_ENV_SWITCH_COMPLETED,
+                        { ...telemetryData, switchedToEnvId: verifyAuthInfo.Results?.EnvironmentId }
+                    );
+                } catch (error) {
+                    await this.resetPacProcessAndThrow(error, telemetryData, 'Error switching environment', 'env_switch_error');
+                }
+            } else {
+                vscode.window.showInformationMessage(URI_HANDLER_STRINGS.INFO.DOWNLOAD_CANCELLED_ENV);
+                oneDSLoggerWrapper.getLogger().traceInfo(
+                    uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
+                    { ...telemetryData, reason: 'user_cancelled_env_switch' }
+                );
+                throw new Error(URI_HANDLER_STRINGS.ERRORS.USER_CANCELLED_ENV_SWITCH);
+            }
+        }
+    }
+
+    /**
+     * Reset PAC process and throw error
+     */
+    public async resetPacProcessAndThrow(error: unknown, telemetryData: Record<string, string>, message: string, errorType: string): Promise<never> {
+        oneDSLoggerWrapper.getLogger().traceError(
+            uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
+            message,
+            error instanceof Error ? error : new Error(String(error)),
+            { ...telemetryData, error: errorType }
+        );
+
+        await this.resetPacProcessSafely(telemetryData);
+        throw error;
+    }
+
+    /**
+     * Safely reset PAC process without throwing
+     */
+    public async resetPacProcessSafely(telemetryData: Record<string, string>): Promise<void> {
+        try {
+            await this.pacWrapper.resetPacProcess();
+            oneDSLoggerWrapper.getLogger().traceInfo(
+                uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
+                { ...telemetryData, message: 'PAC process reset after failure' }
+            );
+        } catch (resetError) {
+            oneDSLoggerWrapper.getLogger().traceError(
+                uriHandlerTelemetryEventNames.URI_HANDLER_OPEN_POWER_PAGES_FAILED,
+                'Failed to reset PAC process after failure',
+                resetError instanceof Error ? resetError : new Error(String(resetError)),
+                { ...telemetryData, error: 'pac_reset_failed' }
+            );
+        }
+    }
+}


### PR DESCRIPTION
PR 2 of 3 (Phase 0-1 foundation). Stacked on #1625.

## Focus commit
2c5d46e2 - Extract shared PAC auth/environment helpers into AuthEnvironmentService (behavior-preserving). Moves prepareAuthenticationAndEnvironment / ensureAuthentication / ensureCorrectEnvironment / resetPacProcess* out of uriHandler.ts into a reusable AuthEnvironmentService so the upcoming create handlers can share them.

## Validation
gulp lint clean; compile-tests clean; npm test 106 passing; npm run build OK.

## Note on diff
Base is main because the PR 1 branch cannot be pushed to the upstream repo (contributor works from fork amitjoshi438/powerplatform-vscode). This PR's diff therefore also contains PR 1's commit (9d919797). **Review only the focus commit 2c5d46e2**, and merge after #1625.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>