### PR TITLE
Fix available Dependabot vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9803,8 +9803,8 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.1",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "version": "10.3.1",
+      "integrity": "sha1-kp+WKdFyT34bdIXOiXUvNnUzahA=",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -14796,8 +14796,8 @@
       }
     },
     "node_modules/release-it/node_modules/undici": {
-      "version": "6.27.0",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "integrity": "sha1-nw44V0T+9QIdZZbFvM14P2EZPBw=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15774,8 +15774,8 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "integrity": "sha1-Z55R/iTRyB35D8X37+Sl9DL+mcA=",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -17021,8 +17021,8 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "integrity": "sha1-rg9vYuBuBXqcu3srX94rt095G48=",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -1875,7 +1875,7 @@
     "axios": "1.18.0",
     "basic-ftp": "5.3.1",
     "fast-uri": "3.1.4",
-    "ip-address": "10.1.1",
+    "ip-address": "10.3.1",
     "tmp": "0.2.7",
     "form-data": "^4.0.6",
     "js-yaml": "^4.3.0",
@@ -1893,10 +1893,11 @@
     "brace-expansion": "5.0.8",
     "serialize-javascript": "^7.0.3",
     "diff": "^8.0.3",
-    "undici": "^7.28.0",
+    "socket.io-parser": "4.2.7",
+    "undici": "^7.29.0",
     "pacote": "21.0.1",
     "release-it": {
-      "undici": "^6.27.0"
+      "undici": "^6.28.0"
     },
     "@koa/router": {
       "path-to-regexp": "^8.4.0"


### PR DESCRIPTION
## Summary

- update `socket.io-parser` to 4.2.7
- update Undici 7.x to 7.29.0 and the `release-it` Undici 6.x branch to 6.28.0
- update `ip-address` to 10.3.1
- keep the lockfile registry-agnostic under the merged `.npmrc` policy

These updates address 12 open Dependabot alerts, including the newer Undici 6.x and `ip-address` advisories.

## Remaining alerts

`fast-uri@3.1.5` and `brace-expansion@5.0.9` are not yet available from the approved package feed, so those two alerts remain unchanged rather than introducing an unreproducible package source.

## Validation

- `npm ci --registry=https://packagefeedproxy.microsoft.io/npm`
- `npm run build`
- `npm test` (106 passing)
- confirmed `package-lock.json` contains no registry URLs