### PR TITLE
URI handler: always-both agent-host picker util (dark)

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -159,6 +159,10 @@
   "Dismiss": "Dismiss",
   "Reload Window": "Reload Window",
   "Resume": "Resume",
+  "GitHub Copilot CLI": "GitHub Copilot CLI",
+  "Claude Code": "Claude Code",
+  "Installed": "Installed",
+  "Installed · {0}": "Installed · {0}",
   "Download Power Pages Site": "Download Power Pages Site",
   "Select Folder for new PCF Control/Do not translate 'PCF' as it is a product name.": {
     "message": "Select Folder for new PCF Control",

--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -187,6 +187,9 @@ This action cannot be undone.</source>
     <trans-unit id="++CODE++2c8d1f9ca282591926b952dc5949d44df6204f1f0a3f5183bcd5ef7ae5864bad">
       <source xml:lang="en">Choose web template</source>
     </trans-unit>
+    <trans-unit id="++CODE++246ef8c1130d56f5d9df740a4b26c033a8b9c064daba9bb0a052d18993e87373">
+      <source xml:lang="en">Claude Code</source>
+    </trans-unit>
     <trans-unit id="++CODE++83b12c2216efb4fdc924e1deb5182e905e4926ed0c1c324d467107f46d5a26a9">
       <source xml:lang="en">Clear</source>
     </trans-unit>
@@ -719,6 +722,9 @@ The {3} represents Solution's Type (Managed or Unmanaged), but that test is loca
     <trans-unit id="++CODE++0087988cdb71080f2525354e125366c6db7d85a36f199e2f80d14a44b3fd0340">
       <source xml:lang="en">Getting website endpoint...</source>
     </trans-unit>
+    <trans-unit id="++CODE++0f77fb6416bc872ede59a1594352d2ec69abadcc1870800eb9c0191ebc5a335b">
+      <source xml:lang="en">GitHub Copilot CLI</source>
+    </trans-unit>
     <trans-unit id="++CODE++7b9ca5026e65057a17f951928bd53dc4e7724c0850490d6237636e9d568db4b1">
       <source xml:lang="en">HTML report saved successfully to '{0}'.</source>
       <note>Success message when HTML report is saved. {0} is the file path.</note>
@@ -767,6 +773,12 @@ Return to this chat and @powerpages can help you write and edit your website cod
     </trans-unit>
     <trans-unit id="++CODE++569ca49f4aaf7846e952c1d4aeca72febd0b79fa1c4f9db08fd3127551218572">
       <source xml:lang="en">Install</source>
+    </trans-unit>
+    <trans-unit id="++CODE++f8b32f4e92bd84ce1fcd177bec17d43093de3ee8303bb40c1b9ea521ed6a70f6">
+      <source xml:lang="en">Installed</source>
+    </trans-unit>
+    <trans-unit id="++CODE++360963aae4ca47256844e205a2496968f7a9bd00dd397aa364a47eaa4eddbfd6">
+      <source xml:lang="en">Installed · {0}</source>
     </trans-unit>
     <trans-unit id="++CODE++25109e9c19daeeed3977b84ace83722ac8a4daafcfe4e3709082fcc5b228e7a8">
       <source xml:lang="en">Installing Power Pages generator(v{0})...</source>

--- a/src/client/test/integration/selectAgentHost.test.ts
+++ b/src/client/test/integration/selectAgentHost.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import {
+    AgentHost,
+    AgentHostDetectionResult
+} from "../../uriHandler/utils/detectAgentHost";
+import {
+    AgentHostSelection,
+    selectAgentHost
+} from "../../uriHandler/utils/selectAgentHost";
+
+const mixedDetection: AgentHostDetectionResult[] = [
+    {
+        host: AgentHost.Copilot,
+        installed: true,
+        version: "1.2.3"
+    },
+    {
+        host: AgentHost.Claude,
+        installed: false
+    }
+];
+
+describe("selectAgentHost", () => {
+    it("shows both hosts in detection order with installation descriptions", async () => {
+        const showQuickPick = sinon.stub().resolves(undefined);
+
+        await selectAgentHost(mixedDetection, { showQuickPick });
+
+        const items = showQuickPick.firstCall.firstArg as Array<vscode.QuickPickItem & AgentHostSelection>;
+        expect(items.map(item => ({
+            label: item.label,
+            description: item.description,
+            host: item.host,
+            installed: item.installed
+        }))).to.deep.equal([
+            {
+                label: "GitHub Copilot CLI",
+                description: "Installed · 1.2.3",
+                host: AgentHost.Copilot,
+                installed: true
+            },
+            {
+                label: "Claude Code",
+                description: "Not installed · Select to view installation guidance.",
+                host: AgentHost.Claude,
+                installed: false
+            }
+        ]);
+    });
+
+    it("shows the installed description without a version when none is available", async () => {
+        const showQuickPick = sinon.stub().resolves(undefined);
+        const detection: AgentHostDetectionResult[] = [
+            {
+                host: AgentHost.Copilot,
+                installed: true
+            },
+            mixedDetection[1]
+        ];
+
+        await selectAgentHost(detection, { showQuickPick });
+
+        const items = showQuickPick.firstCall.firstArg as vscode.QuickPickItem[];
+        expect(items[0].description).to.equal("Installed");
+    });
+
+    it("returns a selection when the chosen host is not installed", async () => {
+        const showQuickPick = sinon.stub().callsFake(async (items: readonly vscode.QuickPickItem[]) => items[1]);
+
+        const result = await selectAgentHost(mixedDetection, { showQuickPick });
+
+        expect(result).to.deep.equal({
+            host: AgentHost.Claude,
+            installed: false
+        });
+    });
+
+    it("returns a selection when the chosen host is installed", async () => {
+        const showQuickPick = sinon.stub().callsFake(async (items: readonly vscode.QuickPickItem[]) => items[0]);
+
+        const result = await selectAgentHost(mixedDetection, { showQuickPick });
+
+        expect(result).to.deep.equal({
+            host: AgentHost.Copilot,
+            installed: true
+        });
+    });
+
+    it("returns undefined when the user cancels", async () => {
+        const showQuickPick = sinon.stub().resolves(undefined);
+
+        const result = await selectAgentHost(mixedDetection, { showQuickPick });
+
+        expect(result).to.be.undefined;
+    });
+});

--- a/src/client/test/integration/selectAgentHost.test.ts
+++ b/src/client/test/integration/selectAgentHost.test.ts
@@ -71,6 +71,23 @@ describe("selectAgentHost", () => {
         expect(items[0].description).to.equal("Installed");
     });
 
+    it("shows the installed description when the version is whitespace-only", async () => {
+        const showQuickPick = sinon.stub().resolves(undefined);
+        const detection: AgentHostDetectionResult[] = [
+            {
+                host: AgentHost.Copilot,
+                installed: true,
+                version: "   "
+            },
+            mixedDetection[1]
+        ];
+
+        await selectAgentHost(detection, { showQuickPick });
+
+        const items = showQuickPick.firstCall.firstArg as vscode.QuickPickItem[];
+        expect(items[0].description).to.equal("Installed");
+    });
+
     it("returns a selection when the chosen host is not installed", async () => {
         const showQuickPick = sinon.stub().callsFake(async (items: readonly vscode.QuickPickItem[]) => items[1]);
 

--- a/src/client/uriHandler/constants/uriStrings.ts
+++ b/src/client/uriHandler/constants/uriStrings.ts
@@ -55,6 +55,12 @@ export const URI_HANDLER_STRINGS = {
         RELOAD_WINDOW: vscode.l10n.t("Reload Window"),
         RESUME: vscode.l10n.t("Resume")
     },
+    AGENT_HOSTS: {
+        COPILOT: vscode.l10n.t("GitHub Copilot CLI"),
+        CLAUDE: vscode.l10n.t("Claude Code"),
+        INSTALLED: vscode.l10n.t("Installed"),
+        INSTALLED_WITH_VERSION: vscode.l10n.t("Installed · {0}")
+    },
     TITLES: {
         DOWNLOAD_TITLE: vscode.l10n.t("Download Power Pages Site"),
         PCF_INIT: vscode.l10n.t({

--- a/src/client/uriHandler/utils/selectAgentHost.ts
+++ b/src/client/uriHandler/utils/selectAgentHost.ts
@@ -30,11 +30,12 @@ const getAgentHostDescription = (result: AgentHostDetectionResult): string => {
         return URI_HANDLER_STRINGS.DESCRIPTIONS.AGENT_HOST_NOT_INSTALLED;
     }
 
-    if (result.version === undefined) {
+    const version = result.version?.trim();
+    if (!version) {
         return URI_HANDLER_STRINGS.AGENT_HOSTS.INSTALLED;
     }
 
-    return URI_HANDLER_STRINGS.AGENT_HOSTS.INSTALLED_WITH_VERSION.replace("{0}", result.version);
+    return URI_HANDLER_STRINGS.AGENT_HOSTS.INSTALLED_WITH_VERSION.replace("{0}", version);
 };
 
 /**

--- a/src/client/uriHandler/utils/selectAgentHost.ts
+++ b/src/client/uriHandler/utils/selectAgentHost.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from "vscode";
+import { URI_HANDLER_STRINGS } from "../constants/uriStrings";
+import { AgentHost, AgentHostDetectionResult } from "./detectAgentHost";
+
+/**
+ * Selected agent host and its installation state.
+ */
+export interface AgentHostSelection {
+    host: AgentHost;
+    installed: boolean;
+}
+
+interface AgentHostQuickPickItem extends vscode.QuickPickItem {
+    host: AgentHost;
+    installed: boolean;
+}
+
+const AGENT_HOST_DISPLAY_NAMES: Record<AgentHost, string> = {
+    [AgentHost.Copilot]: URI_HANDLER_STRINGS.AGENT_HOSTS.COPILOT,
+    [AgentHost.Claude]: URI_HANDLER_STRINGS.AGENT_HOSTS.CLAUDE
+};
+
+const getAgentHostDescription = (result: AgentHostDetectionResult): string => {
+    if (!result.installed) {
+        return URI_HANDLER_STRINGS.DESCRIPTIONS.AGENT_HOST_NOT_INSTALLED;
+    }
+
+    if (result.version === undefined) {
+        return URI_HANDLER_STRINGS.AGENT_HOSTS.INSTALLED;
+    }
+
+    return URI_HANDLER_STRINGS.AGENT_HOSTS.INSTALLED_WITH_VERSION.replace("{0}", result.version);
+};
+
+/**
+ * Prompts the user to select an agent host from the supplied detection results.
+ * @param detection Agent host detection results in display order.
+ * @param deps Optional UI dependencies used to display the QuickPick.
+ * @returns The selected host and installation state, or undefined when the user cancels.
+ */
+export const selectAgentHost = async (
+    detection: AgentHostDetectionResult[],
+    deps: { showQuickPick?: typeof vscode.window.showQuickPick } = {}
+): Promise<AgentHostSelection | undefined> => {
+    const items: AgentHostQuickPickItem[] = detection.map(result => ({
+        label: AGENT_HOST_DISPLAY_NAMES[result.host],
+        description: getAgentHostDescription(result),
+        host: result.host,
+        installed: result.installed
+    }));
+    const selectedItem = await (deps.showQuickPick ?? vscode.window.showQuickPick)(items);
+
+    if (!selectedItem) {
+        return undefined;
+    }
+
+    return {
+        host: selectedItem.host,
+        installed: selectedItem.installed
+    };
+};


### PR DESCRIPTION
## Summary
- add a telemetry-free agent-host QuickPick utility that preserves detector order and always keeps uninstalled hosts selectable
- localize GitHub Copilot CLI, Claude Code, and installed descriptions while reusing GI-A's canonical not-installed description
- add desktop integration coverage for both host states and cancellation

## Validation
- `npm run translations-export`
- `node node_modules/gulp/bin/gulp.js lint`
- `npm run compile-tests`
- `npm test` (111 passing)
- `npm run build` (2 expected LiquidJS warnings)
- `npm run test-desktop-int` (926 passing)

## Notes
- Dark development only; no handler wiring, telemetry, probing, ECS-gate, reload, or global-state changes. Keep this PR in draft pending OII sign-off.
- Rebased onto main after GI-A (#1653); the shared `URI_HANDLER_STRINGS.DESCRIPTIONS.AGENT_HOST_NOT_INSTALLED` localization is reused without duplication.