### PR TITLE
URI handler: agentic host install-guidance util (dark)

### DIFF
--- a/src/client/test/unit/resolveAgentHostInstallation.test.ts
+++ b/src/client/test/unit/resolveAgentHostInstallation.test.ts
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { URI_CONSTANTS } from '../../uriHandler/constants/uriConstants';
+import type { CreateFlowParameters } from '../../uriHandler/handlers/createFlowParams';
+import { uriHandlerTelemetryEventNames } from '../../uriHandler/telemetry/uriHandlerTelemetryEvents';
+import { AgentHost } from '../../uriHandler/utils/detectAgentHost';
+import {
+    AgentHostInstallationStrings,
+    ResolveAgentHostInstallationDependencies,
+    resolveAgentHostInstallation
+} from '../../uriHandler/utils/resolveAgentHostInstallation';
+import type { ResumeMarker } from '../../uriHandler/utils/resumeMarker';
+
+const strings: AgentHostInstallationStrings = {
+    installGuidancePrompt: "{0} isn't installed. Install it, then choose {1}.",
+    viewInstallationGuide: 'View Installation Guide',
+    checkAgain: 'Check Again',
+    dismiss: 'Dismiss',
+    reloadWindow: 'Reload Window',
+    notNow: 'Not Now'
+};
+
+const params: CreateFlowParameters = {
+    environmentId: 'environment-id',
+    orgUrl: 'https://org.crm.dynamics.com',
+    region: 'NAM',
+    tenantId: 'tenant-id',
+    websiteId: 'website-id',
+    source: 'powerPagesHome',
+    agentHost: AgentHost.Copilot,
+    version: '1',
+    correlationId: 'correlation-id'
+};
+
+interface CapturedEvent {
+    eventName: string;
+    extraProps?: Record<string, string>;
+}
+
+function createDependencies(
+    informationSelections: Array<string | undefined>,
+    warningSelections: Array<string | undefined> = []
+): {
+    deps: ResolveAgentHostInstallationDependencies;
+    events: CapturedEvent[];
+    showInformationMessage: sinon.SinonStub;
+    showWarningMessage: sinon.SinonStub;
+    openExternal: sinon.SinonStub;
+    detectHost: sinon.SinonStub;
+    writeMarker: sinon.SinonStub;
+    reloadWindow: sinon.SinonStub;
+} {
+    const events: CapturedEvent[] = [];
+    const showInformationMessage = sinon.stub();
+    informationSelections.forEach((selection, index) => {
+        showInformationMessage.onCall(index).resolves(selection);
+    });
+    const showWarningMessage = sinon.stub();
+    warningSelections.forEach((selection, index) => {
+        showWarningMessage.onCall(index).resolves(selection);
+    });
+    const openExternal = sinon.stub().resolves();
+    const detectHost = sinon.stub().resolves({
+        host: AgentHost.Copilot,
+        installed: false
+    });
+    const writeMarker = sinon.stub().resolves();
+    const reloadWindow = sinon.stub().resolves();
+
+    const deps: ResolveAgentHostInstallationDependencies = {
+        strings,
+        showInformationMessage,
+        showWarningMessage,
+        openExternal,
+        detectHost,
+        writeResumeMarker: writeMarker,
+        reloadWindow,
+        emitEvent: (eventName, _eventParams, _channel, extraProps) => {
+            events.push({ eventName, extraProps });
+        },
+        now: () => 123456
+    };
+
+    return {
+        deps,
+        events,
+        showInformationMessage,
+        showWarningMessage,
+        openExternal,
+        detectHost,
+        writeMarker,
+        reloadWindow
+    };
+}
+
+describe('resolveAgentHostInstallation', () => {
+    it('shows the localized guidance and emits prompted once', async () => {
+        const context = createDependencies([strings.dismiss]);
+
+        await resolveAgentHostInstallation(
+            AgentHost.Copilot,
+            'GitHub Copilot CLI',
+            params,
+            context.deps
+        );
+
+        expect(context.showInformationMessage.calledOnceWithExactly(
+            "GitHub Copilot CLI isn't installed. Install it, then choose Check Again.",
+            strings.viewInstallationGuide,
+            strings.checkAgain,
+            strings.dismiss
+        )).to.be.true;
+        expect(context.events.filter(event =>
+            event.eventName === uriHandlerTelemetryEventNames
+                .URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_PROMPTED
+        )).to.have.length(1);
+    });
+
+    it('opens the host guide, emits guide opened, and re-shows guidance', async () => {
+        const context = createDependencies([
+            strings.viewInstallationGuide,
+            strings.dismiss
+        ]);
+
+        const result = await resolveAgentHostInstallation(
+            AgentHost.Claude,
+            'Claude Code',
+            { ...params, agentHost: AgentHost.Claude },
+            context.deps
+        );
+
+        expect(context.openExternal.calledOnceWithExactly(
+            URI_CONSTANTS.AGENT_HOST_INSTALL_GUIDE_URLS.claude
+        )).to.be.true;
+        expect(context.showInformationMessage.callCount).to.equal(2);
+        expect(context.events.map(event => event.eventName)).to.deep.equal([
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_PROMPTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_GUIDE_OPENED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED
+        ]);
+        expect(result).to.deep.equal({ status: 'dismissed' });
+    });
+
+    it('returns resolved when a live recheck finds the host', async () => {
+        const context = createDependencies([strings.checkAgain]);
+        context.detectHost.resolves({
+            host: AgentHost.Copilot,
+            installed: true,
+            version: '1.2.3'
+        });
+
+        const result = await resolveAgentHostInstallation(
+            AgentHost.Copilot,
+            'GitHub Copilot CLI',
+            params,
+            context.deps
+        );
+
+        expect(context.detectHost.calledOnceWithExactly(AgentHost.Copilot)).to.be.true;
+        expect(context.events).to.deep.include({
+            eventName: uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RECHECKED,
+            extraProps: { outcome: 'found' }
+        });
+        expect(context.events.some(event =>
+            event.eventName === uriHandlerTelemetryEventNames
+                .URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED
+        )).to.be.false;
+        expect(context.reloadWindow.notCalled).to.be.true;
+        expect(result).to.deep.equal({
+            status: 'resolved',
+            host: AgentHost.Copilot
+        });
+    });
+
+    it('persists a complete marker before requesting reload when the host remains missing', async () => {
+        const context = createDependencies(
+            [strings.checkAgain],
+            [strings.reloadWindow]
+        );
+        const calls: string[] = [];
+        context.writeMarker.callsFake(async () => {
+            calls.push('marker');
+        });
+        context.deps.emitEvent = (eventName, _eventParams, _channel, extraProps) => {
+            context.events.push({ eventName, extraProps });
+            if (eventName === uriHandlerTelemetryEventNames
+                .URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RELOAD_REQUESTED) {
+                calls.push('event');
+            }
+        };
+        context.reloadWindow.callsFake(async () => {
+            calls.push('reload');
+        });
+
+        const result = await resolveAgentHostInstallation(
+            AgentHost.Copilot,
+            'GitHub Copilot CLI',
+            params,
+            context.deps
+        );
+
+        const marker = context.writeMarker.firstCall.args[0] as ResumeMarker;
+        expect(marker).to.deep.equal({
+            host: AgentHost.Copilot,
+            timestamp: 123456,
+            correlationId: 'correlation-id',
+            environmentId: 'environment-id',
+            orgUrl: 'https://org.crm.dynamics.com',
+            websiteId: 'website-id',
+            source: 'powerPagesHome'
+        });
+        expect(calls).to.deep.equal(['marker', 'event', 'reload']);
+        expect(context.events).to.deep.include({
+            eventName: uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RECHECKED,
+            extraProps: { outcome: 'missing' }
+        });
+        expect(context.reloadWindow.calledOnce).to.be.true;
+        expect(result).to.deep.equal({ status: 'reloading' });
+    });
+
+    it('dismisses from the missing-host warning', async () => {
+        const context = createDependencies(
+            [strings.checkAgain],
+            [strings.dismiss]
+        );
+
+        const result = await resolveAgentHostInstallation(
+            AgentHost.Copilot,
+            'GitHub Copilot CLI',
+            params,
+            context.deps
+        );
+
+        expect(context.events.map(event => event.eventName)).to.deep.equal([
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_PROMPTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RECHECKED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED
+        ]);
+        expect(context.writeMarker.notCalled).to.be.true;
+        expect(result).to.deep.equal({ status: 'dismissed' });
+    });
+
+    it('dismisses when the initial guidance is dismissed or closed', async () => {
+        for (const selection of [strings.dismiss, strings.notNow, undefined]) {
+            const context = createDependencies([selection]);
+
+            const result = await resolveAgentHostInstallation(
+                AgentHost.Copilot,
+                'GitHub Copilot CLI',
+                params,
+                context.deps
+            );
+
+            expect(context.events.map(event => event.eventName)).to.deep.equal([
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_PROMPTED,
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED
+            ]);
+            expect(result).to.deep.equal({ status: 'dismissed' });
+        }
+    });
+
+    it('keeps raw organization URLs and path data out of event extras', async () => {
+        const context = createDependencies(
+            [strings.checkAgain],
+            [strings.dismiss]
+        );
+        const paramsWithPathLikeValues = {
+            ...params,
+            orgUrl: 'https://private.crm.dynamics.com',
+            source: 'C:\\private\\folder'
+        };
+
+        await resolveAgentHostInstallation(
+            AgentHost.Copilot,
+            'GitHub Copilot CLI',
+            paramsWithPathLikeValues,
+            context.deps
+        );
+
+        const extraProps = context.events
+            .map(event => event.extraProps)
+            .filter((props): props is Record<string, string> => props !== undefined);
+        expect(extraProps).to.deep.equal([{ outcome: 'missing' }]);
+        for (const props of extraProps) {
+            expect(props).to.not.have.property('orgUrl');
+            expect(Object.keys(props).some(key => /path|folder/i.test(key))).to.be.false;
+            expect(Object.values(props).some(value => /private|\\/.test(value))).to.be.false;
+        }
+    });
+});

--- a/src/client/test/unit/resumeMarker.test.ts
+++ b/src/client/test/unit/resumeMarker.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from 'chai';
+import { URI_CONSTANTS } from '../../uriHandler/constants/uriConstants';
+import type { CreateFlowParameters } from '../../uriHandler/handlers/createFlowParams';
+import { AgentHost } from '../../uriHandler/utils/detectAgentHost';
+import {
+    buildResumeMarker,
+    clearResumeMarker,
+    isResumeMarkerFresh,
+    readResumeMarker,
+    ResumeMarkerStore,
+    writeResumeMarker
+} from '../../uriHandler/utils/resumeMarker';
+
+const params: CreateFlowParameters = {
+    environmentId: 'environment-id',
+    orgUrl: 'https://org.crm.dynamics.com',
+    region: 'NAM',
+    tenantId: 'tenant-id',
+    websiteId: 'website-id',
+    source: 'powerPagesHome',
+    agentHost: AgentHost.Copilot,
+    version: '1',
+    correlationId: 'correlation-id'
+};
+
+class FakeResumeMarkerStore implements ResumeMarkerStore {
+    private readonly values = new Map<string, unknown>();
+
+    get<T>(key: string): T | undefined {
+        return this.values.get(key) as T | undefined;
+    }
+
+    update(key: string, value: unknown): void {
+        if (value === undefined) {
+            this.values.delete(key);
+        } else {
+            this.values.set(key, value);
+        }
+    }
+}
+
+describe('resumeMarker', () => {
+    it('builds the locked resumable context with the supplied timestamp', () => {
+        const marker = buildResumeMarker(params, AgentHost.Copilot, 123456);
+
+        expect(marker).to.deep.equal({
+            host: AgentHost.Copilot,
+            timestamp: 123456,
+            correlationId: 'correlation-id',
+            environmentId: 'environment-id',
+            orgUrl: 'https://org.crm.dynamics.com',
+            websiteId: 'website-id',
+            source: 'powerPagesHome'
+        });
+    });
+
+    it('writes and reads a marker through the configured store key', async () => {
+        const store = new FakeResumeMarkerStore();
+        const marker = buildResumeMarker(params, AgentHost.Claude, 123456);
+
+        await writeResumeMarker(store, marker);
+
+        expect(readResumeMarker(store)).to.deep.equal(marker);
+        expect(store.get(URI_CONSTANTS.RESUME_MARKER.KEY)).to.deep.equal(marker);
+    });
+
+    it('clears a persisted marker', async () => {
+        const store = new FakeResumeMarkerStore();
+        await writeResumeMarker(store, buildResumeMarker(params, AgentHost.Copilot, 123456));
+
+        await clearResumeMarker(store);
+
+        expect(readResumeMarker(store)).to.be.undefined;
+    });
+
+    it('treats markers at or within the TTL as fresh', () => {
+        const marker = buildResumeMarker(params, AgentHost.Copilot, 1000);
+
+        expect(isResumeMarkerFresh(marker, 1000)).to.be.true;
+        expect(isResumeMarkerFresh(
+            marker,
+            1000 + URI_CONSTANTS.RESUME_MARKER.TTL_MS
+        )).to.be.true;
+    });
+
+    it('treats markers past the TTL as stale', () => {
+        const marker = buildResumeMarker(params, AgentHost.Copilot, 1000);
+
+        expect(isResumeMarkerFresh(
+            marker,
+            1001 + URI_CONSTANTS.RESUME_MARKER.TTL_MS
+        )).to.be.false;
+    });
+});

--- a/src/client/uriHandler/utils/resolveAgentHostInstallation.ts
+++ b/src/client/uriHandler/utils/resolveAgentHostInstallation.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { URI_CONSTANTS } from '../constants/uriConstants';
+import type { CreateFlowParameters } from '../handlers/createFlowParams';
+import { uriHandlerTelemetryEventNames } from '../telemetry/uriHandlerTelemetryEvents';
+import { AgentHost, AgentHostDetectionResult, detectAgentHost } from './detectAgentHost';
+import { buildResumeMarker, ResumeMarker } from './resumeMarker';
+
+type CreateFlowEventEmitter = (
+    eventName: string,
+    params: CreateFlowParameters,
+    channel: 'agent',
+    extraProps?: Record<string, string>
+) => void | PromiseLike<void>;
+
+/**
+ * Terminal outcomes from the agent-host installation guidance flow.
+ */
+export type AgentHostInstallResolution =
+    | { status: 'resolved'; host: AgentHost }
+    | { status: 'reloading' }
+    | { status: 'dismissed' };
+
+/**
+ * Already-localized copy consumed by the installation guidance flow.
+ */
+export interface AgentHostInstallationStrings {
+    installGuidancePrompt: string;
+    viewInstallationGuide: string;
+    checkAgain: string;
+    dismiss: string;
+    reloadWindow: string;
+    notNow: string;
+}
+
+/**
+ * Side effects used by the agent-host installation guidance flow.
+ */
+export interface ResolveAgentHostInstallationDependencies {
+    strings: AgentHostInstallationStrings;
+    showInformationMessage(
+        message: string,
+        ...buttons: string[]
+    ): PromiseLike<string | undefined>;
+    showWarningMessage(
+        message: string,
+        ...buttons: string[]
+    ): PromiseLike<string | undefined>;
+    openExternal(url: string): PromiseLike<void> | void;
+    detectHost?(host: AgentHost): Promise<AgentHostDetectionResult>;
+    writeResumeMarker(marker: ResumeMarker): PromiseLike<void> | void;
+    reloadWindow(): PromiseLike<void> | void;
+    emitEvent?: CreateFlowEventEmitter;
+    now?(): number;
+}
+
+const defaultEmitEvent: CreateFlowEventEmitter = async (eventName, params, channel, extraProps) => {
+    // Load telemetry only when the production default is used so Node unit tests remain VS Code-free.
+    const { emitCreateFlowEvent } = await import('../telemetry/createFlowTelemetry');
+    emitCreateFlowEvent(eventName, params, channel, extraProps);
+};
+
+function formatInstallGuidance(
+    template: string,
+    hostDisplayName: string,
+    checkAgainLabel: string
+): string {
+    return template
+        .split('{0}').join(hostDisplayName)
+        .split('{1}').join(checkAgainLabel);
+}
+
+/**
+ * Guides a user through installing and re-detecting an external agent-host CLI.
+ * @param host Agent host whose CLI is missing.
+ * @param hostDisplayName Localized display name for the host.
+ * @param params Deep-link create-flow parameters used by redacted telemetry and resume persistence.
+ * @param deps Injected UI and runtime dependencies.
+ * @returns The terminal outcome for the calling create-flow handler.
+ */
+export async function resolveAgentHostInstallation(
+    host: AgentHost,
+    hostDisplayName: string,
+    params: CreateFlowParameters,
+    deps: ResolveAgentHostInstallationDependencies
+): Promise<AgentHostInstallResolution> {
+    const detectHost = deps.detectHost ?? detectAgentHost;
+    const emitEvent = deps.emitEvent ?? defaultEmitEvent;
+    const now = deps.now ?? Date.now;
+    const strings = deps.strings;
+    const guidanceMessage = formatInstallGuidance(
+        strings.installGuidancePrompt,
+        hostDisplayName,
+        strings.checkAgain
+    );
+
+    await emitEvent(
+        uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_PROMPTED,
+        params,
+        'agent'
+    );
+
+    let selection: string | undefined;
+    do {
+        selection = await deps.showInformationMessage(
+            guidanceMessage,
+            strings.viewInstallationGuide,
+            strings.checkAgain,
+            strings.dismiss
+        );
+
+        if (selection === strings.viewInstallationGuide) {
+            await deps.openExternal(URI_CONSTANTS.AGENT_HOST_INSTALL_GUIDE_URLS[host]);
+            await emitEvent(
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_GUIDE_OPENED,
+                params,
+                'agent'
+            );
+        }
+    } while (selection === strings.viewInstallationGuide);
+
+    if (selection === strings.checkAgain) {
+        const detection = await detectHost(host);
+        const outcome = detection.installed ? 'found' : 'missing';
+        await emitEvent(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RECHECKED,
+            params,
+            'agent',
+            { outcome }
+        );
+
+        if (detection.installed) {
+            return { status: 'resolved', host };
+        }
+
+        const warningSelection = await deps.showWarningMessage(
+            guidanceMessage,
+            strings.reloadWindow,
+            strings.dismiss
+        );
+
+        if (warningSelection === strings.reloadWindow) {
+            await deps.writeResumeMarker(buildResumeMarker(params, host, now()));
+            await emitEvent(
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RELOAD_REQUESTED,
+                params,
+                'agent'
+            );
+            await deps.reloadWindow();
+            return { status: 'reloading' };
+        }
+
+        await emitEvent(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED,
+            params,
+            'agent'
+        );
+        return { status: 'dismissed' };
+    }
+
+    await emitEvent(
+        uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED,
+        params,
+        'agent'
+    );
+    return { status: 'dismissed' };
+}

--- a/src/client/uriHandler/utils/resumeMarker.ts
+++ b/src/client/uriHandler/utils/resumeMarker.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { URI_CONSTANTS } from '../constants/uriConstants';
+import type { CreateFlowParameters } from '../handlers/createFlowParams';
+import type { AgentHost } from './detectAgentHost';
+
+/**
+ * Context persisted before reloading VS Code so an agentic create flow can resume.
+ */
+export interface ResumeMarker {
+    host: string;
+    timestamp: number;
+    correlationId: string | null;
+    environmentId: string | null;
+    orgUrl: string | null;
+    websiteId: string | null;
+    source: string | null;
+}
+
+/**
+ * Minimal persistence contract implemented by VS Code global state.
+ */
+export interface ResumeMarkerStore {
+    get<T>(key: string): T | undefined;
+    update(key: string, value: unknown): Thenable<void> | void;
+}
+
+/**
+ * Builds the complete context required to resume an agentic create flow.
+ * @param params Deep-link create-flow parameters.
+ * @param host Agent host selected for the flow.
+ * @param now Timestamp to persist on the marker.
+ * @returns The resumable context marker.
+ */
+export function buildResumeMarker(
+    params: CreateFlowParameters,
+    host: AgentHost,
+    now: number
+): ResumeMarker {
+    return {
+        host,
+        timestamp: now,
+        correlationId: params.correlationId,
+        environmentId: params.environmentId,
+        orgUrl: params.orgUrl,
+        websiteId: params.websiteId,
+        source: params.source
+    };
+}
+
+/**
+ * Persists a resume marker.
+ * @param store Resume-marker persistence store.
+ * @param marker Marker to persist.
+ */
+export async function writeResumeMarker(
+    store: ResumeMarkerStore,
+    marker: ResumeMarker
+): Promise<void> {
+    await store.update(URI_CONSTANTS.RESUME_MARKER.KEY, marker);
+}
+
+/**
+ * Reads the current resume marker.
+ * @param store Resume-marker persistence store.
+ * @returns The persisted marker, when present.
+ */
+export function readResumeMarker(store: ResumeMarkerStore): ResumeMarker | undefined {
+    return store.get<ResumeMarker>(URI_CONSTANTS.RESUME_MARKER.KEY);
+}
+
+/**
+ * Removes the current resume marker.
+ * @param store Resume-marker persistence store.
+ */
+export async function clearResumeMarker(store: ResumeMarkerStore): Promise<void> {
+    await store.update(URI_CONSTANTS.RESUME_MARKER.KEY, undefined);
+}
+
+/**
+ * Checks whether a resume marker remains inside the allowed resume window.
+ * @param marker Resume marker to evaluate.
+ * @param now Current timestamp.
+ * @returns True when the marker has not exceeded its TTL.
+ */
+export function isResumeMarkerFresh(marker: ResumeMarker, now: number): boolean {
+    return now - marker.timestamp <= URI_CONSTANTS.RESUME_MARKER.TTL_MS;
+}


### PR DESCRIPTION
## Summary
- add the VS Code-free agent-host install guidance resolver with fully injected UI/runtime dependencies
- add resume-marker build, persistence, clearing, and TTL helpers for post-reload continuation
- cover guide looping, live re-probe, reload ordering, dismissal, marker context, and telemetry redaction with Node unit tests

## Validation
- `node node_modules/gulp/bin/gulp.js lint`
- `npm run compile-tests`
- `npm test` (123 passing)
- `npm run build` (passes with the 2 expected LiquidJS warnings)
- `npm run test-desktop-int` (921 passing)

## Scope
Dark utility only. No handler wiring, localization changes, ECS-gate changes, or resume-hook implementation.