### PR TITLE
Fix Dependabot vulnerability in fast-uri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4036,22 +4036,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-formats/node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha1-ivPU/J0+cbEVcswmc7UUp9GoyOw=",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -7150,6 +7134,22 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -15781,22 +15781,6 @@
       "peerDependencies": {
         "ajv": "^8.8.2"
       }
-    },
-    "node_modules/schema-utils/node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha1-ivPU/J0+cbEVcswmc7UUp9GoyOw=",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/schema-utils/node_modules/json-schema-traverse": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1874,7 +1874,7 @@
     },
     "axios": "1.18.0",
     "basic-ftp": "5.3.1",
-    "fast-uri": "3.1.2",
+    "fast-uri": "3.1.4",
     "ip-address": "10.1.1",
     "tmp": "0.2.7",
     "form-data": "^4.0.6",


### PR DESCRIPTION
Dependabot flagged `fast-uri` through the lockfile as a transitive runtime dependency. This updates the existing npm override from `3.1.2` to `3.1.4`, so `schema-utils` and `ajv-formats` resolve to the patched version.

The lockfile was regenerated through npm instead of editing integrity hashes by hand. This addresses both high severity `fast-uri` advisories: CVE-2026-13676 and CVE-2026-16221.

Validation:
- `npm run build`
- `npm test`
- `npm ls fast-uri --package-lock-only --all`
- `npm audit --package-lock-only`