### PR TITLE
URI handler (3/3): dark gated create deep-link handlers

### DIFF
--- a/src/client/test/integration/createHandlers.test.ts
+++ b/src/client/test/integration/createHandlers.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { AgenticCreateHandler } from "../../uriHandler/handlers/agenticCreateHandler";
+import { PacCreateHandler } from "../../uriHandler/handlers/pacCreateHandler";
+import { URI_CONSTANTS } from "../../uriHandler/constants/uriConstants";
+import { ECSFeaturesClient } from "../../../common/ecs-features/ecsFeatureClient";
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { uriHandlerTelemetryEventNames } from "../../uriHandler/telemetry/uriHandlerTelemetryEvents";
+import { PacWrapper } from "../../pac/PacWrapper";
+
+describe("Create deep-link handlers (gated)", () => {
+    let sandbox: sinon.SinonSandbox;
+    let getConfigStub: sinon.SinonStub;
+    let traceInfoStub: sinon.SinonStub;
+    let traceErrorStub: sinon.SinonStub;
+
+    const pacCreateUri = vscode.Uri.parse(
+        `vscode://${URI_CONSTANTS.EXTENSION_ID}${URI_CONSTANTS.PATHS.PAC_CREATE}` +
+        `?${URI_CONSTANTS.PARAMETERS.SOURCE}=${URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME}` +
+        `&${URI_CONSTANTS.PARAMETERS.ENV_ID}=env-1&${URI_CONSTANTS.PARAMETERS.VERSION}=${URI_CONSTANTS.CONTRACT_VERSION.CURRENT}`
+    );
+    const agenticCreateUri = vscode.Uri.parse(
+        `vscode://${URI_CONSTANTS.EXTENSION_ID}${URI_CONSTANTS.PATHS.AGENTIC_CREATE}` +
+        `?${URI_CONSTANTS.PARAMETERS.SOURCE}=${URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME}` +
+        `&${URI_CONSTANTS.PARAMETERS.AGENT_HOST}=${URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT}`
+    );
+
+    const setFlags = (enabled: boolean): void => {
+        getConfigStub.returns({
+            enablePacCreateFromHome: enabled,
+            enableAgenticCreateFromHome: enabled
+        });
+    };
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        getConfigStub = sandbox.stub(ECSFeaturesClient, "getConfig") as unknown as sinon.SinonStub;
+        traceInfoStub = sandbox.stub();
+        traceErrorStub = sandbox.stub();
+        sandbox.stub(oneDSLoggerWrapper, "getLogger").returns(
+            { traceInfo: traceInfoStub, traceError: traceErrorStub } as unknown as ReturnType<typeof oneDSLoggerWrapper.getLogger>
+        );
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("PacCreateHandler is a no-op that only emits disabled telemetry when the flag is off", async () => {
+        setFlags(false);
+        const handler = new PacCreateHandler({} as PacWrapper);
+
+        await handler.handle(pacCreateUri);
+
+        expect(PacCreateHandler.isEnabled()).to.be.false;
+        expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_DISABLED)).to.be.true;
+        expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED)).to.be.false;
+    });
+
+    it("PacCreateHandler parses params and emits triggered telemetry when the flag is on", async () => {
+        setFlags(true);
+        const handler = new PacCreateHandler({} as PacWrapper);
+
+        await handler.handle(pacCreateUri);
+
+        expect(PacCreateHandler.isEnabled()).to.be.true;
+        const triggered = traceInfoStub.getCalls().find(
+            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED
+        );
+        expect(triggered, "expected a triggered telemetry event").to.not.be.undefined;
+        expect(triggered?.args[1]).to.include({
+            source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
+            version: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
+            hasEnvironmentId: "true"
+        });
+    });
+
+    it("AgenticCreateHandler is a no-op that only emits disabled telemetry when the flag is off", async () => {
+        setFlags(false);
+        const handler = new AgenticCreateHandler({} as PacWrapper);
+
+        await handler.handle(agenticCreateUri);
+
+        expect(AgenticCreateHandler.isEnabled()).to.be.false;
+        expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_DISABLED)).to.be.true;
+        expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED)).to.be.false;
+    });
+
+    it("AgenticCreateHandler parses params and emits triggered telemetry when the flag is on", async () => {
+        setFlags(true);
+        const handler = new AgenticCreateHandler({} as PacWrapper);
+
+        await handler.handle(agenticCreateUri);
+
+        expect(AgenticCreateHandler.isEnabled()).to.be.true;
+        const triggered = traceInfoStub.getCalls().find(
+            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED
+        );
+        expect(triggered, "expected a triggered telemetry event").to.not.be.undefined;
+        expect(triggered?.args[1]).to.include({
+            source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
+            agentHost: URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT
+        });
+    });
+});

--- a/src/client/test/integration/createHandlers.test.ts
+++ b/src/client/test/integration/createHandlers.test.ts
@@ -59,7 +59,14 @@ describe("Create deep-link handlers (gated)", () => {
         await handler.handle(pacCreateUri);
 
         expect(PacCreateHandler.isEnabled()).to.be.false;
-        expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_DISABLED)).to.be.true;
+        const disabled = traceInfoStub.getCalls().find(
+            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_DISABLED
+        );
+        expect(disabled, "expected a disabled telemetry event").to.not.be.undefined;
+        expect(disabled?.args[1]).to.include({
+            source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
+            hasEnvironmentId: "true"
+        });
         expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED)).to.be.false;
     });
 
@@ -88,7 +95,14 @@ describe("Create deep-link handlers (gated)", () => {
         await handler.handle(agenticCreateUri);
 
         expect(AgenticCreateHandler.isEnabled()).to.be.false;
-        expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_DISABLED)).to.be.true;
+        const disabled = traceInfoStub.getCalls().find(
+            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_DISABLED
+        );
+        expect(disabled, "expected a disabled telemetry event").to.not.be.undefined;
+        expect(disabled?.args[1]).to.include({
+            source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
+            agentHost: URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT
+        });
         expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED)).to.be.false;
     });
 

--- a/src/client/test/integration/uriHandler.test.ts
+++ b/src/client/test/integration/uriHandler.test.ts
@@ -9,6 +9,8 @@ import * as vscode from "vscode";
 import { UriHandler } from "../../uriHandler/uriHandler";
 import { URI_CONSTANTS } from "../../uriHandler/constants/uriConstants";
 import { PacWrapper } from "../../pac/PacWrapper";
+import { AgenticCreateHandler } from "../../uriHandler/handlers/agenticCreateHandler";
+import { PacCreateHandler } from "../../uriHandler/handlers/pacCreateHandler";
 
 // Shape used to stub the private route targets on the prototype without resorting to `any`.
 type UriHandlerRoutes = {
@@ -20,6 +22,8 @@ describe("UriHandler routing", () => {
     let sandbox: sinon.SinonSandbox;
     let pcfInitStub: sinon.SinonStub;
     let openStub: sinon.SinonStub;
+    let agenticCreateStub: sinon.SinonStub;
+    let pacCreateStub: sinon.SinonStub;
     let handler: UriHandler;
 
     const makeUri = (path: string): vscode.Uri =>
@@ -30,6 +34,8 @@ describe("UriHandler routing", () => {
         const prototype = UriHandler.prototype as unknown as UriHandlerRoutes;
         pcfInitStub = sandbox.stub(prototype, "pcfInit").resolves();
         openStub = sandbox.stub(prototype, "handleOpenPowerPages").resolves();
+        agenticCreateStub = sandbox.stub(AgenticCreateHandler.prototype, "handle").resolves();
+        pacCreateStub = sandbox.stub(PacCreateHandler.prototype, "handle").resolves();
         handler = new UriHandler({} as PacWrapper);
     });
 
@@ -42,6 +48,8 @@ describe("UriHandler routing", () => {
 
         expect(pcfInitStub.calledOnce).to.be.true;
         expect(openStub.called).to.be.false;
+        expect(agenticCreateStub.called).to.be.false;
+        expect(pacCreateStub.called).to.be.false;
     });
 
     it("dispatches /open to the open Power Pages handler", async () => {
@@ -49,12 +57,24 @@ describe("UriHandler routing", () => {
 
         expect(openStub.calledOnce).to.be.true;
         expect(pcfInitStub.called).to.be.false;
+        expect(agenticCreateStub.called).to.be.false;
+        expect(pacCreateStub.called).to.be.false;
     });
 
-    it("ignores reserved deep-link paths that are not yet wired up", async () => {
+    it("dispatches /agenticCreate to the agentic create handler", async () => {
         await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.AGENTIC_CREATE));
+
+        expect(agenticCreateStub.calledOnce).to.be.true;
+        expect(pacCreateStub.called).to.be.false;
+        expect(pcfInitStub.called).to.be.false;
+        expect(openStub.called).to.be.false;
+    });
+
+    it("dispatches /pacCreate to the PAC create handler", async () => {
         await handler.handleUri(makeUri(URI_CONSTANTS.PATHS.PAC_CREATE));
 
+        expect(pacCreateStub.calledOnce).to.be.true;
+        expect(agenticCreateStub.called).to.be.false;
         expect(pcfInitStub.called).to.be.false;
         expect(openStub.called).to.be.false;
     });
@@ -64,5 +84,7 @@ describe("UriHandler routing", () => {
 
         expect(pcfInitStub.called).to.be.false;
         expect(openStub.called).to.be.false;
+        expect(agenticCreateStub.called).to.be.false;
+        expect(pacCreateStub.called).to.be.false;
     });
 });

--- a/src/client/uriHandler/handlers/agenticCreateHandler.ts
+++ b/src/client/uriHandler/handlers/agenticCreateHandler.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { PacWrapper } from "../../pac/PacWrapper";
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { ECSFeaturesClient } from "../../../common/ecs-features/ecsFeatureClient";
+import { EnableAgenticCreateFromHome } from "../../../common/ecs-features/ecsFeatureGates";
+import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryEvents";
+import { buildCreateFlowTelemetry, parseCreateFlowParameters } from "./createFlowParams";
+
+/**
+ * Handles the `/agenticCreate` deep link launched from the Power Pages home page, which will
+ * open VS Code into an agentic (terminal CLI agent host) create experience.
+ *
+ * This is a dark, flag-gated scaffold. When {@link EnableAgenticCreateFromHome} is off (the
+ * default) the handler is a no-op. When enabled it only parses the deep-link parameters and
+ * emits a "triggered" telemetry event — the actual agentic behavior (agent-host selection and
+ * Power Pages plugin bootstrapping) is intentionally deferred to a follow-up change.
+ */
+export class AgenticCreateHandler {
+    private readonly pacWrapper: PacWrapper;
+
+    constructor(pacWrapper: PacWrapper) {
+        this.pacWrapper = pacWrapper;
+    }
+
+    /**
+     * Whether the agentic create deep link is enabled via ECS. Defaults to false.
+     */
+    public static isEnabled(): boolean {
+        const enabled = ECSFeaturesClient.getConfig(EnableAgenticCreateFromHome).enableAgenticCreateFromHome;
+        return enabled === undefined ? false : enabled;
+    }
+
+    /**
+     * Entry point wired into the URI route map.
+     */
+    public async handle(uri: vscode.Uri): Promise<void> {
+        if (!AgenticCreateHandler.isEnabled()) {
+            oneDSLoggerWrapper.getLogger().traceInfo(
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_DISABLED,
+                {}
+            );
+            return;
+        }
+
+        try {
+            const params = parseCreateFlowParameters(uri);
+            const telemetryData = buildCreateFlowTelemetry(params);
+
+            oneDSLoggerWrapper.getLogger().traceInfo(
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED,
+                telemetryData
+            );
+
+            // NOTE: Behavior intentionally not implemented yet. The agentic create flow
+            // (agent-host detection/selection + Power Pages plugin bootstrapping) is a
+            // follow-up. `pacWrapper` is retained for use by that implementation.
+            void this.pacWrapper;
+        } catch (error) {
+            oneDSLoggerWrapper.getLogger().traceError(
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_FAILED,
+                'Agentic create deep link failed',
+                error instanceof Error ? error : new Error(String(error)),
+                {}
+            );
+        }
+    }
+}

--- a/src/client/uriHandler/handlers/agenticCreateHandler.ts
+++ b/src/client/uriHandler/handlers/agenticCreateHandler.ts
@@ -39,18 +39,19 @@ export class AgenticCreateHandler {
      * Entry point wired into the URI route map.
      */
     public async handle(uri: vscode.Uri): Promise<void> {
+        // Parse the (secret-free) deep-link params up front so the redacted telemetry payload
+        // is available on every path, including the flag-off and failure cases.
+        const telemetryData = buildCreateFlowTelemetry(parseCreateFlowParameters(uri));
+
         if (!AgenticCreateHandler.isEnabled()) {
             oneDSLoggerWrapper.getLogger().traceInfo(
                 uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_DISABLED,
-                {}
+                telemetryData
             );
             return;
         }
 
         try {
-            const params = parseCreateFlowParameters(uri);
-            const telemetryData = buildCreateFlowTelemetry(params);
-
             oneDSLoggerWrapper.getLogger().traceInfo(
                 uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED,
                 telemetryData
@@ -65,7 +66,7 @@ export class AgenticCreateHandler {
                 uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_FAILED,
                 'Agentic create deep link failed',
                 error instanceof Error ? error : new Error(String(error)),
-                {}
+                telemetryData
             );
         }
     }

--- a/src/client/uriHandler/handlers/createFlowParams.ts
+++ b/src/client/uriHandler/handlers/createFlowParams.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { URI_CONSTANTS } from "../constants/uriConstants";
+
+/**
+ * Parameters carried by the Power Pages "create" deep links (`/agenticCreate` and
+ * `/pacCreate`). The link is treated as a versioned, secret-free contract; see
+ * {@link URI_CONSTANTS.PARAMETERS} for the canonical query-parameter names.
+ */
+export interface CreateFlowParameters {
+    environmentId: string | null;
+    orgUrl: string | null;
+    region: string | null;
+    tenantId: string | null;
+    websiteId: string | null;
+    source: string | null;
+    agentHost: string | null;
+    version: string | null;
+}
+
+/**
+ * Parses the shared create-flow query parameters from a deep-link URI.
+ */
+export function parseCreateFlowParameters(uri: vscode.Uri): CreateFlowParameters {
+    const urlParams = new URLSearchParams(uri.query);
+
+    return {
+        environmentId: urlParams.get(URI_CONSTANTS.PARAMETERS.ENV_ID),
+        orgUrl: urlParams.get(URI_CONSTANTS.PARAMETERS.ORG_URL),
+        region: urlParams.get(URI_CONSTANTS.PARAMETERS.REGION),
+        tenantId: urlParams.get(URI_CONSTANTS.PARAMETERS.TENANT_ID),
+        websiteId: urlParams.get(URI_CONSTANTS.PARAMETERS.WEBSITE_ID),
+        source: urlParams.get(URI_CONSTANTS.PARAMETERS.SOURCE),
+        agentHost: urlParams.get(URI_CONSTANTS.PARAMETERS.AGENT_HOST),
+        version: urlParams.get(URI_CONSTANTS.PARAMETERS.VERSION)
+    };
+}
+
+/**
+ * Builds a non-sensitive telemetry payload describing a create-flow deep link.
+ * Only low-cardinality, non-secret values (source, agent host, contract version, region)
+ * and presence flags for identifiers are recorded — never raw org URLs or tenant IDs.
+ */
+export function buildCreateFlowTelemetry(params: CreateFlowParameters): Record<string, string> {
+    return {
+        source: params.source || 'unknown',
+        agentHost: params.agentHost || 'unspecified',
+        version: params.version || 'unspecified',
+        region: params.region || 'unspecified',
+        hasEnvironmentId: params.environmentId ? 'true' : 'false',
+        hasOrgUrl: params.orgUrl ? 'true' : 'false',
+        hasWebsiteId: params.websiteId ? 'true' : 'false',
+        hasTenantId: params.tenantId ? 'true' : 'false'
+    };
+}

--- a/src/client/uriHandler/handlers/pacCreateHandler.ts
+++ b/src/client/uriHandler/handlers/pacCreateHandler.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { PacWrapper } from "../../pac/PacWrapper";
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { ECSFeaturesClient } from "../../../common/ecs-features/ecsFeatureClient";
+import { EnablePacCreateFromHome } from "../../../common/ecs-features/ecsFeatureGates";
+import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryEvents";
+import { buildCreateFlowTelemetry, parseCreateFlowParameters } from "./createFlowParams";
+
+/**
+ * Handles the `/pacCreate` deep link launched from the Power Pages home page, which will open
+ * VS Code into a Power Platform CLI (PAC) create experience.
+ *
+ * This is a dark, flag-gated scaffold. When {@link EnablePacCreateFromHome} is off (the
+ * default) the handler is a no-op. When enabled it only parses the deep-link parameters and
+ * emits a "triggered" telemetry event — the actual PAC create behavior (auth, environment
+ * selection, folder selection, PAC CLI terminal) is intentionally deferred to a follow-up.
+ */
+export class PacCreateHandler {
+    private readonly pacWrapper: PacWrapper;
+
+    constructor(pacWrapper: PacWrapper) {
+        this.pacWrapper = pacWrapper;
+    }
+
+    /**
+     * Whether the PAC create deep link is enabled via ECS. Defaults to false.
+     */
+    public static isEnabled(): boolean {
+        const enabled = ECSFeaturesClient.getConfig(EnablePacCreateFromHome).enablePacCreateFromHome;
+        return enabled === undefined ? false : enabled;
+    }
+
+    /**
+     * Entry point wired into the URI route map.
+     */
+    public async handle(uri: vscode.Uri): Promise<void> {
+        if (!PacCreateHandler.isEnabled()) {
+            oneDSLoggerWrapper.getLogger().traceInfo(
+                uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_DISABLED,
+                {}
+            );
+            return;
+        }
+
+        try {
+            const params = parseCreateFlowParameters(uri);
+            const telemetryData = buildCreateFlowTelemetry(params);
+
+            oneDSLoggerWrapper.getLogger().traceInfo(
+                uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED,
+                telemetryData
+            );
+
+            // NOTE: Behavior intentionally not implemented yet. The PAC create flow (auth ->
+            // environment -> folder -> PAC CLI terminal) is a follow-up. `pacWrapper` is
+            // retained for use by that implementation.
+            void this.pacWrapper;
+        } catch (error) {
+            oneDSLoggerWrapper.getLogger().traceError(
+                uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_FAILED,
+                'PAC create deep link failed',
+                error instanceof Error ? error : new Error(String(error)),
+                {}
+            );
+        }
+    }
+}

--- a/src/client/uriHandler/handlers/pacCreateHandler.ts
+++ b/src/client/uriHandler/handlers/pacCreateHandler.ts
@@ -39,18 +39,19 @@ export class PacCreateHandler {
      * Entry point wired into the URI route map.
      */
     public async handle(uri: vscode.Uri): Promise<void> {
+        // Parse the (secret-free) deep-link params up front so the redacted telemetry payload
+        // is available on every path, including the flag-off and failure cases.
+        const telemetryData = buildCreateFlowTelemetry(parseCreateFlowParameters(uri));
+
         if (!PacCreateHandler.isEnabled()) {
             oneDSLoggerWrapper.getLogger().traceInfo(
                 uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_DISABLED,
-                {}
+                telemetryData
             );
             return;
         }
 
         try {
-            const params = parseCreateFlowParameters(uri);
-            const telemetryData = buildCreateFlowTelemetry(params);
-
             oneDSLoggerWrapper.getLogger().traceInfo(
                 uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED,
                 telemetryData
@@ -65,7 +66,7 @@ export class PacCreateHandler {
                 uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_FAILED,
                 'PAC create deep link failed',
                 error instanceof Error ? error : new Error(String(error)),
-                {}
+                telemetryData
             );
         }
     }

--- a/src/client/uriHandler/telemetry/uriHandlerTelemetryEvents.ts
+++ b/src/client/uriHandler/telemetry/uriHandlerTelemetryEvents.ts
@@ -16,5 +16,11 @@ export enum uriHandlerTelemetryEventNames {
     URI_HANDLER_DOWNLOAD_STARTED = "UriHandlerDownloadStarted",
     URI_HANDLER_DOWNLOAD_COMPLETED = "UriHandlerDownloadCompleted",
     URI_HANDLER_FOLDER_OPENED = "UriHandlerFolderOpened",
-    URI_HANDLER_PCF_INIT_TRIGGERED = "UriHandlerPcfInitTriggered"
+    URI_HANDLER_PCF_INIT_TRIGGERED = "UriHandlerPcfInitTriggered",
+    URI_HANDLER_AGENTIC_CREATE_TRIGGERED = "UriHandlerAgenticCreateTriggered",
+    URI_HANDLER_AGENTIC_CREATE_DISABLED = "UriHandlerAgenticCreateDisabled",
+    URI_HANDLER_AGENTIC_CREATE_FAILED = "UriHandlerAgenticCreateFailed",
+    URI_HANDLER_PAC_CREATE_TRIGGERED = "UriHandlerPacCreateTriggered",
+    URI_HANDLER_PAC_CREATE_DISABLED = "UriHandlerPacCreateDisabled",
+    URI_HANDLER_PAC_CREATE_FAILED = "UriHandlerPacCreateFailed"
 }

--- a/src/client/uriHandler/uriHandler.ts
+++ b/src/client/uriHandler/uriHandler.ts
@@ -11,6 +11,8 @@ import { URI_HANDLER_STRINGS } from "./constants/uriStrings";
 import { uriHandlerTelemetryEventNames } from "./telemetry/uriHandlerTelemetryEvents";
 import { UriHandlerUtils, UriParameters } from "./utils/uriHandlerUtils";
 import { AuthEnvironmentService } from "./utils/authEnvironment";
+import { AgenticCreateHandler } from "./handlers/agenticCreateHandler";
+import { PacCreateHandler } from "./handlers/pacCreateHandler";
 
 /**
  * Signature for a deep-link route handler. Each registered URI path maps to one handler.
@@ -26,10 +28,14 @@ export class UriHandler implements vscode.UriHandler {
     private readonly pacWrapper: PacWrapper;
     private readonly routes: ReadonlyMap<string, UriRouteHandler>;
     private readonly authEnvironmentService: AuthEnvironmentService;
+    private readonly agenticCreateHandler: AgenticCreateHandler;
+    private readonly pacCreateHandler: PacCreateHandler;
 
     constructor(pacWrapper: PacWrapper) {
         this.pacWrapper = pacWrapper;
         this.authEnvironmentService = new AuthEnvironmentService(pacWrapper);
+        this.agenticCreateHandler = new AgenticCreateHandler(pacWrapper);
+        this.pacCreateHandler = new PacCreateHandler(pacWrapper);
         this.routes = this.buildRoutes();
     }
 
@@ -41,6 +47,8 @@ export class UriHandler implements vscode.UriHandler {
         return new Map<string, UriRouteHandler>([
             [UriPath.PcfInit, () => this.pcfInit()],
             [UriPath.Open, (uri) => this.handleOpenPowerPages(uri)],
+            [UriPath.AgenticCreate, (uri) => this.agenticCreateHandler.handle(uri)],
+            [UriPath.PacCreate, (uri) => this.pacCreateHandler.handle(uri)],
         ]);
     }
 
@@ -54,9 +62,7 @@ export class UriHandler implements vscode.UriHandler {
             await route(uri);
             return;
         }
-        // Unrecognized paths are intentionally ignored for forward compatibility. Reserved
-        // deep-link paths (URI_CONSTANTS.PATHS.AGENTIC_CREATE / PAC_CREATE) will be wired up
-        // in a follow-up change.
+        // Unrecognized paths are intentionally ignored for forward compatibility.
     }
 
     async pcfInit(): Promise<void> {

--- a/src/common/ecs-features/ecsFeatureGates.ts
+++ b/src/common/ecs-features/ecsFeatureGates.ts
@@ -130,3 +130,23 @@ export const {
         enableMetadataDiff: true,
     }
 });
+
+export const {
+    feature: EnableAgenticCreateFromHome
+} = getFeatureConfigs({
+    teamName: PowerPagesClientName,
+    description: 'Enable the agentic create deep link (agenticCreate) launched from the Power Pages home page',
+    fallback: {
+        enableAgenticCreateFromHome: false,
+    }
+});
+
+export const {
+    feature: EnablePacCreateFromHome
+} = getFeatureConfigs({
+    teamName: PowerPagesClientName,
+    description: 'Enable the PAC CLI create deep link (pacCreate) launched from the Power Pages home page',
+    fallback: {
+        enablePacCreateFromHome: false,
+    }
+});


### PR DESCRIPTION
**PR 3 of 3 - Phase 0-1 foundation.** Introduces the **dark, flag-gated** create handlers. PRs 1 and 2 have now merged, so this targets `main` and the diff shows **only this PR's commit**.

## Focus commit
`31690ac4` - Add dark, flag-gated skeleton handlers for the two Power Pages create deep links.

(Rebased onto latest `main`. The branch's earlier duplicate route-map and auth-service commits dropped out automatically once PRs 1 and 2 landed, leaving a single focus commit.)

## What changed
- **ECS gates** `EnableAgenticCreateFromHome` / `EnablePacCreateFromHome` (fallback **off**).
- **Handlers** `agenticCreateHandler.ts` / `pacCreateHandler.ts` wired into the PR 1 route map. Flag **off** = no-op that emits a `*_Disabled` telemetry event; flag **on** = parse deep-link params + emit `*_Triggered`. Actual create behavior (auth -> environment -> folder -> PAC CLI / agent-host bootstrap) is deferred to follow-ups.
- **`createFlowParams.ts`** - shared param parsing + a **redacted** telemetry builder that records only low-cardinality values and presence flags, never raw org URLs / tenant IDs.
- **Telemetry** - 6 new events (triggered/disabled/failed for each flow).

## Tests
- **`test/integration/createHandlers.test.ts`** (new) - flag-off no-op path and flag-on parse+telemetry path for both handlers.
- **`test/integration/uriHandler.test.ts`** - updated to assert the new paths dispatch to their handlers.

## Validation
Rebased cleanly onto latest `main`; `gulp lint` clean; `npm run build` OK; desktop integration suite **904 passing** (includes the new create-handler and routing tests).

## Rollout
Ships **dark**: both gates default off, telemetry-only, no user-facing behavior. PRs 1 and 2 have merged; this is the final PR in the stack.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>