### PR TITLE
ci: pin integration test runners to VS Code 'stable' to fix macOS build

### DIFF
--- a/src/common/test/runTest.ts
+++ b/src/common/test/runTest.ts
@@ -22,7 +22,10 @@ async function main() {
 
         // Download VS Code, unzip it and run the integration test
         await runTests({
-            version: 'insiders',
+            // Pin to 'stable' rather than 'insiders'. 'insiders' always pulls the
+            // latest Insiders build at run time; a change to its macOS app-bundle
+            // layout breaks @vscode/test-electron's binary resolution (spawn ENOENT).
+            version: 'stable',
             extensionDevelopmentPath,
             extensionTestsPath
         });

--- a/src/web/client/test/runTest.ts
+++ b/src/web/client/test/runTest.ts
@@ -22,7 +22,10 @@ async function main() {
 
         // Download VS Code, unzip it and run the integration test
         await runTests({
-            version: 'insiders',
+            // Pin to 'stable' rather than 'insiders'. 'insiders' always pulls the
+            // latest Insiders build at run time; a change to its macOS app-bundle
+            // layout breaks @vscode/test-electron's binary resolution (spawn ENOENT).
+            version: 'stable',
             extensionDevelopmentPath,
             extensionTestsPath
         });


### PR DESCRIPTION
## Why

`build (macos-latest)` is failing on PRs at the **Run Web integration tests** step with:

```
Test error: Error: spawn .../Visual Studio Code - Insiders.app/Contents/MacOS/Electron ENOENT
Failed to run tests
```

This is **upstream drift, not a code change in this repo.** The web-int and common-int test runners request VS Code `'insiders'` via `@vscode/test-electron`. Since `'insiders'` resolves to the *latest Insiders build at run time*, a recent change to the Insiders **macOS** app-bundle layout broke the binary resolution in the pinned `@vscode/test-electron@^2.3.8` (from 2022). Linux/Windows Insiders keep the old layout, so **only macOS** fails.

Evidence it isn't our code:
- `src/web/client/test/runTest.ts` last edited **2022-12-19**; the `@vscode/test-electron` pin last changed **2022-07-18** — stable for years.
- Last green `main` run was 7/21; first red run 7/22 — the config didn't change, the upstream Insiders build did.
- The **desktop** and **debugger** runners already default to `'stable'` (Insiders is even commented out in the desktop runner), and they pass on macOS in the same job.

## What changed

Switch the two remaining `'insiders'` runners to `'stable'`, matching the desktop/debugger convention:

- `src/web/client/test/runTest.ts`
- `src/common/test/runTest.ts`

No product code touched. A short comment is added to each so `'insiders'` isn't reintroduced.

## Impact

- Fixes `build (macos-latest)` repo-wide (not just one PR).
- Integration tests now run against a deterministic stable channel instead of a moving target, removing this class of flake.

## Alternative considered

Bumping `@vscode/test-electron` to a version that understands the new Insiders macOS layout would also work, but it's a broader dependency/lockfile change and keeps tests on a moving channel. Pinning to `'stable'` is the smaller, lower-risk fix and is consistent with the runners that already pass.
