### PR TITLE
Fix Dependabot alert: bump liquidjs to 10.27.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "gpt-tokenizer": "^2.1.1",
         "gulp": "^5.0.0",
         "https-browserify": "^1.0.0",
-        "liquidjs": "10.26.0",
+        "liquidjs": "10.27.1",
         "n-readlines": "^1.0.1",
         "puppeteer-core": "^22.13.1",
         "recursive-readdir": "^2.2.3",
@@ -4446,8 +4446,8 @@
     },
     "node_modules/axios/node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -4458,8 +4458,8 @@
     },
     "node_modules/axios/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -11084,9 +11084,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.26.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.26.0.tgz",
-      "integrity": "sha512-Ub9FFNOLB9tdH/gB2MKkeU7x9NifoVidxAam6YWU7LUcy7Glumi6q5C3tDpWOEpeNaT8Cdwdb1axEdlvLSoyaQ==",
+      "version": "10.27.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.1.tgz",
+      "integrity": "sha512-ylE+1q2kSef1UxAyxqbyuWM3FRWS1v48JK1Y3CoW3bD6TSNXZh0+GsVnihujEpKyR+Jejx2aRAFfC3AHm9rElg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"
@@ -17413,8 +17413,8 @@
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha1-+NP30OxMPeo1p+PI76TLi0XJ5+4=",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1843,7 +1843,7 @@
     "gpt-tokenizer": "^2.1.1",
     "gulp": "^5.0.0",
     "https-browserify": "^1.0.0",
-    "liquidjs": "10.26.0",
+    "liquidjs": "10.27.1",
     "n-readlines": "^1.0.1",
     "puppeteer-core": "^22.13.1",
     "recursive-readdir": "^2.2.3",


### PR DESCRIPTION
Closes Dependabot alert 229. liquidjs 10.26.0 is affected by CVE-2026-55575 / GHSA-g357-x5c3-c72p (high): the `pop` filter skips the `memoryLimit` accounting that its array-filter siblings enforce, so template rendering can exceed the configured limit. We use liquidjs in the HTML language server for Liquid autocomplete, so it processes user template content.

## What changed

- `liquidjs` 10.26.0 -> 10.27.1. Patch release within 10.x with no API changes; the two files that import it (`LiquidAutoCompleteRule.ts`, `LiquidAutoCompleteRuleEngine.ts`) only use `Tokenizer`, `TokenKind`, and token types, none of which moved.

## Lockfile cleanup

Four `package-lock.json` entries had `resolved` URLs pointing at `ms-feed-*.pkgs.visualstudio.com` with sha1 integrity instead of `registry.npmjs.org` with sha512. This happens when someone runs `npm install` on a machine configured against the internal npm proxy, and it can produce `EINTEGRITY` failures for anyone resolving through a different registry. Normalized `agent-base@6.0.2`, `https-proxy-agent@5.0.1`, `uc.micro@2.1.0`, and the new `liquidjs@10.27.1`.

Each sha512 was recomputed from the actual tarball, and each tarball's sha1 was checked against the registry's published shasum first, so the hashes are derived from verified content rather than hand-written.

## Two alerts intentionally left open

Alerts #230 (`tar`, needs 7.5.21) and #231 (`brace-expansion`, needs 5.0.8) are not in this PR. Neither patched version has synced to the internal npm feed yet, which is the only registry reachable from a managed device, so there is nothing installable to bump to. Both packages are transitive and already pinned through `overrides`, so each becomes a one-line change once the feed catches up.

Worth flagging for whoever picks up #231: the brace-expansion advisory covers every version `<= 5.0.7`, so the nested `@vscode/vsce -> brace-expansion 1.1.16` override is affected too and will need its own patched 1.x release or removal.

## Validation

- `npm ci` reinstalls cleanly and leaves the lockfile untouched, which confirms the hand-normalized integrity values are correct.
- `npm run build` succeeds.
- `npm test` passes, 106 tests.