### PR TITLE
Fix macOS integration tests broken by VS Code 1.131.0

### DIFF
--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       # - name: Install dependencies
       #   run: npm i -g npm
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "@vscode/l10n-dev": "^0.0.35",
-        "@vscode/test-electron": "^2.3.8",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/test-web": "^0.0.80",
         "@vscode/vsce": "^2.19.0",
         "assert": "^2.0.0",
@@ -3469,10 +3469,11 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
@@ -3481,7 +3482,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/test-web": {

--- a/package.json
+++ b/package.json
@@ -1784,7 +1784,7 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "@vscode/l10n-dev": "^0.0.35",
-    "@vscode/test-electron": "^2.3.8",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/test-web": "^0.0.80",
     "@vscode/vsce": "^2.19.0",
     "assert": "^2.0.0",

--- a/src/common/test/runTest.ts
+++ b/src/common/test/runTest.ts
@@ -22,9 +22,10 @@ async function main() {
 
         // Download VS Code, unzip it and run the integration test
         await runTests({
-            // Pin to 'stable' rather than 'insiders'. 'insiders' always pulls the
-            // latest Insiders build at run time; a change to its macOS app-bundle
-            // layout breaks @vscode/test-electron's binary resolution (spawn ENOENT).
+            // Pin to 'stable' rather than 'insiders' so CI runs against a
+            // predictable build. 'insiders' pulls whatever was published that
+            // day, which historically broke @vscode/test-electron's macOS
+            // binary resolution before the resolver was hardened in 3.1.0.
             version: 'stable',
             extensionDevelopmentPath,
             extensionTestsPath

--- a/src/web/client/test/runTest.ts
+++ b/src/web/client/test/runTest.ts
@@ -22,9 +22,10 @@ async function main() {
 
         // Download VS Code, unzip it and run the integration test
         await runTests({
-            // Pin to 'stable' rather than 'insiders'. 'insiders' always pulls the
-            // latest Insiders build at run time; a change to its macOS app-bundle
-            // layout breaks @vscode/test-electron's binary resolution (spawn ENOENT).
+            // Pin to 'stable' rather than 'insiders' so CI runs against a
+            // predictable build. 'insiders' pulls whatever was published that
+            // day, which historically broke @vscode/test-electron's macOS
+            // binary resolution before the resolver was hardened in 3.1.0.
             version: 'stable',
             extensionDevelopmentPath,
             extensionTestsPath


### PR DESCRIPTION
The macOS leg of the build is broken on `main` today, independent of any change in this PR.

VS Code 1.131.0 (released Jul 28) renamed the macOS app bundle executable from `Contents/MacOS/Electron` to `Contents/MacOS/Code`. `@vscode/test-electron` 2.5.2 hardcodes the old name, so every macOS run dies immediately after the download step with:

```
spawn .../Visual Studio Code.app/Contents/MacOS/Electron ENOENT
```

Linux and Windows are unaffected because their launcher paths did not change.

### The fix

`@vscode/test-electron` 3.1.0 resolves the executable from the bundle contents instead of assuming a fixed name, so this bumps to it. Nothing older carries the fix: 3.0.0 still hardcodes `Electron`, and there is no 2.x backport.

That release declares `engines.node >= 22`, so the CI jobs that install and run it move from Node 20 (already past end of life) to Node 22.

I also refreshed the `'stable'` pin comments in the two `runTest.ts` files. They described the old resolver bug as an open hazard, which is no longer accurate; pinning to `stable` is still worth keeping for run-to-run determinism.

### Validation

On macOS locally: reproduced the `ENOENT` failure with 2.5.2, confirmed VS Code launches again after the bump, and `npm run dist` (compile, vsix package, lint, 106 unit tests) passes.