### PR TITLE
URI handler: instrument common create-flow stages (auth/env/folder) (dark)

### DIFF
--- a/src/client/test/integration/authEnvironment.test.ts
+++ b/src/client/test/integration/authEnvironment.test.ts
@@ -47,7 +47,8 @@ describe("AuthEnvironmentService", () => {
         websiteId: null,
         source: null,
         agentHost: null,
-        version: null
+        version: null,
+        correlationId: null
     };
 
     beforeEach(() => {

--- a/src/client/test/integration/createFlowCommonStages.test.ts
+++ b/src/client/test/integration/createFlowCommonStages.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { PacWrapper } from "../../pac/PacWrapper";
+import {
+    CreateFlowCommonStagesDependencies,
+    runCreateFlowCommonStages
+} from "../../uriHandler/handlers/createFlowCommonStages";
+import {
+    buildCreateFlowTelemetry,
+    CreateFlowParameters
+} from "../../uriHandler/handlers/createFlowParams";
+import {
+    emitCreateFlowError,
+    emitCreateFlowEvent
+} from "../../uriHandler/telemetry/createFlowTelemetry";
+import { uriHandlerTelemetryEventNames } from "../../uriHandler/telemetry/uriHandlerTelemetryEvents";
+import { AuthEnvironmentService } from "../../uriHandler/utils/authEnvironment";
+
+describe("Create-flow common stages", () => {
+    let sandbox: sinon.SinonSandbox;
+    let prepareAuthenticationAndEnvironmentStub: sinon.SinonStub;
+    let selectTargetFolderStub: sinon.SinonStub;
+    let emitCreateFlowEventStub: sinon.SinonStub;
+    let emitCreateFlowErrorStub: sinon.SinonStub;
+    let traceInfoStub: sinon.SinonStub;
+    let traceErrorStub: sinon.SinonStub;
+    let emittedEventNames: string[];
+    let dependencies: CreateFlowCommonStagesDependencies;
+
+    const params: CreateFlowParameters = {
+        environmentId: 'environment-id',
+        orgUrl: 'https://sensitive.crm.dynamics.com',
+        region: 'NAM',
+        tenantId: 'sensitive-tenant-id',
+        websiteId: 'website-id',
+        source: 'power-pages-home',
+        agentHost: null,
+        version: '1',
+        correlationId: 'correlation-id'
+    };
+    const telemetryData = buildCreateFlowTelemetry(params);
+    const pacWrapper = {} as PacWrapper;
+    const selectedFolder = vscode.Uri.file("C:\\sensitive\\selected-folder");
+
+    const expectRedactedTelemetry = (): void => {
+        const properties = [
+            ...traceInfoStub.getCalls().map((call) => call.args[1] as Record<string, string>),
+            ...traceErrorStub.getCalls().map((call) => call.args[3] as Record<string, string>)
+        ];
+
+        for (const eventProperties of properties) {
+            expect(eventProperties).to.not.have.property('folderPath');
+            expect(eventProperties).to.not.have.property('orgUrl');
+            expect(eventProperties).to.not.have.property('tenantId');
+            expect(Object.values(eventProperties)).to.not.include(selectedFolder.fsPath);
+            expect(Object.values(eventProperties)).to.not.include(params.orgUrl);
+            expect(Object.values(eventProperties)).to.not.include(params.tenantId);
+            expect(eventProperties).to.include({
+                environmentId: params.environmentId,
+                websiteId: params.websiteId,
+                correlationId: params.correlationId
+            });
+        }
+    };
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        emittedEventNames = [];
+        prepareAuthenticationAndEnvironmentStub = sandbox.stub().resolves();
+        selectTargetFolderStub = sandbox.stub();
+        traceInfoStub = sandbox.stub();
+        traceErrorStub = sandbox.stub();
+        emitCreateFlowEventStub = sandbox.stub().callsFake((
+            eventName: string,
+            eventParams: CreateFlowParameters,
+            channel: 'pac' | 'agent'
+        ) => {
+            emittedEventNames.push(eventName);
+            emitCreateFlowEvent(eventName, eventParams, channel);
+        });
+        emitCreateFlowErrorStub = sandbox.stub().callsFake((
+            eventName: string,
+            message: string,
+            error: unknown,
+            eventParams: CreateFlowParameters,
+            channel: 'pac' | 'agent'
+        ) => {
+            emittedEventNames.push(eventName);
+            emitCreateFlowError(eventName, message, error, eventParams, channel);
+        });
+
+        sandbox.stub(oneDSLoggerWrapper, "getLogger").returns(
+            { traceInfo: traceInfoStub, traceError: traceErrorStub } as unknown as ReturnType<typeof oneDSLoggerWrapper.getLogger>
+        );
+
+        const authEnvironmentService = {
+            prepareAuthenticationAndEnvironment: prepareAuthenticationAndEnvironmentStub
+        } as unknown as AuthEnvironmentService;
+        dependencies = {
+            createAuthEnvironmentService: sandbox.stub().returns(authEnvironmentService),
+            selectTargetFolder: selectTargetFolderStub,
+            emitCreateFlowEvent: emitCreateFlowEventStub,
+            emitCreateFlowError: emitCreateFlowErrorStub
+        };
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("emits ordered stages and returns the selected folder", async () => {
+        selectTargetFolderStub.resolves(selectedFolder);
+
+        const result = await runCreateFlowCommonStages(
+            params,
+            'pac',
+            telemetryData,
+            pacWrapper,
+            dependencies
+        );
+
+        expect(result).to.equal(selectedFolder);
+        expect(prepareAuthenticationAndEnvironmentStub.calledOnceWithExactly(
+            {
+                environmentId: params.environmentId,
+                orgUrl: params.orgUrl
+            },
+            telemetryData
+        )).to.be.true;
+        expect(emittedEventNames).to.deep.equal([
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_COMPLETED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_ENVIRONMENT_SET,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_SELECTED
+        ]);
+        expectRedactedTelemetry();
+    });
+
+    it("emits cancellation and drop stages when folder selection is cancelled", async () => {
+        selectTargetFolderStub.resolves(undefined);
+
+        const result = await runCreateFlowCommonStages(
+            params,
+            'agent',
+            telemetryData,
+            pacWrapper,
+            dependencies
+        );
+
+        expect(result).to.be.undefined;
+        expect(emittedEventNames).to.deep.equal([
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_COMPLETED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_ENVIRONMENT_SET,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_CANCELLED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        ]);
+        expectRedactedTelemetry();
+    });
+
+    it("emits authentication failure and drop stages when authentication fails", async () => {
+        prepareAuthenticationAndEnvironmentStub.rejects(new Error('authentication failed'));
+
+        const result = await runCreateFlowCommonStages(
+            params,
+            'pac',
+            telemetryData,
+            pacWrapper,
+            dependencies
+        );
+
+        expect(result).to.be.undefined;
+        expect(selectTargetFolderStub.called).to.be.false;
+        expect(emittedEventNames).to.deep.equal([
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_FAILED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        ]);
+        expect(traceErrorStub.calledOnce).to.be.true;
+        expectRedactedTelemetry();
+    });
+});

--- a/src/client/test/integration/createHandlers.test.ts
+++ b/src/client/test/integration/createHandlers.test.ts
@@ -13,12 +13,14 @@ import { ECSFeaturesClient } from "../../../common/ecs-features/ecsFeatureClient
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 import { uriHandlerTelemetryEventNames } from "../../uriHandler/telemetry/uriHandlerTelemetryEvents";
 import { PacWrapper } from "../../pac/PacWrapper";
+import * as createFlowCommonStages from "../../uriHandler/handlers/createFlowCommonStages";
 
 describe("Create deep-link handlers (gated)", () => {
     let sandbox: sinon.SinonSandbox;
     let getConfigStub: sinon.SinonStub;
     let traceInfoStub: sinon.SinonStub;
     let traceErrorStub: sinon.SinonStub;
+    let runCreateFlowCommonStagesStub: sinon.SinonStub;
 
     const pacCreateUri = vscode.Uri.parse(
         `vscode://${URI_CONSTANTS.EXTENSION_ID}${URI_CONSTANTS.PATHS.PAC_CREATE}` +
@@ -62,6 +64,10 @@ describe("Create deep-link handlers (gated)", () => {
         sandbox.stub(oneDSLoggerWrapper, "getLogger").returns(
             { traceInfo: traceInfoStub, traceError: traceErrorStub } as unknown as ReturnType<typeof oneDSLoggerWrapper.getLogger>
         );
+        runCreateFlowCommonStagesStub = sandbox.stub(
+            createFlowCommonStages,
+            "runCreateFlowCommonStages"
+        ).resolves(vscode.Uri.file("C:\\sites"));
     });
 
     afterEach(() => {
@@ -86,11 +92,13 @@ describe("Create deep-link handlers (gated)", () => {
         expectIdentifiers(disabled?.args[1] as Record<string, string>, 'env-1', 'pac-website');
         expect(disabled?.args[1]).to.not.have.property('channel');
         expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED)).to.be.false;
+        expect(runCreateFlowCommonStagesStub.called).to.be.false;
     });
 
     it("PacCreateHandler parses params and emits triggered telemetry when the flag is on", async () => {
         setFlags(true);
-        const handler = new PacCreateHandler({} as PacWrapper);
+        const pacWrapper = {} as PacWrapper;
+        const handler = new PacCreateHandler(pacWrapper);
 
         await handler.handle(pacCreateUri);
 
@@ -108,6 +116,18 @@ describe("Create deep-link handlers (gated)", () => {
             correlationId: 'pac-correlation'
         });
         expectIdentifiers(triggered?.args[1] as Record<string, string>, 'env-1', 'pac-website');
+        expect(runCreateFlowCommonStagesStub.calledOnce).to.be.true;
+        expect(runCreateFlowCommonStagesStub.firstCall.args[0]).to.include({
+            environmentId: 'env-1',
+            websiteId: 'pac-website',
+            correlationId: 'pac-correlation'
+        });
+        expect(runCreateFlowCommonStagesStub.firstCall.args[1]).to.equal('pac');
+        expect(runCreateFlowCommonStagesStub.firstCall.args[2]).to.include({
+            environmentId: 'env-1',
+            websiteId: 'pac-website'
+        });
+        expect(runCreateFlowCommonStagesStub.firstCall.args[3]).to.equal(pacWrapper);
     });
 
     it("PacCreateHandler emits failed telemetry through the create-flow helper", async () => {
@@ -151,11 +171,13 @@ describe("Create deep-link handlers (gated)", () => {
         expectIdentifiers(disabled?.args[1] as Record<string, string>, 'agent-env', 'agent-website');
         expect(disabled?.args[1]).to.not.have.property('channel');
         expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED)).to.be.false;
+        expect(runCreateFlowCommonStagesStub.called).to.be.false;
     });
 
     it("AgenticCreateHandler parses params and emits triggered telemetry when the flag is on", async () => {
         setFlags(true);
-        const handler = new AgenticCreateHandler({} as PacWrapper);
+        const pacWrapper = {} as PacWrapper;
+        const handler = new AgenticCreateHandler(pacWrapper);
 
         await handler.handle(agenticCreateUri);
 
@@ -172,6 +194,18 @@ describe("Create deep-link handlers (gated)", () => {
             correlationId: 'agent-correlation'
         });
         expectIdentifiers(triggered?.args[1] as Record<string, string>, 'agent-env', 'agent-website');
+        expect(runCreateFlowCommonStagesStub.calledOnce).to.be.true;
+        expect(runCreateFlowCommonStagesStub.firstCall.args[0]).to.include({
+            environmentId: 'agent-env',
+            websiteId: 'agent-website',
+            correlationId: 'agent-correlation'
+        });
+        expect(runCreateFlowCommonStagesStub.firstCall.args[1]).to.equal('agent');
+        expect(runCreateFlowCommonStagesStub.firstCall.args[2]).to.include({
+            environmentId: 'agent-env',
+            websiteId: 'agent-website'
+        });
+        expect(runCreateFlowCommonStagesStub.firstCall.args[3]).to.equal(pacWrapper);
     });
 
     it("AgenticCreateHandler emits failed telemetry through the create-flow helper", async () => {

--- a/src/client/uriHandler/handlers/agenticCreateHandler.ts
+++ b/src/client/uriHandler/handlers/agenticCreateHandler.ts
@@ -11,15 +11,16 @@ import { EnableAgenticCreateFromHome } from "../../../common/ecs-features/ecsFea
 import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryEvents";
 import { buildCreateFlowTelemetry, parseCreateFlowParameters } from "./createFlowParams";
 import { emitCreateFlowError, emitCreateFlowEvent } from "../telemetry/createFlowTelemetry";
+import { runCreateFlowCommonStages } from "./createFlowCommonStages";
 
 /**
  * Handles the `/agenticCreate` deep link launched from the Power Pages home page, which will
  * open VS Code into an agentic (terminal CLI agent host) create experience.
  *
  * This is a dark, flag-gated scaffold. When {@link EnableAgenticCreateFromHome} is off (the
- * default) the handler is a no-op. When enabled it only parses the deep-link parameters and
- * emits a "triggered" telemetry event — the actual agentic behavior (agent-host selection and
- * Power Pages plugin bootstrapping) is intentionally deferred to a follow-up change.
+ * default) the handler is a no-op. When enabled it runs the shared authentication, environment,
+ * and folder-selection stages. The actual agentic behavior (agent-host selection and Power Pages
+ * plugin bootstrapping) is intentionally deferred to a follow-up change.
  */
 export class AgenticCreateHandler {
     private readonly pacWrapper: PacWrapper;
@@ -60,10 +61,17 @@ export class AgenticCreateHandler {
                 'agent'
             );
 
-            // NOTE: Behavior intentionally not implemented yet. The agentic create flow
-            // (agent-host detection/selection + Power Pages plugin bootstrapping) is a
-            // follow-up. `pacWrapper` is retained for use by that implementation.
-            void this.pacWrapper;
+            const folderUri = await runCreateFlowCommonStages(
+                params,
+                'agent',
+                telemetryData,
+                this.pacWrapper
+            );
+            if (!folderUri) {
+                return;
+            }
+
+            // TODO (G2/G3 agent): Implement the channel-specific tail using folderUri.
         } catch (error) {
             emitCreateFlowError(
                 uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_FAILED,

--- a/src/client/uriHandler/handlers/createFlowCommonStages.ts
+++ b/src/client/uriHandler/handlers/createFlowCommonStages.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { PacWrapper } from "../../pac/PacWrapper";
+import { emitCreateFlowError, emitCreateFlowEvent } from "../telemetry/createFlowTelemetry";
+import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryEvents";
+import { AuthEnvironmentService, AuthEnvironmentTarget } from "../utils/authEnvironment";
+import { selectTargetFolder } from "../utils/selectTargetFolder";
+import { CreateFlowParameters } from "./createFlowParams";
+
+/**
+ * Create-flow channel that is running the common stages.
+ */
+export type CreateFlowChannel = 'pac' | 'agent';
+
+/**
+ * Injectable dependencies for the common create-flow stages.
+ */
+export interface CreateFlowCommonStagesDependencies {
+    createAuthEnvironmentService: (pacWrapper: PacWrapper) => AuthEnvironmentService;
+    selectTargetFolder: typeof selectTargetFolder;
+    emitCreateFlowEvent: typeof emitCreateFlowEvent;
+    emitCreateFlowError: typeof emitCreateFlowError;
+}
+
+const DEFAULT_DEPENDENCIES: CreateFlowCommonStagesDependencies = {
+    createAuthEnvironmentService: (pacWrapper) => new AuthEnvironmentService(pacWrapper),
+    selectTargetFolder,
+    emitCreateFlowEvent,
+    emitCreateFlowError
+};
+
+/**
+ * Runs the authentication, environment, and target-folder stages shared by create flows.
+ * @param params Parsed create-flow parameters.
+ * @param channel Create-flow channel requesting the shared stages.
+ * @param telemetryData Redacted telemetry passed to the authentication/environment service.
+ * @param pacWrapper PAC CLI wrapper used by the authentication/environment service.
+ * @param dependencies Injectable dependencies used by integration tests.
+ * @returns The selected target folder, or undefined when the flow has already been dropped.
+ */
+export const runCreateFlowCommonStages = async (
+    params: CreateFlowParameters,
+    channel: CreateFlowChannel,
+    telemetryData: Record<string, string>,
+    pacWrapper: PacWrapper,
+    dependencies: CreateFlowCommonStagesDependencies = DEFAULT_DEPENDENCIES
+): Promise<vscode.Uri | undefined> => {
+    dependencies.emitCreateFlowEvent(
+        uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+        params,
+        channel
+    );
+
+    const target: AuthEnvironmentTarget = {
+        environmentId: params.environmentId,
+        orgUrl: params.orgUrl
+    };
+
+    try {
+        const authEnvironmentService = dependencies.createAuthEnvironmentService(pacWrapper);
+        await authEnvironmentService.prepareAuthenticationAndEnvironment(target, telemetryData);
+    } catch (error) {
+        dependencies.emitCreateFlowError(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_FAILED,
+            'Create flow authentication and environment preparation failed',
+            error,
+            params,
+            channel
+        );
+        dependencies.emitCreateFlowEvent(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED,
+            params,
+            channel
+        );
+        return undefined;
+    }
+
+    dependencies.emitCreateFlowEvent(
+        uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_COMPLETED,
+        params,
+        channel
+    );
+    dependencies.emitCreateFlowEvent(
+        uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_ENVIRONMENT_SET,
+        params,
+        channel
+    );
+
+    const folderUri = await dependencies.selectTargetFolder();
+    if (!folderUri) {
+        dependencies.emitCreateFlowEvent(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_CANCELLED,
+            params,
+            channel
+        );
+        dependencies.emitCreateFlowEvent(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED,
+            params,
+            channel
+        );
+        return undefined;
+    }
+
+    dependencies.emitCreateFlowEvent(
+        uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_SELECTED,
+        params,
+        channel
+    );
+    return folderUri;
+};

--- a/src/client/uriHandler/handlers/pacCreateHandler.ts
+++ b/src/client/uriHandler/handlers/pacCreateHandler.ts
@@ -11,15 +11,16 @@ import { EnablePacCreateFromHome } from "../../../common/ecs-features/ecsFeature
 import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryEvents";
 import { buildCreateFlowTelemetry, parseCreateFlowParameters } from "./createFlowParams";
 import { emitCreateFlowError, emitCreateFlowEvent } from "../telemetry/createFlowTelemetry";
+import { runCreateFlowCommonStages } from "./createFlowCommonStages";
 
 /**
  * Handles the `/pacCreate` deep link launched from the Power Pages home page, which will open
  * VS Code into a Power Platform CLI (PAC) create experience.
  *
  * This is a dark, flag-gated scaffold. When {@link EnablePacCreateFromHome} is off (the
- * default) the handler is a no-op. When enabled it only parses the deep-link parameters and
- * emits a "triggered" telemetry event — the actual PAC create behavior (auth, environment
- * selection, folder selection, PAC CLI terminal) is intentionally deferred to a follow-up.
+ * default) the handler is a no-op. When enabled it runs the shared authentication, environment,
+ * and folder-selection stages. The actual PAC create behavior (parameter collection and PAC CLI
+ * terminal launch) is intentionally deferred to a follow-up.
  */
 export class PacCreateHandler {
     private readonly pacWrapper: PacWrapper;
@@ -60,10 +61,17 @@ export class PacCreateHandler {
                 'pac'
             );
 
-            // NOTE: Behavior intentionally not implemented yet. The PAC create flow (auth ->
-            // environment -> folder -> PAC CLI terminal) is a follow-up. `pacWrapper` is
-            // retained for use by that implementation.
-            void this.pacWrapper;
+            const folderUri = await runCreateFlowCommonStages(
+                params,
+                'pac',
+                telemetryData,
+                this.pacWrapper
+            );
+            if (!folderUri) {
+                return;
+            }
+
+            // TODO (P1/P2 pac): Implement the channel-specific tail using folderUri.
         } catch (error) {
             emitCreateFlowError(
                 uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_FAILED,


### PR DESCRIPTION
## Summary
- add one shared create-flow spine for authentication, environment setup, and target-folder selection
- emit the existing funnel events at the handler seam for both PAC and agent channels
- stop cleanly on auth failure or folder cancellation while preserving redaction and correlation metadata
- keep both ECS gates default-off and leave channel-specific tails as explicit follow-up TODOs

## Validation
- `node node_modules/gulp/bin/gulp.js lint`
- `npm run compile-tests`
- `npm test` (110 passing)
- `npm run build` (2 expected LiquidJS warnings)
- `npm run test-desktop-int` (921 passing)

## Review state
Draft only. Ready-for-review remains gated on the separate OII telemetry-ingestion classification sign-off; this change does not alter either ECS gate.