### PR TITLE
URI handler: validate deep-link contract version (dark)

### DIFF
--- a/src/client/test/integration/createHandlers.test.ts
+++ b/src/client/test/integration/createHandlers.test.ts
@@ -40,6 +40,12 @@ describe("Create deep-link handlers (gated)", () => {
         `&${URI_CONSTANTS.PARAMETERS.REFERRER_SESSION_ID}=agent-correlation`
     );
 
+    const withContractVersion = (uri: vscode.Uri, version: string): vscode.Uri => {
+        const query = new URLSearchParams(uri.query);
+        query.set(URI_CONSTANTS.PARAMETERS.VERSION, version);
+        return uri.with({ query: query.toString() });
+    };
+
     const setFlags = (enabled: boolean): void => {
         getConfigStub.returns({
             enablePacCreateFromHome: enabled,
@@ -95,7 +101,7 @@ describe("Create deep-link handlers (gated)", () => {
         expect(runCreateFlowCommonStagesStub.called).to.be.false;
     });
 
-    it("PacCreateHandler parses params and emits triggered telemetry when the flag is on", async () => {
+    it("PacCreateHandler proceeds with the supported contract version when the flag is on", async () => {
         setFlags(true);
         const pacWrapper = {} as PacWrapper;
         const handler = new PacCreateHandler(pacWrapper);
@@ -128,6 +134,30 @@ describe("Create deep-link handlers (gated)", () => {
             websiteId: 'pac-website'
         });
         expect(runCreateFlowCommonStagesStub.firstCall.args[3]).to.equal(pacWrapper);
+        expect(traceInfoStub.calledWith(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        )).to.be.false;
+    });
+
+    it("PacCreateHandler drops an unsupported contract version before the flow starts", async () => {
+        setFlags(true);
+        const handler = new PacCreateHandler({} as PacWrapper);
+
+        await handler.handle(withContractVersion(pacCreateUri, '2'));
+
+        const dropped = traceInfoStub.getCalls().find(
+            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        );
+        expect(dropped, "expected a dropped telemetry event").to.not.be.undefined;
+        expect(dropped?.args[1]).to.include({
+            channel: 'pac',
+            reason: 'unsupportedContractVersion',
+            version: '2'
+        });
+        expect(traceInfoStub.calledWith(
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED
+        )).to.be.false;
+        expect(runCreateFlowCommonStagesStub.called).to.be.false;
     });
 
     it("PacCreateHandler emits failed telemetry through the create-flow helper", async () => {
@@ -174,7 +204,7 @@ describe("Create deep-link handlers (gated)", () => {
         expect(runCreateFlowCommonStagesStub.called).to.be.false;
     });
 
-    it("AgenticCreateHandler parses params and emits triggered telemetry when the flag is on", async () => {
+    it("AgenticCreateHandler proceeds without a contract version when the flag is on", async () => {
         setFlags(true);
         const pacWrapper = {} as PacWrapper;
         const handler = new AgenticCreateHandler(pacWrapper);
@@ -206,6 +236,30 @@ describe("Create deep-link handlers (gated)", () => {
             websiteId: 'agent-website'
         });
         expect(runCreateFlowCommonStagesStub.firstCall.args[3]).to.equal(pacWrapper);
+        expect(traceInfoStub.calledWith(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        )).to.be.false;
+    });
+
+    it("AgenticCreateHandler drops an unsupported contract version before the flow starts", async () => {
+        setFlags(true);
+        const handler = new AgenticCreateHandler({} as PacWrapper);
+
+        await handler.handle(withContractVersion(agenticCreateUri, '2'));
+
+        const dropped = traceInfoStub.getCalls().find(
+            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        );
+        expect(dropped, "expected a dropped telemetry event").to.not.be.undefined;
+        expect(dropped?.args[1]).to.include({
+            channel: 'agent',
+            reason: 'unsupportedContractVersion',
+            version: '2'
+        });
+        expect(traceInfoStub.calledWith(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED
+        )).to.be.false;
+        expect(runCreateFlowCommonStagesStub.called).to.be.false;
     });
 
     it("AgenticCreateHandler emits failed telemetry through the create-flow helper", async () => {

--- a/src/client/test/unit/createFlowContractVersion.test.ts
+++ b/src/client/test/unit/createFlowContractVersion.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import { isSupportedContractVersion } from "../../uriHandler/handlers/createFlowContractVersion";
+
+describe("Create-flow contract version", () => {
+    it("allows a missing version", () => {
+        expect(isSupportedContractVersion(null)).to.be.true;
+    });
+
+    it("allows an empty version", () => {
+        expect(isSupportedContractVersion('')).to.be.true;
+    });
+
+    it("allows the current version", () => {
+        expect(isSupportedContractVersion('1')).to.be.true;
+    });
+
+    it("rejects a future version", () => {
+        expect(isSupportedContractVersion('2')).to.be.false;
+    });
+
+    it("rejects an unknown version", () => {
+        expect(isSupportedContractVersion('abc')).to.be.false;
+    });
+});

--- a/src/client/uriHandler/constants/uriConstants.ts
+++ b/src/client/uriHandler/constants/uriConstants.ts
@@ -42,7 +42,8 @@ export const URI_CONSTANTS = {
         AUTO: 'auto'
     },
     CONTRACT_VERSION: {
-        CURRENT: '1'
+        CURRENT: '1',
+        SUPPORTED: ['1'] as const
     },
     MODEL_VERSIONS: {
         VERSION_1: 1,

--- a/src/client/uriHandler/handlers/agenticCreateHandler.ts
+++ b/src/client/uriHandler/handlers/agenticCreateHandler.ts
@@ -12,6 +12,7 @@ import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryE
 import { buildCreateFlowTelemetry, parseCreateFlowParameters } from "./createFlowParams";
 import { emitCreateFlowError, emitCreateFlowEvent } from "../telemetry/createFlowTelemetry";
 import { runCreateFlowCommonStages } from "./createFlowCommonStages";
+import { isSupportedContractVersion } from "./createFlowContractVersion";
 
 /**
  * Handles the `/agenticCreate` deep link launched from the Power Pages home page, which will
@@ -55,6 +56,19 @@ export class AgenticCreateHandler {
         }
 
         try {
+            if (!isSupportedContractVersion(params.version)) {
+                emitCreateFlowEvent(
+                    uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED,
+                    params,
+                    'agent',
+                    {
+                        reason: 'unsupportedContractVersion',
+                        version: params.version ?? ''
+                    }
+                );
+                return;
+            }
+
             emitCreateFlowEvent(
                 uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED,
                 params,

--- a/src/client/uriHandler/handlers/createFlowContractVersion.ts
+++ b/src/client/uriHandler/handlers/createFlowContractVersion.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { URI_CONSTANTS } from "../constants/uriConstants";
+
+/**
+ * Determines whether a create-flow contract version can be handled by this extension.
+ * Missing and empty versions remain supported for backward compatibility.
+ * @param version Contract version parsed from the deep link.
+ * @returns Whether the create flow may proceed.
+ */
+export function isSupportedContractVersion(version: string | null): boolean {
+    if (!version) {
+        return true;
+    }
+
+    return URI_CONSTANTS.CONTRACT_VERSION.SUPPORTED.some(
+        (supportedVersion) => supportedVersion === version
+    );
+}

--- a/src/client/uriHandler/handlers/pacCreateHandler.ts
+++ b/src/client/uriHandler/handlers/pacCreateHandler.ts
@@ -12,6 +12,7 @@ import { uriHandlerTelemetryEventNames } from "../telemetry/uriHandlerTelemetryE
 import { buildCreateFlowTelemetry, parseCreateFlowParameters } from "./createFlowParams";
 import { emitCreateFlowError, emitCreateFlowEvent } from "../telemetry/createFlowTelemetry";
 import { runCreateFlowCommonStages } from "./createFlowCommonStages";
+import { isSupportedContractVersion } from "./createFlowContractVersion";
 
 /**
  * Handles the `/pacCreate` deep link launched from the Power Pages home page, which will open
@@ -55,6 +56,19 @@ export class PacCreateHandler {
         }
 
         try {
+            if (!isSupportedContractVersion(params.version)) {
+                emitCreateFlowEvent(
+                    uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED,
+                    params,
+                    'pac',
+                    {
+                        reason: 'unsupportedContractVersion',
+                        version: params.version ?? ''
+                    }
+                );
+                return;
+            }
+
             emitCreateFlowEvent(
                 uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED,
                 params,


### PR DESCRIPTION
## Summary
- add an append-only supported contract-version set and a pure backward-compatible validator
- drop unsupported non-empty versions before triggered telemetry or shared create stages in both dark handlers
- preserve missing/empty version links and the existing ECS-disabled no-op paths

## Validation
- `node node_modules/gulp/bin/gulp.js lint`
- `npm run compile-tests`
- `npm test` (115 passing)
- `npm run build` (2 expected LiquidJS warnings)
- `npm run test-desktop-int` (923 passing)

## Rollout
- remains behind the existing default-off ECS gates
- no user-facing strings, gate changes, new telemetry events, dependencies, or channel tails