### PR TITLE
Fix Other Sites section hiding classic sites in Actions Hub

### DIFF
--- a/src/client/power-pages/actions-hub/ActionsHubUtils.ts
+++ b/src/client/power-pages/actions-hub/ActionsHubUtils.ts
@@ -14,7 +14,7 @@ import { IOtherSiteInfo, IWebsiteDetails, WebsiteYaml } from "../../../common/se
 import ArtemisContext from "../../ArtemisContext";
 import { getActiveWebsites, getAllWebsites } from "../../../common/utilities/WebsiteUtil";
 import { ServiceEndpointCategory } from "../../../common/services/Constants";
-import { getWebsiteRecordId, getWebsiteYamlPath, hasWebsiteYaml } from "../../../common/utilities/WorkspaceInfoFinderUtil";
+import { getWebsiteRecordId, getWebsiteYamlPath } from "../../../common/utilities/WorkspaceInfoFinderUtil";
 import { POWERPAGES_SITE_FOLDER, UTF8_ENCODING } from "../../../common/constants";
 import { OrgInfo } from "../../pac/PacTypes";
 
@@ -114,18 +114,17 @@ export function findOtherSites(knownSiteIds: Set<string>, fsModule = fs, yamlMod
         // Check each directory for website.yml or .powerpages-site folder
         const otherSites: IOtherSiteInfo[] = [];
         for (const dir of directories) {
-            let websiteYamlPath = getWebsiteYamlPath(dir);
-            let hasWebsiteYamlFile = hasWebsiteYaml(dir);
-            const powerPagesSiteFolderExists = fs.existsSync(dir)
-            let workingDir = dir;
+            // A code site keeps its metadata under <site>/.powerpages-site, while a classic site keeps
+            // website.yml directly at the folder root. Probe for the .powerpages-site folder itself:
+            // probing `dir` would always report true, because every path here came from readdirSync,
+            // which would make classic sites invisible and mislabel every site as a code site.
+            const powerPagesSiteFolder = path.join(dir, POWERPAGES_SITE_FOLDER);
+            const isCodeSite = fsModule.existsSync(powerPagesSiteFolder);
+            const workingDir = isCodeSite ? powerPagesSiteFolder : dir;
+            const websiteYamlPath = getWebsiteYamlPath(workingDir);
 
-            if (powerPagesSiteFolderExists) {
-                workingDir = path.join(dir, POWERPAGES_SITE_FOLDER);
-                websiteYamlPath = getWebsiteYamlPath(workingDir);
-                hasWebsiteYamlFile = hasWebsiteYaml(workingDir);
-            }
-
-            if (hasWebsiteYamlFile) {
+            // fsModule (rather than hasWebsiteYaml) keeps the whole scan on the injected fs module.
+            if (fsModule.existsSync(websiteYamlPath)) {
                 try {
                     // Use the utility function to get website record ID
                     const websiteId = getWebsiteRecordId(workingDir);
@@ -140,7 +139,7 @@ export function findOtherSites(knownSiteIds: Set<string>, fsModule = fs, yamlMod
                             name: websiteData?.adx_name || websiteData?.name || path.basename(dir), // Use folder name as fallback
                             websiteId: websiteId,
                             folderPath: dir,
-                            isCodeSite: powerPagesSiteFolderExists
+                            isCodeSite: isCodeSite
                         });
                     }
                 } catch (error) {

--- a/src/client/test/integration/power-pages/actions-hub/ActionsHubUtils.test.ts
+++ b/src/client/test/integration/power-pages/actions-hub/ActionsHubUtils.test.ts
@@ -133,7 +133,8 @@ describe('ActionsHubUtils', () => {
 
             // Create mock yaml module with stubbed methods
             mockYaml = {
-                load: sandbox.stub()
+                load: sandbox.stub(),
+                parse: sandbox.stub()
             };
 
             // Stub workspace folders
@@ -191,6 +192,95 @@ describe('ActionsHubUtils', () => {
             const result = findOtherSites(knownSiteIds, mockFs, mockYaml);
 
             expect(result).to.be.an('array').that.is.empty;
+        });
+
+        it('should find a classic site whose website.yml sits at the folder root', () => {
+            const siteFolder = path.join('/test/current', 'classic-site');
+
+            mockFs.readdirSync.returns([
+                { name: 'classic-site', isDirectory: () => true }
+            ]);
+
+            // No .powerpages-site folder, website.yml lives at the site folder root
+            mockFs.existsSync.withArgs(path.join(siteFolder, '.powerpages-site')).returns(false);
+            mockFs.existsSync.withArgs(path.join(siteFolder, 'website.yml')).returns(true);
+            mockFs.existsSync.returns(false);
+            mockFs.readFileSync.returns('yaml content');
+            mockYaml.parse.returns({ adx_name: 'Classic Site' });
+
+            mockGetWebsiteRecordId.withArgs(siteFolder).returns('classic-site-id');
+
+            const result = findOtherSites(new Set<string>(), mockFs, mockYaml);
+
+            expect(result).to.deep.equal([{
+                name: 'Classic Site',
+                websiteId: 'classic-site-id',
+                folderPath: siteFolder,
+                isCodeSite: false
+            }]);
+        });
+
+        it('should find a code site whose website.yml sits under .powerpages-site', () => {
+            const siteFolder = path.join('/test/current', 'code-site');
+            const powerPagesSiteFolder = path.join(siteFolder, '.powerpages-site');
+
+            mockFs.readdirSync.returns([
+                { name: 'code-site', isDirectory: () => true }
+            ]);
+
+            mockFs.existsSync.withArgs(powerPagesSiteFolder).returns(true);
+            mockFs.existsSync.withArgs(path.join(powerPagesSiteFolder, 'website.yml')).returns(true);
+            mockFs.existsSync.returns(false);
+            mockFs.readFileSync.returns('yaml content');
+            mockYaml.parse.returns({ adx_name: 'Code Site' });
+
+            mockGetWebsiteRecordId.withArgs(powerPagesSiteFolder).returns('code-site-id');
+
+            const result = findOtherSites(new Set<string>(), mockFs, mockYaml);
+
+            expect(result).to.deep.equal([{
+                name: 'Code Site',
+                websiteId: 'code-site-id',
+                folderPath: siteFolder,
+                isCodeSite: true
+            }]);
+        });
+
+        it('should exclude sites that already belong to the connected environment', () => {
+            const siteFolder = path.join('/test/current', 'known-site');
+
+            mockFs.readdirSync.returns([
+                { name: 'known-site', isDirectory: () => true }
+            ]);
+
+            mockFs.existsSync.withArgs(path.join(siteFolder, '.powerpages-site')).returns(false);
+            mockFs.existsSync.withArgs(path.join(siteFolder, 'website.yml')).returns(true);
+            mockFs.existsSync.returns(false);
+            mockFs.readFileSync.returns('yaml content');
+            mockYaml.parse.returns({ adx_name: 'Known Site' });
+
+            // Site IDs are normalized to lowercase when the known set is built
+            mockGetWebsiteRecordId.withArgs(siteFolder).returns('KNOWN-SITE-ID');
+
+            const result = findOtherSites(new Set<string>(['known-site-id']), mockFs, mockYaml);
+
+            expect(result).to.be.an('array').that.is.empty;
+        });
+
+        it('should skip folders without a website.yml', () => {
+            const siteFolder = path.join('/test/current', 'not-a-site');
+
+            mockFs.readdirSync.returns([
+                { name: 'not-a-site', isDirectory: () => true }
+            ]);
+
+            mockFs.existsSync.returns(false);
+
+            const result = findOtherSites(new Set<string>(), mockFs, mockYaml);
+
+            expect(result).to.be.an('array').that.is.empty;
+            expect(mockGetWebsiteRecordId.called).to.be.false;
+            expect(mockFs.existsSync.calledWith(path.join(siteFolder, 'website.yml'))).to.be.true;
         });
     });
 


### PR DESCRIPTION
## Why

QA reported that the "Other Sites" section never appears in the Power Pages Actions Hub. Part of that is by design (the section is only rendered when unknown local sites are found next to the opened workspace folder), but there is also a real bug underneath: classic sites were never detected at all.

`findOtherSites` decided whether a folder was a code site with:

```ts
const powerPagesSiteFolderExists = fs.existsSync(dir)
```

Every path in that loop came from `readdirSync`, so this was unconditionally `true`. The scan was then always redirected into `<site>/.powerpages-site`, which means:

- Classic sites, which keep `website.yml` at the folder root, were silently skipped and never listed under "Other Sites".
- Any site that did surface was reported with `isCodeSite: true` regardless of its actual shape.

## What changed

Probe the `.powerpages-site` folder itself instead of `dir`, and derive `isCodeSite` from that result:

```ts
const powerPagesSiteFolder = path.join(dir, POWERPAGES_SITE_FOLDER);
const isCodeSite = fsModule.existsSync(powerPagesSiteFolder);
const workingDir = isCodeSite ? powerPagesSiteFolder : dir;
```

The `website.yml` lookup also moved from `hasWebsiteYaml` to the injected `fsModule`. `hasWebsiteYaml` reaches for the real `fs` module, so the existing unit tests were stubbing a mock filesystem that the function under test never consulted. That is why this bug shipped with green tests. Running the whole scan through `fsModule` keeps the injection contract honest.

## Tests

Four new cases in `ActionsHubUtils.test.ts` covering a classic site, a code site, a site that already belongs to the connected environment, and a folder with no `website.yml`. Three of them fail against the old implementation and all pass after the fix.

## Reviewer notes

No behavior change to the visibility rule itself: `OtherSitesGroupTreeItem` is still only pushed when `_otherSites.length > 0`. This PR only makes the detection correct, so folders that should have matched now actually do.