### PR TITLE
URI handler: generalize AuthEnvironmentService for create-flow params (dark)

### DIFF
--- a/src/client/test/integration/authEnvironment.test.ts
+++ b/src/client/test/integration/authEnvironment.test.ts
@@ -8,6 +8,7 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { AuthEnvironmentService } from "../../uriHandler/utils/authEnvironment";
 import { UriParameters } from "../../uriHandler/utils/uriHandlerUtils";
+import { CreateFlowParameters } from "../../uriHandler/handlers/createFlowParams";
 import { PacWrapper } from "../../pac/PacWrapper";
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 
@@ -28,10 +29,25 @@ describe("AuthEnvironmentService", () => {
     let service: AuthEnvironmentService;
     let warningStub: sinon.SinonStub;
 
-    const uriParams = {
+    const OPEN_URI_PARAMS: UriParameters = {
+        websiteId: "site-1",
         environmentId: "env-1",
-        orgUrl: "https://org.crm.dynamics.com/"
-    } as unknown as UriParameters;
+        orgUrl: "https://org.crm.dynamics.com/",
+        schema: null,
+        siteName: null,
+        siteUrl: null,
+        modelVersion: 1
+    };
+    const CREATE_FLOW_PARAMS: CreateFlowParameters = {
+        environmentId: "env-1",
+        orgUrl: "https://org.crm.dynamics.com/",
+        region: null,
+        tenantId: null,
+        websiteId: null,
+        source: null,
+        agentHost: null,
+        version: null
+    };
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
@@ -76,11 +92,24 @@ describe("AuthEnvironmentService", () => {
             Results: { EnvironmentId: "env-1" }
         });
 
-        await service.prepareAuthenticationAndEnvironment(uriParams, {});
+        await service.prepareAuthenticationAndEnvironment(OPEN_URI_PARAMS, {});
 
         expect(warningStub.called).to.be.false;
         expect(pacWrapperStub.orgSelect.called).to.be.false;
         expect(pacWrapperStub.authCreateNewAuthProfileForOrg.called).to.be.false;
+    });
+
+    it("authenticates when passed create-flow parameters", async () => {
+        pacWrapperStub.activeOrg
+            .onFirstCall().resolves({ Status: "Failure" })
+            .onSecondCall().resolves({ Status: "Success", Results: { EnvironmentId: "env-1" } })
+            .onThirdCall().resolves({ Status: "Success", Results: { EnvironmentId: "env-1" } });
+        warningStub.resolves("Yes");
+
+        await service.prepareAuthenticationAndEnvironment(CREATE_FLOW_PARAMS, {});
+
+        expect(pacWrapperStub.authCreateNewAuthProfileForOrg.calledOnceWith("https://org.crm.dynamics.com/")).to.be.true;
+        expect(pacWrapperStub.orgSelect.called).to.be.false;
     });
 
     it("switches environment when the active org points at a different environment", async () => {
@@ -90,7 +119,7 @@ describe("AuthEnvironmentService", () => {
             .onThirdCall().resolves({ Status: "Success", Results: { EnvironmentId: "env-1" } });
         warningStub.resolves("Yes");
 
-        await service.prepareAuthenticationAndEnvironment(uriParams, {});
+        await service.prepareAuthenticationAndEnvironment(OPEN_URI_PARAMS, {});
 
         expect(pacWrapperStub.orgSelect.calledOnceWith("https://org.crm.dynamics.com/")).to.be.true;
     });

--- a/src/client/test/integration/authEnvironment.test.ts
+++ b/src/client/test/integration/authEnvironment.test.ts
@@ -11,6 +11,7 @@ import { UriParameters } from "../../uriHandler/utils/uriHandlerUtils";
 import { CreateFlowParameters } from "../../uriHandler/handlers/createFlowParams";
 import { PacWrapper } from "../../pac/PacWrapper";
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { URI_HANDLER_STRINGS } from "../../uriHandler/constants/uriStrings";
 
 type ProgressReporter = vscode.Progress<{ message?: string; increment?: number }>;
 type ProgressTask = (progress: ProgressReporter, token: vscode.CancellationToken) => Thenable<void>;
@@ -110,6 +111,40 @@ describe("AuthEnvironmentService", () => {
 
         expect(pacWrapperStub.authCreateNewAuthProfileForOrg.calledOnceWith("https://org.crm.dynamics.com/")).to.be.true;
         expect(pacWrapperStub.orgSelect.called).to.be.false;
+    });
+
+    it("rejects create-flow parameters without an environment ID", async () => {
+        const incompleteParams: CreateFlowParameters = {
+            ...CREATE_FLOW_PARAMS,
+            environmentId: null
+        };
+
+        let thrown: unknown;
+        try {
+            await service.prepareAuthenticationAndEnvironment(incompleteParams, {});
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).to.be.an("error").with.property("message", URI_HANDLER_STRINGS.ERRORS.ENVIRONMENT_ID_REQUIRED);
+        expect(pacWrapperStub.activeOrg.called).to.be.false;
+    });
+
+    it("rejects create-flow parameters without an organization URL", async () => {
+        const incompleteParams: CreateFlowParameters = {
+            ...CREATE_FLOW_PARAMS,
+            orgUrl: null
+        };
+
+        let thrown: unknown;
+        try {
+            await service.prepareAuthenticationAndEnvironment(incompleteParams, {});
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).to.be.an("error").with.property("message", URI_HANDLER_STRINGS.ERRORS.ORG_URL_REQUIRED);
+        expect(pacWrapperStub.activeOrg.called).to.be.false;
     });
 
     it("switches environment when the active org points at a different environment", async () => {

--- a/src/client/uriHandler/utils/authEnvironment.ts
+++ b/src/client/uriHandler/utils/authEnvironment.ts
@@ -17,6 +17,11 @@ export interface AuthEnvironmentTarget {
     orgUrl: string | null;
 }
 
+interface ValidatedAuthEnvironmentTarget {
+    environmentId: string;
+    orgUrl: string;
+}
+
 /**
  * Encapsulates the PAC CLI authentication and environment-selection steps shared by the
  * Power Pages deep-link flows. Extracted from `UriHandler` so that each deep-link handler
@@ -34,6 +39,8 @@ export class AuthEnvironmentService {
      * Handle authentication and environment setup, reporting progress to the user.
      */
     public async prepareAuthenticationAndEnvironment(uriParams: AuthEnvironmentTarget, telemetryData: Record<string, string>): Promise<void> {
+        const target = this.validateTarget(uriParams);
+
         await vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
@@ -52,7 +59,7 @@ export class AuthEnvironmentService {
                 });
 
                 // Check and handle authentication
-                await this.ensureAuthentication(uriParams, telemetryData, progress);
+                await this.ensureAuthentication(target, telemetryData, progress);
 
                 progress.report({
                     message: URI_HANDLER_STRINGS.PROGRESS.CHECKING_ENV,
@@ -60,7 +67,7 @@ export class AuthEnvironmentService {
                 });
 
                 // Check and handle environment switching
-                await this.ensureCorrectEnvironment(uriParams, telemetryData, progress);
+                await this.ensureCorrectEnvironment(target, telemetryData, progress);
 
                 progress.report({
                     message: URI_HANDLER_STRINGS.PROGRESS.READY_TO_SELECT,
@@ -76,7 +83,7 @@ export class AuthEnvironmentService {
     /**
      * Ensure user is authenticated with PAC CLI
      */
-    private async ensureAuthentication(uriParams: AuthEnvironmentTarget, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
+    private async ensureAuthentication(uriParams: ValidatedAuthEnvironmentTarget, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
         let authInfo;
         try {
             authInfo = await this.pacWrapper.activeOrg();
@@ -109,7 +116,7 @@ export class AuthEnvironmentService {
                         increment: 10
                     });
 
-                    await this.pacWrapper.authCreateNewAuthProfileForOrg(uriParams.orgUrl!);
+                    await this.pacWrapper.authCreateNewAuthProfileForOrg(uriParams.orgUrl);
 
                     const newAuthInfo = await this.pacWrapper.activeOrg();
                     if (!newAuthInfo || newAuthInfo.Status !== "Success") {
@@ -137,7 +144,7 @@ export class AuthEnvironmentService {
     /**
      * Ensure we're connected to the correct environment
      */
-    private async ensureCorrectEnvironment(uriParams: AuthEnvironmentTarget, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
+    private async ensureCorrectEnvironment(uriParams: ValidatedAuthEnvironmentTarget, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
         let currentAuthInfo;
         try {
             currentAuthInfo = await this.pacWrapper.activeOrg();
@@ -169,7 +176,7 @@ export class AuthEnvironmentService {
                         increment: 10
                     });
 
-                    await this.pacWrapper.orgSelect(uriParams.orgUrl!);
+                    await this.pacWrapper.orgSelect(uriParams.orgUrl);
 
                     const verifyAuthInfo = await this.pacWrapper.activeOrg();
                     if (verifyAuthInfo?.Status !== "Success" || verifyAuthInfo.Results?.EnvironmentId !== uriParams.environmentId) {
@@ -192,6 +199,24 @@ export class AuthEnvironmentService {
                 throw new Error(URI_HANDLER_STRINGS.ERRORS.USER_CANCELLED_ENV_SWITCH);
             }
         }
+    }
+
+    /**
+     * Validate the authentication and environment target before invoking PAC CLI.
+     */
+    private validateTarget(uriParams: AuthEnvironmentTarget): ValidatedAuthEnvironmentTarget {
+        if (!uriParams.environmentId) {
+            throw new Error(URI_HANDLER_STRINGS.ERRORS.ENVIRONMENT_ID_REQUIRED);
+        }
+
+        if (!uriParams.orgUrl) {
+            throw new Error(URI_HANDLER_STRINGS.ERRORS.ORG_URL_REQUIRED);
+        }
+
+        return {
+            environmentId: uriParams.environmentId,
+            orgUrl: uriParams.orgUrl
+        };
     }
 
     /**

--- a/src/client/uriHandler/utils/authEnvironment.ts
+++ b/src/client/uriHandler/utils/authEnvironment.ts
@@ -8,7 +8,14 @@ import { PacWrapper } from "../../pac/PacWrapper";
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryEvents";
 import { URI_HANDLER_STRINGS } from "../constants/uriStrings";
-import { UriParameters } from "./uriHandlerUtils";
+
+/**
+ * Minimal target required for PAC CLI authentication and environment selection.
+ */
+export interface AuthEnvironmentTarget {
+    environmentId: string | null;
+    orgUrl: string | null;
+}
 
 /**
  * Encapsulates the PAC CLI authentication and environment-selection steps shared by the
@@ -26,7 +33,7 @@ export class AuthEnvironmentService {
     /**
      * Handle authentication and environment setup, reporting progress to the user.
      */
-    public async prepareAuthenticationAndEnvironment(uriParams: UriParameters, telemetryData: Record<string, string>): Promise<void> {
+    public async prepareAuthenticationAndEnvironment(uriParams: AuthEnvironmentTarget, telemetryData: Record<string, string>): Promise<void> {
         await vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
@@ -69,7 +76,7 @@ export class AuthEnvironmentService {
     /**
      * Ensure user is authenticated with PAC CLI
      */
-    private async ensureAuthentication(uriParams: UriParameters, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
+    private async ensureAuthentication(uriParams: AuthEnvironmentTarget, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
         let authInfo;
         try {
             authInfo = await this.pacWrapper.activeOrg();
@@ -130,7 +137,7 @@ export class AuthEnvironmentService {
     /**
      * Ensure we're connected to the correct environment
      */
-    private async ensureCorrectEnvironment(uriParams: UriParameters, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
+    private async ensureCorrectEnvironment(uriParams: AuthEnvironmentTarget, telemetryData: Record<string, string>, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<void> {
         let currentAuthInfo;
         try {
             currentAuthInfo = await this.pacWrapper.activeOrg();


### PR DESCRIPTION
## Summary

Implements Power Pages → VS Code deep-link **Phase 2, slice 2a**.

- Introduces the minimal `AuthEnvironmentTarget` contract so both `/open` `UriParameters` and `CreateFlowParameters` can reuse `AuthEnvironmentService`.
- Validates the environment ID and organization URL before invoking PAC CLI.
- Adds typed integration coverage for the existing `/open` flow, create-flow authentication, environment switching, and missing auth targets.

## Dark behavior

This is an internal, no-behavior-change refactor. `/pacCreate` and `/agenticCreate` remain ECS-gated, telemetry-only no-ops; neither handler invokes authentication yet.

URI parameters are unchanged. This PR does not add `referrersessionid` or any correlation/session ID contract.

This unblocks a later slice from reusing the existing PAC authentication and environment-selection behavior in both create flows.

## Validation

- `node node_modules/gulp/bin/gulp.js lint` — passed
- `npm run compile-tests` — passed
- `npm test` — 106 passing
- `npm run build` — passed (two existing LiquidJS webpack warnings)
- `npm run test-desktop-int` — 907 passing