### PR TITLE
URI handler: agentic-install telemetry events + constants + strings (dark)

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -139,12 +139,19 @@
   "You are currently connected to a different environment. Would you like to switch to the required environment?": "You are currently connected to a different environment. Would you like to switch to the required environment?",
   "Power Pages site download completed successfully. Would you like to open the downloaded site folder?": "Power Pages site download completed successfully. Would you like to open the downloaded site folder?",
   "Select Folder to Download Power Pages Site": "Select Folder to Download Power Pages Site",
+  "{0} isn't installed. Install it, then choose Check Again — most installs are picked up without restarting VS Code.": "{0} isn't installed. Install it, then choose Check Again — most installs are picked up without restarting VS Code.",
+  "{0} is now installed. Resume creating your Power Pages site?": "{0} is now installed. Resume creating your Power Pages site?",
   "Yes": "Yes",
   "No": "No",
   "Select Folder": "Select Folder",
   "Open Folder": "Open Folder",
   "Open in New Workspace": "Open in New Workspace",
   "Not Now": "Not Now",
+  "View Installation Guide": "View Installation Guide",
+  "Check Again": "Check Again",
+  "Dismiss": "Dismiss",
+  "Reload Window": "Reload Window",
+  "Resume": "Resume",
   "Download Power Pages Site": "Download Power Pages Site",
   "Select Folder for new PCF Control/Do not translate 'PCF' as it is a product name.": {
     "message": "Select Folder for new PCF Control",
@@ -163,6 +170,7 @@
   "Authenticating...": "Authenticating...",
   "Switching environment...": "Switching environment...",
   "pac pcf init": "pac pcf init",
+  "Not installed · Select to view installation guidance.": "Not installed · Select to view installation guidance.",
   "File might be referenced by name {0} here./{0} represents the name of the file": {
     "message": "File might be referenced by name {0} here.",
     "comment": [

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -139,7 +139,15 @@
   "You are currently connected to a different environment. Would you like to switch to the required environment?": "You are currently connected to a different environment. Would you like to switch to the required environment?",
   "Power Pages site download completed successfully. Would you like to open the downloaded site folder?": "Power Pages site download completed successfully. Would you like to open the downloaded site folder?",
   "Select Folder to Download Power Pages Site": "Select Folder to Download Power Pages Site",
-  "{0} isn't installed. Install it, then choose Check Again — most installs are picked up without restarting VS Code.": "{0} isn't installed. Install it, then choose Check Again — most installs are picked up without restarting VS Code.",
+  "Check Again": "Check Again",
+  "{0} isn't installed. Install it, then choose {1} — most installs are picked up without restarting VS Code./{0} is the agent host display name and is replaced when the message is shown.{1} is the localized label of the Check Again button.Do not translate 'VS Code' as it is a product name.": {
+    "message": "{0} isn't installed. Install it, then choose {1} — most installs are picked up without restarting VS Code.",
+    "comment": [
+      "{0} is the agent host display name and is replaced when the message is shown.",
+      "{1} is the localized label of the Check Again button.",
+      "Do not translate 'VS Code' as it is a product name."
+    ]
+  },
   "{0} is now installed. Resume creating your Power Pages site?": "{0} is now installed. Resume creating your Power Pages site?",
   "Yes": "Yes",
   "No": "No",
@@ -148,7 +156,6 @@
   "Open in New Workspace": "Open in New Workspace",
   "Not Now": "Not Now",
   "View Installation Guide": "View Installation Guide",
-  "Check Again": "Check Again",
   "Dismiss": "Dismiss",
   "Reload Window": "Reload Window",
   "Resume": "Resume",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -166,6 +166,9 @@ This action cannot be undone.</source>
     <trans-unit id="++CODE++b75d741af5a9c59c95a5c7b7d9f654bb93617232db14c8d2671a5c731828782b">
       <source xml:lang="en">Changing environment...</source>
     </trans-unit>
+    <trans-unit id="++CODE++32e60e730d2e6845d352b9c5dd55af8bed341c220b7f94d58325bc1dc75adb63">
+      <source xml:lang="en">Check Again</source>
+    </trans-unit>
     <trans-unit id="++CODE++9885d66d0771f63c5a4b5d3b8cbe26be8832bc941243f5b18573975750a9986b">
       <source xml:lang="en">Check the URL and verify the parameters are correct</source>
     </trans-unit>
@@ -429,6 +432,9 @@ Check the CodeQL extension panel for available queries.</source>
     </trans-unit>
     <trans-unit id="++CODE++21c02244893ddc07c4494a2ac7eb69a143e75d7b49d04f10234a1865c2111310">
       <source xml:lang="en">Dislike something? Tell us more.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++48845bff334a50a59aaecf499f28a7a24c3b4b891b8b18a9f1169ad8e8a6b261">
+      <source xml:lang="en">Dismiss</source>
     </trans-unit>
     <trans-unit id="++CODE++e9f79ac902b11087dd0d34e8afc1de54df4e48d45861a0c0b6e4edd3c204f314">
       <source xml:lang="en">Display Name: {0}
@@ -928,6 +934,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++ccb4c324f516c63335c648ee08a66b8cc78737d26156f0c84707cd0ee4235492">
       <source xml:lang="en">Not Now</source>
     </trans-unit>
+    <trans-unit id="++CODE++29aea876d5bca2b2ee00e4d89a01aa8b1a8e97175fef5ab5cb73e81d8455b500">
+      <source xml:lang="en">Not installed · Select to view installation guidance.</source>
+    </trans-unit>
     <trans-unit id="++CODE++b2b461f3eae470e95fdcfd61a3cbe6680e84d0a7221a305f696ce44843badc89">
       <source xml:lang="en">Object ID: {0}</source>
       <note>{0} is the Object ID</note>
@@ -1081,6 +1090,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
       <source xml:lang="en">Refreshing comparison for {0} ([details](command:microsoft.powerplatform.pages.actionsHub.showOutputChannel &quot;Show download output&quot;))...</source>
       <note>This is a markdown formatting which must persist across translations.</note>
     </trans-unit>
+    <trans-unit id="++CODE++423e44de44431caef68c0c61968777e088fd50d2577feea60b9ba4a14b28a827">
+      <source xml:lang="en">Reload Window</source>
+    </trans-unit>
     <trans-unit id="++CODE++ffa98e02f7ce33fc935f02b3b668f6ad57661814dade5f41453fbee2b70cdd95">
       <source xml:lang="en">Remote</source>
     </trans-unit>
@@ -1089,6 +1101,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     </trans-unit>
     <trans-unit id="++CODE++b87504a6b179044cf99d39cf641f47aa5e76c4c5b949413ec33953ec35c10ac4">
       <source xml:lang="en">Results opened in SARIF viewer successfully.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++d640c7421da066618a39daf4266da5f61f66a9b1afcd626481b831a17064965d">
+      <source xml:lang="en">Resume</source>
     </trans-unit>
     <trans-unit id="++CODE++00d60e31a4e6b8344d4201f25a6a7dee770713107f6d097abb01559d32b17f26">
       <source xml:lang="en">Run</source>
@@ -1443,6 +1458,9 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++527423ed0138373aa91233083f12eceeae92aa1998e6706d7a260524dafbe6c4">
       <source xml:lang="en">Validating authentication...</source>
     </trans-unit>
+    <trans-unit id="++CODE++e9d8c62d601b715092d29b92eb772eff38e7130e2f8199a3c41196489ef23bf4">
+      <source xml:lang="en">View Installation Guide</source>
+    </trans-unit>
     <trans-unit id="++CODE++d941ee96c6f480390012381f9fc0dfd961f2aa803732860e2505a8453700f458">
       <source xml:lang="en">We encountered an error preparing the files for edit.</source>
     </trans-unit>
@@ -1557,6 +1575,12 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++75a1e748520c8974a0ff5bf44b9d3a54c618fc7422b40e41465de59d8049331d">
       <source xml:lang="en">{0} files changed (Imported {1})</source>
       <note>Description for imported comparison. {0} is file count, {1} is formatted date.</note>
+    </trans-unit>
+    <trans-unit id="++CODE++cbb58bf52139fb4500869fc02c2559dc0bcd41de2b78a941bd8ab8c33e665a26">
+      <source xml:lang="en">{0} is now installed. Resume creating your Power Pages site?</source>
+    </trans-unit>
+    <trans-unit id="++CODE++7130e6af997675b07ed7d33d223f0cefa01078eef3dbefeefc80a5003aaeb4d8">
+      <source xml:lang="en">{0} isn't installed. Install it, then choose Check Again — most installs are picked up without restarting VS Code.</source>
     </trans-unit>
     <trans-unit id="++CODE++21471e6993c28688e252bf884db38022cef15af0126d3d7f68c5e4a6c4dfd9d3">
       <source xml:lang="en">{0}: {1} (Remote ↔ Local)</source>

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -1579,8 +1579,11 @@ The {3} represents Dataverse Environment's Organization ID (GUID)</note>
     <trans-unit id="++CODE++cbb58bf52139fb4500869fc02c2559dc0bcd41de2b78a941bd8ab8c33e665a26">
       <source xml:lang="en">{0} is now installed. Resume creating your Power Pages site?</source>
     </trans-unit>
-    <trans-unit id="++CODE++7130e6af997675b07ed7d33d223f0cefa01078eef3dbefeefc80a5003aaeb4d8">
-      <source xml:lang="en">{0} isn't installed. Install it, then choose Check Again — most installs are picked up without restarting VS Code.</source>
+    <trans-unit id="++CODE++dda309fd0551478f2a322c36bc4ce212517a94dc4011163cfb3c23a125779792">
+      <source xml:lang="en">{0} isn't installed. Install it, then choose {1} — most installs are picked up without restarting VS Code.</source>
+      <note>{0} is the agent host display name and is replaced when the message is shown.
+{1} is the localized label of the Check Again button.
+Do not translate 'VS Code' as it is a product name.</note>
     </trans-unit>
     <trans-unit id="++CODE++21471e6993c28688e252bf884db38022cef15af0126d3d7f68c5e4a6c4dfd9d3">
       <source xml:lang="en">{0}: {1} (Remote ↔ Local)</source>

--- a/src/client/test/integration/createFlowTelemetry.test.ts
+++ b/src/client/test/integration/createFlowTelemetry.test.ts
@@ -65,7 +65,7 @@ describe("Create-flow telemetry", () => {
     });
 
     it("defines the create-flow funnel events in stage order", () => {
-        expect(Object.values(uriHandlerTelemetryEventNames).slice(-13)).to.deep.equal([
+        expect(Object.values(uriHandlerTelemetryEventNames).slice(-19)).to.deep.equal([
             'UriHandlerCreateAuthStarted',
             'UriHandlerCreateAuthCompleted',
             'UriHandlerCreateAuthFailed',
@@ -78,7 +78,13 @@ describe("Create-flow telemetry", () => {
             'UriHandlerAgenticCreateHostSelected',
             'UriHandlerAgenticCreatePluginSequenceLaunched',
             'UriHandlerAgenticCreateSamplePromptSent',
-            'UriHandlerCreateFlowDropped'
+            'UriHandlerCreateFlowDropped',
+            'UriHandlerAgenticCreateHostInstallPrompted',
+            'UriHandlerAgenticCreateHostInstallGuideOpened',
+            'UriHandlerAgenticCreateHostInstallRechecked',
+            'UriHandlerAgenticCreateHostInstallReloadRequested',
+            'UriHandlerAgenticCreateHostInstallResumed',
+            'UriHandlerAgenticCreateHostInstallDismissed'
         ]);
     });
 

--- a/src/client/test/unit/uriConstants.test.ts
+++ b/src/client/test/unit/uriConstants.test.ts
@@ -37,4 +37,15 @@ describe("URI_CONSTANTS deep-link contract", () => {
         expect(URI_CONSTANTS.AGENT_HOST_VALUES.CLAUDE).to.equal("claude");
         expect(URI_CONSTANTS.AGENT_HOST_VALUES.AUTO).to.equal("auto");
     });
+
+    it("defines agent host install metadata", () => {
+        expect(URI_CONSTANTS.AGENT_HOST_INSTALL_GUIDE_URLS.copilot).to.equal(
+            "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli"
+        );
+        expect(URI_CONSTANTS.AGENT_HOST_INSTALL_GUIDE_URLS.claude).to.equal(
+            "https://code.claude.com/docs/en/setup"
+        );
+        expect(URI_CONSTANTS.RESUME_MARKER.KEY).to.equal("powerPages.agenticCreate.resumeMarker");
+        expect(URI_CONSTANTS.RESUME_MARKER.TTL_MS).to.equal(600000);
+    });
 });

--- a/src/client/uriHandler/constants/uriConstants.ts
+++ b/src/client/uriHandler/constants/uriConstants.ts
@@ -50,6 +50,16 @@ export const URI_CONSTANTS = {
     },
     TIMEOUTS: {
         COMPLETION_DIALOG: 30000 // 30 seconds
+    },
+    // TODO: confirm final install-guide URLs with design
+    AGENT_HOST_INSTALL_GUIDE_URLS: {
+        copilot: 'https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli',
+        claude: 'https://code.claude.com/docs/en/setup'
+    },
+    // Resume markers remain fresh for 10 minutes.
+    RESUME_MARKER: {
+        KEY: 'powerPages.agenticCreate.resumeMarker',
+        TTL_MS: 600000
     }
 } as const;
 

--- a/src/client/uriHandler/constants/uriStrings.ts
+++ b/src/client/uriHandler/constants/uriStrings.ts
@@ -31,7 +31,15 @@ export const URI_HANDLER_STRINGS = {
         ENV_SWITCH_REQUIRED: vscode.l10n.t("You are currently connected to a different environment. Would you like to switch to the required environment?"),
         DOWNLOAD_COMPLETE: vscode.l10n.t("Power Pages site download completed successfully. Would you like to open the downloaded site folder?"),
         FOLDER_SELECT: vscode.l10n.t("Select Folder to Download Power Pages Site"),
-        AGENT_HOST_INSTALL_GUIDANCE: vscode.l10n.t("{0} isn't installed. Install it, then choose Check Again — most installs are picked up without restarting VS Code."),
+        AGENT_HOST_INSTALL_GUIDANCE: vscode.l10n.t({
+            message: "{0} isn't installed. Install it, then choose {1} — most installs are picked up without restarting VS Code.",
+            args: ["{0}", vscode.l10n.t("Check Again")],
+            comment: [
+                "{0} is the agent host display name and is replaced when the message is shown.",
+                "{1} is the localized label of the Check Again button.",
+                "Do not translate 'VS Code' as it is a product name."
+            ]
+        }),
         AGENT_HOST_INSTALL_RESUME: vscode.l10n.t("{0} is now installed. Resume creating your Power Pages site?")
     },
     BUTTONS: {

--- a/src/client/uriHandler/constants/uriStrings.ts
+++ b/src/client/uriHandler/constants/uriStrings.ts
@@ -30,7 +30,9 @@ export const URI_HANDLER_STRINGS = {
         AUTH_REQUIRED: vscode.l10n.t("You need to authenticate with Power Platform to download the site. Would you like to authenticate now?"),
         ENV_SWITCH_REQUIRED: vscode.l10n.t("You are currently connected to a different environment. Would you like to switch to the required environment?"),
         DOWNLOAD_COMPLETE: vscode.l10n.t("Power Pages site download completed successfully. Would you like to open the downloaded site folder?"),
-        FOLDER_SELECT: vscode.l10n.t("Select Folder to Download Power Pages Site")
+        FOLDER_SELECT: vscode.l10n.t("Select Folder to Download Power Pages Site"),
+        AGENT_HOST_INSTALL_GUIDANCE: vscode.l10n.t("{0} isn't installed. Install it, then choose Check Again — most installs are picked up without restarting VS Code."),
+        AGENT_HOST_INSTALL_RESUME: vscode.l10n.t("{0} is now installed. Resume creating your Power Pages site?")
     },
     BUTTONS: {
         YES: vscode.l10n.t("Yes"),
@@ -38,7 +40,12 @@ export const URI_HANDLER_STRINGS = {
         SELECT_FOLDER: vscode.l10n.t("Select Folder"),
         OPEN_FOLDER: vscode.l10n.t("Open Folder"),
         OPEN_NEW_WORKSPACE: vscode.l10n.t("Open in New Workspace"),
-        NOT_NOW: vscode.l10n.t("Not Now")
+        NOT_NOW: vscode.l10n.t("Not Now"),
+        VIEW_INSTALLATION_GUIDE: vscode.l10n.t("View Installation Guide"),
+        CHECK_AGAIN: vscode.l10n.t("Check Again"),
+        DISMISS: vscode.l10n.t("Dismiss"),
+        RELOAD_WINDOW: vscode.l10n.t("Reload Window"),
+        RESUME: vscode.l10n.t("Resume")
     },
     TITLES: {
         DOWNLOAD_TITLE: vscode.l10n.t("Download Power Pages Site"),
@@ -61,5 +68,8 @@ export const URI_HANDLER_STRINGS = {
     },
     COMMANDS: {
         PAC_PCF_INIT: vscode.l10n.t("pac pcf init")
+    },
+    DESCRIPTIONS: {
+        AGENT_HOST_NOT_INSTALLED: vscode.l10n.t("Not installed · Select to view installation guidance.")
     }
 } as const;

--- a/src/client/uriHandler/telemetry/uriHandlerTelemetryEvents.ts
+++ b/src/client/uriHandler/telemetry/uriHandlerTelemetryEvents.ts
@@ -35,5 +35,11 @@ export enum uriHandlerTelemetryEventNames {
     URI_HANDLER_AGENTIC_CREATE_HOST_SELECTED = "UriHandlerAgenticCreateHostSelected",
     URI_HANDLER_AGENTIC_CREATE_PLUGIN_SEQUENCE_LAUNCHED = "UriHandlerAgenticCreatePluginSequenceLaunched",
     URI_HANDLER_AGENTIC_CREATE_SAMPLE_PROMPT_SENT = "UriHandlerAgenticCreateSamplePromptSent",
-    URI_HANDLER_CREATE_FLOW_DROPPED = "UriHandlerCreateFlowDropped"
+    URI_HANDLER_CREATE_FLOW_DROPPED = "UriHandlerCreateFlowDropped",
+    URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_PROMPTED = "UriHandlerAgenticCreateHostInstallPrompted",
+    URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_GUIDE_OPENED = "UriHandlerAgenticCreateHostInstallGuideOpened",
+    URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RECHECKED = "UriHandlerAgenticCreateHostInstallRechecked",
+    URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RELOAD_REQUESTED = "UriHandlerAgenticCreateHostInstallReloadRequested",
+    URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RESUMED = "UriHandlerAgenticCreateHostInstallResumed",
+    URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED = "UriHandlerAgenticCreateHostInstallDismissed"
 }


### PR DESCRIPTION
## Summary
- append six dark agentic host-install telemetry event names
- add official Copilot CLI and Claude Code installation guide URLs plus a 10-minute resume marker
- externalize the approved install guidance, resume prompt, picker description, and action labels
- update focused enum-order and constants-contract coverage and regenerate localization artifacts

## Validation
- `node node_modules/gulp/bin/gulp.js lint`
- `npm run compile-tests`
- `npm test`
- `npm run build`
- `npm run test-desktop-int`
- `npm run translations-export`

All commands pass. The build emits the two expected LiquidJS webpack warnings.

## Notes
This remains dark: no handler/util wiring, behavior, ECS-gate, or dependency changes. Keep the PR in draft pending OII telemetry-ingestion classification sign-off.