### PR TITLE
URI handler: create-flow telemetry tests + dashboard spec (dark)

### DIFF
--- a/src/client/test/integration/createFlowCommonStages.test.ts
+++ b/src/client/test/integration/createFlowCommonStages.test.ts
@@ -9,9 +9,11 @@ import * as vscode from "vscode";
 import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
 import { PacWrapper } from "../../pac/PacWrapper";
 import {
+    CreateFlowChannel,
     CreateFlowCommonStagesDependencies,
     runCreateFlowCommonStages
 } from "../../uriHandler/handlers/createFlowCommonStages";
+import { URI_CONSTANTS } from "../../uriHandler/constants/uriConstants";
 import {
     buildCreateFlowTelemetry,
     CreateFlowParameters
@@ -49,7 +51,7 @@ describe("Create-flow common stages", () => {
     const pacWrapper = {} as PacWrapper;
     const selectedFolder = vscode.Uri.file("C:\\sensitive\\selected-folder");
 
-    const expectRedactedTelemetry = (): void => {
+    const expectRedactedTelemetry = (channel: CreateFlowChannel): void => {
         const properties = [
             ...traceInfoStub.getCalls().map((call) => call.args[1] as Record<string, string>),
             ...traceErrorStub.getCalls().map((call) => call.args[3] as Record<string, string>)
@@ -63,10 +65,28 @@ describe("Create-flow common stages", () => {
             expect(Object.values(eventProperties)).to.not.include(params.orgUrl);
             expect(Object.values(eventProperties)).to.not.include(params.tenantId);
             expect(eventProperties).to.include({
+                source: params.source,
+                agentHost: 'unspecified',
+                version: params.version,
+                region: params.region,
+                hasEnvironmentId: 'true',
+                hasOrgUrl: 'true',
+                hasTenantId: 'true',
+                hasWebsiteId: 'true',
                 environmentId: params.environmentId,
                 websiteId: params.websiteId,
+                channel,
+                contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
                 correlationId: params.correlationId
             });
+            for (const presenceProperty of [
+                'hasEnvironmentId',
+                'hasOrgUrl',
+                'hasTenantId',
+                'hasWebsiteId'
+            ]) {
+                expect(eventProperties[presenceProperty]).to.be.a('string');
+            }
         }
     };
 
@@ -115,33 +135,35 @@ describe("Create-flow common stages", () => {
         sandbox.restore();
     });
 
-    it("emits ordered stages and returns the selected folder", async () => {
-        selectTargetFolderStub.resolves(selectedFolder);
+    for (const channel of ['pac', 'agent'] as CreateFlowChannel[]) {
+        it(`emits ordered ${channel} stages and returns the selected folder`, async () => {
+            selectTargetFolderStub.resolves(selectedFolder);
 
-        const result = await runCreateFlowCommonStages(
-            params,
-            'pac',
-            telemetryData,
-            pacWrapper,
-            dependencies
-        );
+            const result = await runCreateFlowCommonStages(
+                params,
+                channel,
+                telemetryData,
+                pacWrapper,
+                dependencies
+            );
 
-        expect(result).to.equal(selectedFolder);
-        expect(prepareAuthenticationAndEnvironmentStub.calledOnceWithExactly(
-            {
-                environmentId: params.environmentId,
-                orgUrl: params.orgUrl
-            },
-            telemetryData
-        )).to.be.true;
-        expect(emittedEventNames).to.deep.equal([
-            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
-            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_COMPLETED,
-            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_ENVIRONMENT_SET,
-            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_SELECTED
-        ]);
-        expectRedactedTelemetry();
-    });
+            expect(result).to.equal(selectedFolder);
+            expect(prepareAuthenticationAndEnvironmentStub.calledOnceWithExactly(
+                {
+                    environmentId: params.environmentId,
+                    orgUrl: params.orgUrl
+                },
+                telemetryData
+            )).to.be.true;
+            expect(emittedEventNames).to.deep.equal([
+                uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+                uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_COMPLETED,
+                uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_ENVIRONMENT_SET,
+                uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_SELECTED
+            ]);
+            expectRedactedTelemetry(channel);
+        });
+    }
 
     it("emits cancellation and drop stages when folder selection is cancelled", async () => {
         selectTargetFolderStub.resolves(undefined);
@@ -162,7 +184,7 @@ describe("Create-flow common stages", () => {
             uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_CANCELLED,
             uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
         ]);
-        expectRedactedTelemetry();
+        expectRedactedTelemetry('agent');
     });
 
     it("emits authentication failure and drop stages when authentication fails", async () => {
@@ -184,6 +206,6 @@ describe("Create-flow common stages", () => {
             uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
         ]);
         expect(traceErrorStub.calledOnce).to.be.true;
-        expectRedactedTelemetry();
+        expectRedactedTelemetry('pac');
     });
 });

--- a/src/client/test/integration/createFlowTelemetry.test.ts
+++ b/src/client/test/integration/createFlowTelemetry.test.ts
@@ -35,20 +35,35 @@ describe("Create-flow telemetry", () => {
         version: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
         correlationId: 'correlation-123'
     };
+    const sensitiveFolderPath = "C:\\sensitive\\selected-folder";
 
     const expectIdentifiersHandled = (properties: Record<string, string>): void => {
         expect(properties.environmentId).to.equal(params.environmentId);
         expect(properties.websiteId).to.equal(params.websiteId);
-        expect(properties).to.not.have.property('orgUrl');
-        expect(properties).to.not.have.property('tenantId');
-        expect(Object.values(properties)).to.not.include(params.orgUrl);
-        expect(Object.values(properties)).to.not.include(params.tenantId);
         expect(properties).to.include({
+            source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
+            agentHost: URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT,
+            version: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
+            region: 'NAM',
             hasEnvironmentId: 'true',
             hasOrgUrl: 'true',
             hasTenantId: 'true',
             hasWebsiteId: 'true'
         });
+        expect(properties).to.not.have.property('orgUrl');
+        expect(properties).to.not.have.property('tenantId');
+        expect(properties).to.not.have.property('folderPath');
+        expect(Object.values(properties)).to.not.include(params.orgUrl);
+        expect(Object.values(properties)).to.not.include(params.tenantId);
+        expect(Object.values(properties)).to.not.include(sensitiveFolderPath);
+        for (const presenceProperty of [
+            'hasEnvironmentId',
+            'hasOrgUrl',
+            'hasTenantId',
+            'hasWebsiteId'
+        ]) {
+            expect(properties[presenceProperty]).to.be.a('string');
+        }
     };
 
     beforeEach(() => {
@@ -64,8 +79,40 @@ describe("Create-flow telemetry", () => {
         sandbox.restore();
     });
 
-    it("defines the create-flow funnel events in stage order", () => {
-        expect(Object.values(uriHandlerTelemetryEventNames).slice(-19)).to.deep.equal([
+    it("defines the complete create-flow telemetry catalog", () => {
+        expect([
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_DISABLED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_FAILED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_DISABLED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_FAILED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_COMPLETED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_FAILED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_ENVIRONMENT_SET,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_SELECTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_CANCELLED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_PARAMS_COLLECTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TERMINAL_LAUNCHED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_DETECTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_SELECTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_PLUGIN_SEQUENCE_LAUNCHED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_SAMPLE_PROMPT_SENT,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_PROMPTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_GUIDE_OPENED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RECHECKED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RELOAD_REQUESTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RESUMED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED
+        ]).to.deep.equal([
+            'UriHandlerAgenticCreateTriggered',
+            'UriHandlerAgenticCreateDisabled',
+            'UriHandlerAgenticCreateFailed',
+            'UriHandlerPacCreateTriggered',
+            'UriHandlerPacCreateDisabled',
+            'UriHandlerPacCreateFailed',
             'UriHandlerCreateAuthStarted',
             'UriHandlerCreateAuthCompleted',
             'UriHandlerCreateAuthFailed',
@@ -102,7 +149,7 @@ describe("Create-flow telemetry", () => {
             uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
             params,
             'pac',
-            { authenticationMode: 'existing', region: 'extra-region' }
+            { authenticationMode: 'existing' }
         );
 
         expect(traceInfoStub.calledOnce).to.be.true;
@@ -114,8 +161,7 @@ describe("Create-flow telemetry", () => {
             channel: 'pac',
             contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
             correlationId: params.correlationId,
-            authenticationMode: 'existing',
-            region: 'extra-region'
+            authenticationMode: 'existing'
         });
         expectIdentifiersHandled(properties);
     });
@@ -163,18 +209,50 @@ describe("Create-flow telemetry", () => {
         expectIdentifiersHandled(properties);
     });
 
-    it("uses empty identifier values when website and environment IDs are absent", () => {
-        const properties = buildCreateFlowTelemetry({
+    it("emits low-cardinality defaults and false presence flags when parameters are absent", () => {
+        const emptyParams: CreateFlowParameters = {
             ...params,
             environmentId: null,
             orgUrl: null,
-            websiteId: null
-        });
+            websiteId: null,
+            tenantId: null,
+            source: null,
+            agentHost: null,
+            version: null,
+            region: null
+        };
 
+        emitCreateFlowEvent(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+            emptyParams,
+            'agent'
+        );
+
+        const properties = traceInfoStub.firstCall.args[1] as Record<string, string>;
         expect(properties).to.include({
+            source: 'unknown',
+            agentHost: 'unspecified',
+            version: 'unspecified',
+            region: 'unspecified',
+            hasEnvironmentId: 'false',
+            hasOrgUrl: 'false',
+            hasTenantId: 'false',
+            hasWebsiteId: 'false',
             environmentId: '',
-            websiteId: ''
+            websiteId: '',
+            channel: 'agent',
+            contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
+            correlationId: params.correlationId
         });
         expect(properties).to.not.have.property('orgUrl');
+        expect(properties).to.not.have.property('tenantId');
+        for (const presenceProperty of [
+            'hasEnvironmentId',
+            'hasOrgUrl',
+            'hasTenantId',
+            'hasWebsiteId'
+        ]) {
+            expect(properties[presenceProperty]).to.be.a('string');
+        }
     });
 });

--- a/src/client/test/integration/createHandlers.test.ts
+++ b/src/client/test/integration/createHandlers.test.ts
@@ -14,6 +14,14 @@ import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLo
 import { uriHandlerTelemetryEventNames } from "../../uriHandler/telemetry/uriHandlerTelemetryEvents";
 import { PacWrapper } from "../../pac/PacWrapper";
 import * as createFlowCommonStages from "../../uriHandler/handlers/createFlowCommonStages";
+import { CreateFlowParameters } from "../../uriHandler/handlers/createFlowParams";
+import {
+    emitCreateFlowError,
+    emitCreateFlowEvent
+} from "../../uriHandler/telemetry/createFlowTelemetry";
+import { AuthEnvironmentService } from "../../uriHandler/utils/authEnvironment";
+
+type CreateFlowChannel = createFlowCommonStages.CreateFlowChannel;
 
 describe("Create deep-link handlers (gated)", () => {
     let sandbox: sinon.SinonSandbox;
@@ -21,12 +29,19 @@ describe("Create deep-link handlers (gated)", () => {
     let traceInfoStub: sinon.SinonStub;
     let traceErrorStub: sinon.SinonStub;
     let runCreateFlowCommonStagesStub: sinon.SinonStub;
+    const realRunCreateFlowCommonStages = createFlowCommonStages.runCreateFlowCommonStages;
+    const selectedFolder = vscode.Uri.file("C:\\sensitive\\sites");
+    const pacOrgUrl = 'https://pac.crm.dynamics.com';
+    const agentOrgUrl = 'https://agent.crm.dynamics.com';
+    const pacTenantId = 'pac-sensitive-tenant';
+    const agentTenantId = 'agent-sensitive-tenant';
 
     const pacCreateUri = vscode.Uri.parse(
         `vscode://${URI_CONSTANTS.EXTENSION_ID}${URI_CONSTANTS.PATHS.PAC_CREATE}` +
         `?${URI_CONSTANTS.PARAMETERS.SOURCE}=${URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME}` +
         `&${URI_CONSTANTS.PARAMETERS.ENV_ID}=env-1&${URI_CONSTANTS.PARAMETERS.VERSION}=${URI_CONSTANTS.CONTRACT_VERSION.CURRENT}` +
         `&${URI_CONSTANTS.PARAMETERS.ORG_URL}=https%3A%2F%2Fpac.crm.dynamics.com` +
+        `&${URI_CONSTANTS.PARAMETERS.TENANT_ID}=${pacTenantId}` +
         `&${URI_CONSTANTS.PARAMETERS.WEBSITE_ID}=pac-website` +
         `&${URI_CONSTANTS.PARAMETERS.REFERRER_SESSION_ID}=pac-correlation`
     );
@@ -36,6 +51,7 @@ describe("Create deep-link handlers (gated)", () => {
         `&${URI_CONSTANTS.PARAMETERS.AGENT_HOST}=${URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT}` +
         `&${URI_CONSTANTS.PARAMETERS.ENV_ID}=agent-env` +
         `&${URI_CONSTANTS.PARAMETERS.ORG_URL}=https%3A%2F%2Fagent.crm.dynamics.com` +
+        `&${URI_CONSTANTS.PARAMETERS.TENANT_ID}=${agentTenantId}` +
         `&${URI_CONSTANTS.PARAMETERS.WEBSITE_ID}=agent-website` +
         `&${URI_CONSTANTS.PARAMETERS.REFERRER_SESSION_ID}=agent-correlation`
     );
@@ -53,13 +69,63 @@ describe("Create deep-link handlers (gated)", () => {
         });
     };
 
-    const expectIdentifiers = (
+    const expectRedactedProperties = (
         properties: Record<string, string>,
         environmentId: string,
-        websiteId: string
+        websiteId: string,
+        orgUrl: string,
+        tenantId: string
     ): void => {
-        expect(properties).to.include({ environmentId, websiteId });
+        expect(properties).to.include({
+            environmentId,
+            websiteId,
+            hasEnvironmentId: 'true',
+            hasOrgUrl: 'true',
+            hasTenantId: 'true',
+            hasWebsiteId: 'true'
+        });
         expect(properties).to.not.have.property('orgUrl');
+        expect(properties).to.not.have.property('tenantId');
+        expect(properties).to.not.have.property('folderPath');
+        expect(Object.values(properties)).to.not.include(orgUrl);
+        expect(Object.values(properties)).to.not.include(tenantId);
+        expect(Object.values(properties)).to.not.include(selectedFolder.fsPath);
+        for (const presenceProperty of [
+            'hasEnvironmentId',
+            'hasOrgUrl',
+            'hasTenantId',
+            'hasWebsiteId'
+        ]) {
+            expect(properties[presenceProperty]).to.be.a('string');
+        }
+    };
+
+    const expectCreateFlowEnvelope = (
+        properties: Record<string, string>,
+        channel: CreateFlowChannel,
+        correlationId: string
+    ): void => {
+        expect(properties).to.include({
+            channel,
+            contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
+            correlationId
+        });
+    };
+
+    const expectAllCapturedPropertiesRedacted = (
+        environmentId: string,
+        websiteId: string,
+        orgUrl: string,
+        tenantId: string
+    ): void => {
+        const properties = [
+            ...traceInfoStub.getCalls().map((call) => call.args[1] as Record<string, string>),
+            ...traceErrorStub.getCalls().map((call) => call.args[3] as Record<string, string>)
+        ];
+
+        for (const eventProperties of properties) {
+            expectRedactedProperties(eventProperties, environmentId, websiteId, orgUrl, tenantId);
+        }
     };
 
     beforeEach(() => {
@@ -70,10 +136,29 @@ describe("Create deep-link handlers (gated)", () => {
         sandbox.stub(oneDSLoggerWrapper, "getLogger").returns(
             { traceInfo: traceInfoStub, traceError: traceErrorStub } as unknown as ReturnType<typeof oneDSLoggerWrapper.getLogger>
         );
+        const commonStageDependencies: createFlowCommonStages.CreateFlowCommonStagesDependencies = {
+            createAuthEnvironmentService: sandbox.stub().returns({
+                prepareAuthenticationAndEnvironment: sandbox.stub().resolves()
+            } as unknown as AuthEnvironmentService),
+            selectTargetFolder: sandbox.stub().resolves(selectedFolder),
+            emitCreateFlowEvent,
+            emitCreateFlowError
+        };
         runCreateFlowCommonStagesStub = sandbox.stub(
             createFlowCommonStages,
             "runCreateFlowCommonStages"
-        ).resolves(vscode.Uri.file("C:\\sites"));
+        ).callsFake((
+            params: CreateFlowParameters,
+            channel: CreateFlowChannel,
+            telemetryData: Record<string, string>,
+            pacWrapper: PacWrapper
+        ) => realRunCreateFlowCommonStages(
+            params,
+            channel,
+            telemetryData,
+            pacWrapper,
+            commonStageDependencies
+        ));
     });
 
     afterEach(() => {
@@ -87,18 +172,19 @@ describe("Create deep-link handlers (gated)", () => {
         await handler.handle(pacCreateUri);
 
         expect(PacCreateHandler.isEnabled()).to.be.false;
-        const disabled = traceInfoStub.getCalls().find(
-            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_DISABLED
+        expect(traceInfoStub.callCount).to.equal(1);
+        expect(traceErrorStub.called).to.be.false;
+        expect(traceInfoStub.firstCall.args[0]).to.equal(
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_DISABLED
         );
-        expect(disabled, "expected a disabled telemetry event").to.not.be.undefined;
-        expect(disabled?.args[1]).to.include({
+        expect(traceInfoStub.firstCall.args[1]).to.include({
             source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
             hasEnvironmentId: "true"
         });
-        expectIdentifiers(disabled?.args[1] as Record<string, string>, 'env-1', 'pac-website');
-        expect(disabled?.args[1]).to.not.have.property('channel');
+        expect(traceInfoStub.firstCall.args[1]).to.not.have.property('channel');
         expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED)).to.be.false;
         expect(runCreateFlowCommonStagesStub.called).to.be.false;
+        expectAllCapturedPropertiesRedacted('env-1', 'pac-website', pacOrgUrl, pacTenantId);
     });
 
     it("PacCreateHandler proceeds with the supported contract version when the flag is on", async () => {
@@ -109,19 +195,23 @@ describe("Create deep-link handlers (gated)", () => {
         await handler.handle(pacCreateUri);
 
         expect(PacCreateHandler.isEnabled()).to.be.true;
-        const triggered = traceInfoStub.getCalls().find(
-            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED
-        );
-        expect(triggered, "expected a triggered telemetry event").to.not.be.undefined;
-        expect(triggered?.args[1]).to.include({
+        expect(traceInfoStub.getCalls().map((call) => call.args[0])).to.deep.equal([
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_COMPLETED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_ENVIRONMENT_SET,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_SELECTED
+        ]);
+        expect(traceErrorStub.called).to.be.false;
+        expect(traceInfoStub.firstCall.args[1]).to.include({
             source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
             version: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
-            hasEnvironmentId: "true",
-            channel: 'pac',
-            contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
-            correlationId: 'pac-correlation'
+            hasEnvironmentId: "true"
         });
-        expectIdentifiers(triggered?.args[1] as Record<string, string>, 'env-1', 'pac-website');
+        for (const call of traceInfoStub.getCalls()) {
+            expectCreateFlowEnvelope(call.args[1] as Record<string, string>, 'pac', 'pac-correlation');
+        }
+        expectAllCapturedPropertiesRedacted('env-1', 'pac-website', pacOrgUrl, pacTenantId);
         expect(runCreateFlowCommonStagesStub.calledOnce).to.be.true;
         expect(runCreateFlowCommonStagesStub.firstCall.args[0]).to.include({
             environmentId: 'env-1',
@@ -145,12 +235,15 @@ describe("Create deep-link handlers (gated)", () => {
 
         await handler.handle(withContractVersion(pacCreateUri, '2'));
 
-        const dropped = traceInfoStub.getCalls().find(
-            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        expect(traceInfoStub.callCount).to.equal(1);
+        expect(traceErrorStub.called).to.be.false;
+        expect(traceInfoStub.firstCall.args[0]).to.equal(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
         );
-        expect(dropped, "expected a dropped telemetry event").to.not.be.undefined;
-        expect(dropped?.args[1]).to.include({
+        expect(traceInfoStub.firstCall.args[1]).to.include({
             channel: 'pac',
+            contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
+            correlationId: 'pac-correlation',
             reason: 'unsupportedContractVersion',
             version: '2'
         });
@@ -158,15 +251,19 @@ describe("Create deep-link handlers (gated)", () => {
             uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED
         )).to.be.false;
         expect(runCreateFlowCommonStagesStub.called).to.be.false;
+        expectAllCapturedPropertiesRedacted('env-1', 'pac-website', pacOrgUrl, pacTenantId);
     });
 
     it("PacCreateHandler emits failed telemetry through the create-flow helper", async () => {
         setFlags(true);
-        traceInfoStub.throws(new Error('trigger failed'));
+        runCreateFlowCommonStagesStub.rejects(new Error('create flow failed'));
         const handler = new PacCreateHandler({} as PacWrapper);
 
         await handler.handle(pacCreateUri);
 
+        expect(traceInfoStub.calledOnceWith(
+            uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_TRIGGERED
+        )).to.be.true;
         expect(traceErrorStub.calledOnce).to.be.true;
         expect(traceErrorStub.firstCall.args[0]).to.equal(
             uriHandlerTelemetryEventNames.URI_HANDLER_PAC_CREATE_FAILED
@@ -176,11 +273,7 @@ describe("Create deep-link handlers (gated)", () => {
             contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
             correlationId: 'pac-correlation'
         });
-        expectIdentifiers(
-            traceErrorStub.firstCall.args[3] as Record<string, string>,
-            'env-1',
-            'pac-website'
-        );
+        expectAllCapturedPropertiesRedacted('env-1', 'pac-website', pacOrgUrl, pacTenantId);
     });
 
     it("AgenticCreateHandler is a no-op that only emits disabled telemetry when the flag is off", async () => {
@@ -190,18 +283,24 @@ describe("Create deep-link handlers (gated)", () => {
         await handler.handle(agenticCreateUri);
 
         expect(AgenticCreateHandler.isEnabled()).to.be.false;
-        const disabled = traceInfoStub.getCalls().find(
-            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_DISABLED
+        expect(traceInfoStub.callCount).to.equal(1);
+        expect(traceErrorStub.called).to.be.false;
+        expect(traceInfoStub.firstCall.args[0]).to.equal(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_DISABLED
         );
-        expect(disabled, "expected a disabled telemetry event").to.not.be.undefined;
-        expect(disabled?.args[1]).to.include({
+        expect(traceInfoStub.firstCall.args[1]).to.include({
             source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
             agentHost: URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT
         });
-        expectIdentifiers(disabled?.args[1] as Record<string, string>, 'agent-env', 'agent-website');
-        expect(disabled?.args[1]).to.not.have.property('channel');
+        expect(traceInfoStub.firstCall.args[1]).to.not.have.property('channel');
         expect(traceInfoStub.calledWith(uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED)).to.be.false;
         expect(runCreateFlowCommonStagesStub.called).to.be.false;
+        expectAllCapturedPropertiesRedacted(
+            'agent-env',
+            'agent-website',
+            agentOrgUrl,
+            agentTenantId
+        );
     });
 
     it("AgenticCreateHandler proceeds without a contract version when the flag is on", async () => {
@@ -212,18 +311,28 @@ describe("Create deep-link handlers (gated)", () => {
         await handler.handle(agenticCreateUri);
 
         expect(AgenticCreateHandler.isEnabled()).to.be.true;
-        const triggered = traceInfoStub.getCalls().find(
-            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED
-        );
-        expect(triggered, "expected a triggered telemetry event").to.not.be.undefined;
-        expect(triggered?.args[1]).to.include({
+        expect(traceInfoStub.getCalls().map((call) => call.args[0])).to.deep.equal([
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_STARTED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_AUTH_COMPLETED,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_ENVIRONMENT_SET,
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FOLDER_SELECTED
+        ]);
+        expect(traceErrorStub.called).to.be.false;
+        expect(traceInfoStub.firstCall.args[1]).to.include({
             source: URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME,
             agentHost: URI_CONSTANTS.AGENT_HOST_VALUES.COPILOT,
-            channel: 'agent',
-            contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
-            correlationId: 'agent-correlation'
+            version: 'unspecified'
         });
-        expectIdentifiers(triggered?.args[1] as Record<string, string>, 'agent-env', 'agent-website');
+        for (const call of traceInfoStub.getCalls()) {
+            expectCreateFlowEnvelope(call.args[1] as Record<string, string>, 'agent', 'agent-correlation');
+        }
+        expectAllCapturedPropertiesRedacted(
+            'agent-env',
+            'agent-website',
+            agentOrgUrl,
+            agentTenantId
+        );
         expect(runCreateFlowCommonStagesStub.calledOnce).to.be.true;
         expect(runCreateFlowCommonStagesStub.firstCall.args[0]).to.include({
             environmentId: 'agent-env',
@@ -247,12 +356,15 @@ describe("Create deep-link handlers (gated)", () => {
 
         await handler.handle(withContractVersion(agenticCreateUri, '2'));
 
-        const dropped = traceInfoStub.getCalls().find(
-            (call) => call.args[0] === uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        expect(traceInfoStub.callCount).to.equal(1);
+        expect(traceErrorStub.called).to.be.false;
+        expect(traceInfoStub.firstCall.args[0]).to.equal(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
         );
-        expect(dropped, "expected a dropped telemetry event").to.not.be.undefined;
-        expect(dropped?.args[1]).to.include({
+        expect(traceInfoStub.firstCall.args[1]).to.include({
             channel: 'agent',
+            contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
+            correlationId: 'agent-correlation',
             reason: 'unsupportedContractVersion',
             version: '2'
         });
@@ -260,15 +372,24 @@ describe("Create deep-link handlers (gated)", () => {
             uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED
         )).to.be.false;
         expect(runCreateFlowCommonStagesStub.called).to.be.false;
+        expectAllCapturedPropertiesRedacted(
+            'agent-env',
+            'agent-website',
+            agentOrgUrl,
+            agentTenantId
+        );
     });
 
     it("AgenticCreateHandler emits failed telemetry through the create-flow helper", async () => {
         setFlags(true);
-        traceInfoStub.throws(new Error('trigger failed'));
+        runCreateFlowCommonStagesStub.rejects(new Error('create flow failed'));
         const handler = new AgenticCreateHandler({} as PacWrapper);
 
         await handler.handle(agenticCreateUri);
 
+        expect(traceInfoStub.calledOnceWith(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_TRIGGERED
+        )).to.be.true;
         expect(traceErrorStub.calledOnce).to.be.true;
         expect(traceErrorStub.firstCall.args[0]).to.equal(
             uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_FAILED
@@ -278,10 +399,11 @@ describe("Create deep-link handlers (gated)", () => {
             contractVersion: URI_CONSTANTS.CONTRACT_VERSION.CURRENT,
             correlationId: 'agent-correlation'
         });
-        expectIdentifiers(
-            traceErrorStub.firstCall.args[3] as Record<string, string>,
+        expectAllCapturedPropertiesRedacted(
             'agent-env',
-            'agent-website'
+            'agent-website',
+            agentOrgUrl,
+            agentTenantId
         );
     });
 });

--- a/src/client/uriHandler/telemetry/createFlowDashboard.kql.md
+++ b/src/client/uriHandler/telemetry/createFlowDashboard.kql.md
@@ -1,0 +1,174 @@
+# Create-flow telemetry dashboard specification
+
+This specification defines the intended analytics view for the dark Power Pages-to-VS Code create deep-link funnel. It is not a live-wired dashboard. The final OneDS table/view name and OII ingestion classification remain pending.
+
+## Privacy contract
+
+Queries may use only:
+
+- Low-cardinality dimensions: `source`, `agentHost`, `version`, `region`, `channel`, `contractVersion`, `reason`
+- Correlation: `correlationId`
+- Presence flags: `hasEnvironmentId`, `hasOrgUrl`, `hasWebsiteId`, `hasTenantId`
+- Requested record identifiers: `environmentId`, `websiteId`
+
+Do not ingest or query organization URL values, tenant ID values, local folder paths, command text, prompts, or terminal contents. `hasOrgUrl` and `hasTenantId` are string-valued booleans and are the only allowed representations of those fields.
+
+## Event-to-stage mapping
+
+| Event | Channel | Funnel stage | Meaning |
+|---|---|---|---|
+| `UriHandlerAgenticCreateTriggered` | agent | Trigger | Enabled agent create flow accepted |
+| `UriHandlerPacCreateTriggered` | pac | Trigger | Enabled PAC create flow accepted |
+| `UriHandlerAgenticCreateDisabled` | agent | Trigger / gated | Agent create flow blocked by ECS |
+| `UriHandlerPacCreateDisabled` | pac | Trigger / gated | PAC create flow blocked by ECS |
+| `UriHandlerAgenticCreateFailed` | agent | Failure | Unhandled agent flow failure |
+| `UriHandlerPacCreateFailed` | pac | Failure | Unhandled PAC flow failure |
+| `UriHandlerCreateAuthStarted` | both | Auth | Authentication/environment preparation started |
+| `UriHandlerCreateAuthCompleted` | both | Auth | Authentication/environment preparation completed |
+| `UriHandlerCreateAuthFailed` | both | Auth / failure | Authentication/environment preparation failed |
+| `UriHandlerCreateEnvironmentSet` | both | Environment | Target environment selected |
+| `UriHandlerCreateFolderSelected` | both | Folder | Local target folder selected |
+| `UriHandlerCreateFolderCancelled` | both | Folder / drop | Folder picker cancelled |
+| `UriHandlerCreateFlowDropped` | both | Drop | Flow stopped; `reason` identifies classified drops when available |
+| `UriHandlerAgenticCreateHostDetected` | agent | Host detect | Installed agent host detection completed |
+| `UriHandlerAgenticCreateHostSelected` | agent | Host select | User selected the agent host |
+| `UriHandlerAgenticCreateHostInstallPrompted` | agent | Host install | Missing-host installation prompt shown |
+| `UriHandlerAgenticCreateHostInstallGuideOpened` | agent | Host install | Installation guide opened |
+| `UriHandlerAgenticCreateHostInstallRechecked` | agent | Host install | Host installation rechecked |
+| `UriHandlerAgenticCreateHostInstallReloadRequested` | agent | Host install | Extension reload requested |
+| `UriHandlerAgenticCreateHostInstallResumed` | agent | Host resume | Create flow resumed after reload |
+| `UriHandlerAgenticCreateHostInstallDismissed` | agent | Host install / drop | Installation guidance dismissed |
+| `UriHandlerAgenticCreatePluginSequenceLaunched` | agent | Agent launch | Power Pages plugin sequence launched |
+| `UriHandlerAgenticCreateSamplePromptSent` | agent | Agent launch | Sample prompt sent |
+| `UriHandlerPacCreateParamsCollected` | pac | PAC params | PAC create parameters collected |
+| `UriHandlerPacCreateTerminalLaunched` | pac | PAC terminal | PAC terminal launched |
+
+## Normalized source view
+
+Each example assumes the ingestion owner replaces `YourOneDSEventTable` and its projected columns with the approved OneDS source. The normalized view intentionally exposes only the privacy contract above.
+
+```kusto
+let CreateFlowEventNames = dynamic([
+    "UriHandlerAgenticCreateTriggered",
+    "UriHandlerPacCreateTriggered",
+    "UriHandlerAgenticCreateDisabled",
+    "UriHandlerPacCreateDisabled",
+    "UriHandlerAgenticCreateFailed",
+    "UriHandlerPacCreateFailed",
+    "UriHandlerCreateAuthStarted",
+    "UriHandlerCreateAuthCompleted",
+    "UriHandlerCreateAuthFailed",
+    "UriHandlerCreateEnvironmentSet",
+    "UriHandlerCreateFolderSelected",
+    "UriHandlerCreateFolderCancelled",
+    "UriHandlerCreateFlowDropped",
+    "UriHandlerAgenticCreateHostDetected",
+    "UriHandlerAgenticCreateHostSelected",
+    "UriHandlerAgenticCreateHostInstallPrompted",
+    "UriHandlerAgenticCreateHostInstallGuideOpened",
+    "UriHandlerAgenticCreateHostInstallRechecked",
+    "UriHandlerAgenticCreateHostInstallReloadRequested",
+    "UriHandlerAgenticCreateHostInstallResumed",
+    "UriHandlerAgenticCreateHostInstallDismissed",
+    "UriHandlerAgenticCreatePluginSequenceLaunched",
+    "UriHandlerAgenticCreateSamplePromptSent",
+    "UriHandlerPacCreateParamsCollected",
+    "UriHandlerPacCreateTerminalLaunched"
+]);
+let CreateFlowEvents = materialize(
+    YourOneDSEventTable
+    | where timestamp between (ago(30d) .. now())
+    | where eventName in (CreateFlowEventNames)
+    | extend properties = todynamic(properties)
+    | extend
+        channel = case(
+            tostring(properties.channel) in ("agent", "pac"), tostring(properties.channel),
+            eventName startswith "UriHandlerAgentic", "agent",
+            eventName startswith "UriHandlerPac", "pac",
+            "unknown"),
+        contractVersion = tostring(properties.contractVersion),
+        correlationId = tostring(properties.correlationId),
+        source = tostring(properties.source),
+        agentHost = tostring(properties.agentHost),
+        region = tostring(properties.region),
+        reason = tostring(properties.reason),
+        hasEnvironmentId = tostring(properties.hasEnvironmentId),
+        hasOrgUrl = tostring(properties.hasOrgUrl),
+        hasWebsiteId = tostring(properties.hasWebsiteId),
+        hasTenantId = tostring(properties.hasTenantId)
+    | project
+        timestamp,
+        eventName,
+        channel,
+        contractVersion,
+        correlationId,
+        source,
+        agentHost,
+        region,
+        reason,
+        hasEnvironmentId,
+        hasOrgUrl,
+        hasWebsiteId,
+        hasTenantId
+);
+```
+
+Disabled events predate the shared create-flow helper and therefore derive `channel` from their event names. Queries that require session-level conversion should filter out empty `correlationId` values and report their count separately.
+
+## Funnel conversion
+
+This query reports distinct correlated flows reaching each common stage, split by channel.
+
+```kusto
+CreateFlowEvents
+| where isnotempty(correlationId)
+| extend stage = case(
+    eventName in ("UriHandlerAgenticCreateTriggered", "UriHandlerPacCreateTriggered"), "1 Trigger",
+    eventName == "UriHandlerCreateAuthStarted", "2 Auth started",
+    eventName == "UriHandlerCreateAuthCompleted", "3 Auth completed",
+    eventName == "UriHandlerCreateEnvironmentSet", "4 Environment set",
+    eventName == "UriHandlerCreateFolderSelected", "5 Folder selected",
+    "")
+| where isnotempty(stage)
+| summarize flows=dcount(correlationId) by channel, stage
+| order by channel asc, stage asc
+```
+
+## Drop-off by reason
+
+Unclassified common-stage drops are grouped as `unspecified`; unsupported contract versions are classified as `unsupportedContractVersion`.
+
+```kusto
+CreateFlowEvents
+| where eventName == "UriHandlerCreateFlowDropped"
+| extend dropReason = iff(isempty(reason), "unspecified", reason)
+| summarize drops=count(), correlatedFlows=dcountif(correlationId, isnotempty(correlationId))
+    by channel, dropReason
+| order by drops desc
+```
+
+## Channel split
+
+```kusto
+CreateFlowEvents
+| where eventName in (
+    "UriHandlerAgenticCreateTriggered",
+    "UriHandlerPacCreateTriggered",
+    "UriHandlerAgenticCreateDisabled",
+    "UriHandlerPacCreateDisabled")
+| extend disposition = iff(eventName endswith "Disabled", "gated", "triggered")
+| summarize events=count() by channel, disposition
+| order by channel asc, disposition asc
+```
+
+## Contract-version distribution
+
+Disabled events do not currently carry the shared `contractVersion` property and are excluded from this distribution.
+
+```kusto
+CreateFlowEvents
+| where isnotempty(contractVersion)
+| summarize events=count(), correlatedFlows=dcountif(correlationId, isnotempty(correlationId))
+    by channel, contractVersion
+| order by channel asc, contractVersion asc
+```


### PR DESCRIPTION
## Summary
- assert the agent and PAC create-flow telemetry funnel across enabled, gated, unsupported-version, cancellation, and failure paths
- enforce redaction, shared envelope, low-cardinality defaults, and explicit create-flow event catalog coverage
- document the intended privacy-safe KQL dashboard stages and example queries

## Validation
- `node node_modules/gulp/bin/gulp.js lint`
- `npm run compile-tests`
- `npm test`
- `npm run build` (2 expected LiquidJS warnings)
- `npm run test-desktop-int` (930 passing)

Test and specification changes only; no production code changes.