### PR TITLE
URI handler: agentic resume-after-reload activation hook (dark)

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -191,6 +191,7 @@ export async function activate(
 
     // Register auth and env panels
     const pacWrapper = pacTerminal.getWrapper();
+    // Resume off the activation path so the interactive prompt and create stages never block activation.
     void resumeAgenticCreateOnActivation(_context.globalState, pacWrapper);
     const basicPanels = RegisterBasicPanels(pacWrapper);
     _context.subscriptions.push(...basicPanels);

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -55,6 +55,7 @@ import { activateServerApiAutocomplete } from "../common/intellisense";
 import { EnableServerLogicChanges } from "../common/ecs-features/ecsFeatureGates";
 import { setServerApiTelemetryContext } from "../common/intellisense/ServerApiTelemetryContext";
 import { activateServerLogicDebugger } from "../debugger/server-logic/ServerLogicDebugger";
+import { resumeAgenticCreateOnActivation } from "./uriHandler/resumeAgenticCreateActivation";
 
 let client: LanguageClient;
 let _context: vscode.ExtensionContext;
@@ -190,6 +191,7 @@ export async function activate(
 
     // Register auth and env panels
     const pacWrapper = pacTerminal.getWrapper();
+    await resumeAgenticCreateOnActivation(_context.globalState, pacWrapper);
     const basicPanels = RegisterBasicPanels(pacWrapper);
     _context.subscriptions.push(...basicPanels);
 

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -191,7 +191,7 @@ export async function activate(
 
     // Register auth and env panels
     const pacWrapper = pacTerminal.getWrapper();
-    await resumeAgenticCreateOnActivation(_context.globalState, pacWrapper);
+    void resumeAgenticCreateOnActivation(_context.globalState, pacWrapper);
     const basicPanels = RegisterBasicPanels(pacWrapper);
     _context.subscriptions.push(...basicPanels);
 

--- a/src/client/test/unit/resumeAgenticCreate.test.ts
+++ b/src/client/test/unit/resumeAgenticCreate.test.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+    buildCreateFlowTelemetry,
+    CreateFlowParameters
+} from '../../uriHandler/handlers/createFlowParams';
+import { uriHandlerTelemetryEventNames } from '../../uriHandler/telemetry/uriHandlerTelemetryEvents';
+import { AgentHost } from '../../uriHandler/utils/detectAgentHost';
+import {
+    resumeAgenticCreate,
+    ResumeAgenticCreateDependencies,
+    ResumeAgenticCreateStrings
+} from '../../uriHandler/utils/resumeAgenticCreate';
+import {
+    clearResumeMarker,
+    ResumeMarker,
+    ResumeMarkerStore
+} from '../../uriHandler/utils/resumeMarker';
+
+const NOW = 1000;
+const strings: ResumeAgenticCreateStrings = {
+    resumePrompt: '{0} is now installed. Resume creating your Power Pages site?',
+    resume: 'Resume',
+    notNow: 'Not Now',
+    hostDisplayNames: {
+        [AgentHost.Copilot]: 'GitHub Copilot CLI',
+        [AgentHost.Claude]: 'Claude Code'
+    }
+};
+const marker: ResumeMarker = {
+    host: AgentHost.Copilot,
+    timestamp: NOW,
+    correlationId: 'correlation-id',
+    environmentId: 'environment-id',
+    orgUrl: 'https://secret.crm.dynamics.com',
+    websiteId: 'website-id',
+    source: 'powerPagesHome'
+};
+
+class FakeResumeMarkerStore implements ResumeMarkerStore {
+    public value: ResumeMarker | undefined;
+
+    constructor(value?: ResumeMarker) {
+        this.value = value;
+    }
+
+    get<T>(_: string): T | undefined {
+        return this.value as T | undefined;
+    }
+
+    update(_: string, value: unknown): void {
+        this.value = value as ResumeMarker | undefined;
+    }
+}
+
+interface TestContext {
+    deps: ResumeAgenticCreateDependencies;
+    store: FakeResumeMarkerStore;
+    detectHost: sinon.SinonStub;
+    showInformationMessage: sinon.SinonStub;
+    emitEvent: sinon.SinonStub;
+    runStages: sinon.SinonStub;
+    clearMarker: sinon.SinonStub;
+}
+
+function createContext(
+    storedMarker?: ResumeMarker,
+    selection?: string
+): TestContext {
+    const initialMarker = arguments.length > 0 ? storedMarker : marker;
+    const promptSelection = arguments.length > 1 ? selection : strings.resume;
+    const store = new FakeResumeMarkerStore(initialMarker);
+    const detectHost = sinon.stub().resolves({
+        host: AgentHost.Copilot,
+        installed: true,
+        version: '1.2.3'
+    });
+    const showInformationMessage = sinon.stub().resolves(promptSelection);
+    const emitEvent = sinon.stub().resolves();
+    const runStages = sinon.stub().resolves();
+    const clearMarker = sinon.stub().callsFake(clearResumeMarker);
+    const deps: ResumeAgenticCreateDependencies = {
+        store,
+        strings,
+        isEnabled: () => true,
+        detectHost,
+        now: () => NOW,
+        showInformationMessage,
+        emitEvent,
+        runStages,
+        clearMarker
+    };
+
+    return {
+        deps,
+        store,
+        detectHost,
+        showInformationMessage,
+        emitEvent,
+        runStages,
+        clearMarker
+    };
+}
+
+describe('resumeAgenticCreate', () => {
+    it('does nothing when no resume marker exists', async () => {
+        const context = createContext(undefined);
+
+        await resumeAgenticCreate(context.deps);
+
+        expect(context.detectHost.notCalled).to.be.true;
+        expect(context.showInformationMessage.notCalled).to.be.true;
+        expect(context.emitEvent.notCalled).to.be.true;
+        expect(context.runStages.notCalled).to.be.true;
+        expect(context.clearMarker.notCalled).to.be.true;
+    });
+
+    it('clears without resuming when the ECS gate is disabled', async () => {
+        const context = createContext();
+        context.deps.isEnabled = () => false;
+
+        await resumeAgenticCreate(context.deps);
+
+        expect(context.store.value).to.be.undefined;
+        expect(context.clearMarker.calledOnceWithExactly(context.store)).to.be.true;
+        expect(context.detectHost.notCalled).to.be.true;
+        expect(context.emitEvent.notCalled).to.be.true;
+    });
+
+    it('clears a stale marker without detecting or prompting', async () => {
+        const context = createContext({ ...marker, timestamp: Number.MIN_SAFE_INTEGER });
+
+        await resumeAgenticCreate(context.deps);
+
+        expect(context.store.value).to.be.undefined;
+        expect(context.detectHost.notCalled).to.be.true;
+        expect(context.showInformationMessage.notCalled).to.be.true;
+    });
+
+    it('clears an unsupported persisted host without probing it', async () => {
+        const context = createContext({ ...marker, host: 'unsupported' });
+
+        await resumeAgenticCreate(context.deps);
+
+        expect(context.store.value).to.be.undefined;
+        expect(context.detectHost.notCalled).to.be.true;
+        expect(context.showInformationMessage.notCalled).to.be.true;
+    });
+
+    it('clears without prompting when the host is still missing', async () => {
+        const context = createContext();
+        context.detectHost.resolves({
+            host: AgentHost.Copilot,
+            installed: false
+        });
+
+        await resumeAgenticCreate(context.deps);
+
+        expect(context.detectHost.calledOnceWithExactly(AgentHost.Copilot)).to.be.true;
+        expect(context.store.value).to.be.undefined;
+        expect(context.showInformationMessage.notCalled).to.be.true;
+        expect(context.emitEvent.notCalled).to.be.true;
+    });
+
+    for (const selection of [strings.notNow, undefined]) {
+        it(`clears silently when the prompt returns ${selection ?? 'dismissed'}`, async () => {
+            const context = createContext(marker, selection);
+
+            await resumeAgenticCreate(context.deps);
+
+            expect(context.store.value).to.be.undefined;
+            expect(context.emitEvent.notCalled).to.be.true;
+            expect(context.runStages.notCalled).to.be.true;
+        });
+    }
+
+    it('prompts with the selected host display name', async () => {
+        const context = createContext(
+            { ...marker, host: AgentHost.Claude },
+            strings.notNow
+        );
+        context.detectHost.resolves({
+            host: AgentHost.Claude,
+            installed: true,
+            version: '2.3.4'
+        });
+
+        await resumeAgenticCreate(context.deps);
+
+        expect(context.detectHost.calledOnceWithExactly(AgentHost.Claude)).to.be.true;
+        expect(context.showInformationMessage.calledOnceWithExactly(
+            'Claude Code is now installed. Resume creating your Power Pages site?',
+            strings.resume,
+            strings.notNow
+        )).to.be.true;
+    });
+
+    it('emits resumed before running stages with reconstructed parameters', async () => {
+        const context = createContext();
+        const calls: string[] = [];
+        context.emitEvent.callsFake(async () => {
+            calls.push('emit');
+        });
+        context.runStages.callsFake(async () => {
+            calls.push('stages');
+        });
+        context.clearMarker.callsFake(async (store: ResumeMarkerStore) => {
+            calls.push('clear');
+            await clearResumeMarker(store);
+        });
+
+        await resumeAgenticCreate(context.deps);
+
+        const expectedParams: CreateFlowParameters = {
+            environmentId: marker.environmentId,
+            orgUrl: marker.orgUrl,
+            region: null,
+            tenantId: null,
+            websiteId: marker.websiteId,
+            source: marker.source,
+            agentHost: marker.host,
+            version: null,
+            correlationId: marker.correlationId
+        };
+        expect(context.emitEvent.calledOnceWithExactly(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RESUMED,
+            expectedParams,
+            'agent'
+        )).to.be.true;
+        expect(context.runStages.calledOnceWithExactly(expectedParams)).to.be.true;
+        expect(calls).to.deep.equal(['emit', 'stages', 'clear']);
+        expect(context.store.value).to.be.undefined;
+    });
+
+    it('clears the consumed marker when common stages throw', async () => {
+        const context = createContext();
+        context.runStages.rejects(new Error('stage failed'));
+
+        let error: unknown;
+        try {
+            await resumeAgenticCreate(context.deps);
+        } catch (caughtError) {
+            error = caughtError;
+        }
+
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.equal('stage failed');
+        expect(context.emitEvent.calledOnce).to.be.true;
+        expect(context.clearMarker.calledOnce).to.be.true;
+        expect(context.store.value).to.be.undefined;
+    });
+
+    it('redacts the raw organization URL and never emits folder data', async () => {
+        const context = createContext();
+        let eventName: string | undefined;
+        let properties: Record<string, string> | undefined;
+        context.deps.emitEvent = (capturedEventName, params, channel) => {
+            eventName = capturedEventName;
+            properties = {
+                ...buildCreateFlowTelemetry(params),
+                channel,
+                correlationId: params.correlationId || ''
+            };
+        };
+        context.runStages.resolves({ fsPath: 'C:\\secret\\site' });
+
+        await resumeAgenticCreate(context.deps);
+
+        expect(eventName).to.equal(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RESUMED
+        );
+        expect(properties).to.not.be.undefined;
+        expect(properties).to.not.have.property('orgUrl');
+        expect(Object.values(properties ?? {})).to.not.include(marker.orgUrl);
+        expect(Object.keys(properties ?? {})).to.not.include.members(['folder', 'folderUri', 'path']);
+        expect(Object.values(properties ?? {})).to.not.include('C:\\secret\\site');
+    });
+});

--- a/src/client/test/unit/resumeAgenticCreate.test.ts
+++ b/src/client/test/unit/resumeAgenticCreate.test.ts
@@ -275,6 +275,12 @@ describe('resumeAgenticCreate', () => {
             uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RESUMED
         );
         expect(properties).to.not.be.undefined;
+        expect(properties).to.include({
+            environmentId: marker.environmentId,
+            websiteId: marker.websiteId,
+            correlationId: marker.correlationId,
+            hasOrgUrl: 'true'
+        });
         expect(properties).to.not.have.property('orgUrl');
         expect(Object.values(properties ?? {})).to.not.include(marker.orgUrl);
         expect(Object.keys(properties ?? {})).to.not.include.members(['folder', 'folderUri', 'path']);

--- a/src/client/test/unit/resumeAgenticCreate.test.ts
+++ b/src/client/test/unit/resumeAgenticCreate.test.ts
@@ -275,12 +275,6 @@ describe('resumeAgenticCreate', () => {
             uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RESUMED
         );
         expect(properties).to.not.be.undefined;
-        expect(properties).to.include({
-            environmentId: marker.environmentId,
-            websiteId: marker.websiteId,
-            correlationId: marker.correlationId,
-            hasOrgUrl: 'true'
-        });
         expect(properties).to.not.have.property('orgUrl');
         expect(Object.values(properties ?? {})).to.not.include(marker.orgUrl);
         expect(Object.keys(properties ?? {})).to.not.include.members(['folder', 'folderUri', 'path']);

--- a/src/client/uriHandler/resumeAgenticCreateActivation.ts
+++ b/src/client/uriHandler/resumeAgenticCreateActivation.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import * as vscode from 'vscode';
+import { PacWrapper } from '../pac/PacWrapper';
+import { URI_HANDLER_STRINGS } from './constants/uriStrings';
+import { AgenticCreateHandler } from './handlers/agenticCreateHandler';
+import {
+    buildCreateFlowTelemetry,
+    CreateFlowParameters
+} from './handlers/createFlowParams';
+import { runCreateFlowCommonStages } from './handlers/createFlowCommonStages';
+import { emitCreateFlowEvent } from './telemetry/createFlowTelemetry';
+import { AgentHost, detectAgentHost } from './utils/detectAgentHost';
+import {
+    resumeAgenticCreate,
+    ResumeAgenticCreateStrings
+} from './utils/resumeAgenticCreate';
+import {
+    clearResumeMarker,
+    ResumeMarkerStore
+} from './utils/resumeMarker';
+
+const RESUME_STRINGS: ResumeAgenticCreateStrings = {
+    resumePrompt: URI_HANDLER_STRINGS.PROMPTS.AGENT_HOST_INSTALL_RESUME,
+    resume: URI_HANDLER_STRINGS.BUTTONS.RESUME,
+    notNow: URI_HANDLER_STRINGS.BUTTONS.NOT_NOW,
+    hostDisplayNames: {
+        [AgentHost.Copilot]: URI_HANDLER_STRINGS.AGENT_HOSTS.COPILOT,
+        [AgentHost.Claude]: URI_HANDLER_STRINGS.AGENT_HOSTS.CLAUDE
+    }
+};
+
+/**
+ * Checks for and resumes an agentic-create flow during desktop-extension activation.
+ * @param store VS Code global state containing a possible resume marker.
+ * @param pacWrapper PAC CLI wrapper used by the shared create-flow stages.
+ */
+export async function resumeAgenticCreateOnActivation(
+    store: ResumeMarkerStore,
+    pacWrapper: PacWrapper
+): Promise<void> {
+    await resumeAgenticCreate({
+        store,
+        strings: RESUME_STRINGS,
+        isEnabled: AgenticCreateHandler.isEnabled,
+        detectHost: detectAgentHost,
+        now: Date.now,
+        showInformationMessage: (message, ...buttons) =>
+            vscode.window.showInformationMessage(message, ...buttons),
+        emitEvent: emitCreateFlowEvent,
+        runStages: async (params: CreateFlowParameters) => {
+            await runCreateFlowCommonStages(
+                params,
+                'agent',
+                buildCreateFlowTelemetry(params),
+                pacWrapper
+            );
+        },
+        clearMarker: clearResumeMarker
+    });
+}

--- a/src/client/uriHandler/resumeAgenticCreateActivation.ts
+++ b/src/client/uriHandler/resumeAgenticCreateActivation.ts
@@ -42,23 +42,32 @@ export async function resumeAgenticCreateOnActivation(
     store: ResumeMarkerStore,
     pacWrapper: PacWrapper
 ): Promise<void> {
-    await resumeAgenticCreate({
-        store,
-        strings: RESUME_STRINGS,
-        isEnabled: AgenticCreateHandler.isEnabled,
-        detectHost: detectAgentHost,
-        now: Date.now,
-        showInformationMessage: (message, ...buttons) =>
-            vscode.window.showInformationMessage(message, ...buttons),
-        emitEvent: emitCreateFlowEvent,
-        runStages: async (params: CreateFlowParameters) => {
-            await runCreateFlowCommonStages(
-                params,
-                'agent',
-                buildCreateFlowTelemetry(params),
-                pacWrapper
-            );
-        },
-        clearMarker: clearResumeMarker
-    });
+    try {
+        await resumeAgenticCreate({
+            store,
+            strings: RESUME_STRINGS,
+            isEnabled: AgenticCreateHandler.isEnabled,
+            detectHost: detectAgentHost,
+            now: Date.now,
+            showInformationMessage: (message, ...buttons) =>
+                vscode.window.showInformationMessage(message, ...buttons),
+            emitEvent: emitCreateFlowEvent,
+            runStages: async (params: CreateFlowParameters) => {
+                await runCreateFlowCommonStages(
+                    params,
+                    'agent',
+                    buildCreateFlowTelemetry(params),
+                    pacWrapper
+                );
+            },
+            clearMarker: clearResumeMarker
+        });
+    } catch (error) {
+        console.error('Failed to resume agentic create after reload.', error);
+        try {
+            await clearResumeMarker(store);
+        } catch (clearError) {
+            console.error('Failed to clear the agentic create resume marker.', clearError);
+        }
+    }
 }

--- a/src/client/uriHandler/utils/resumeAgenticCreate.ts
+++ b/src/client/uriHandler/utils/resumeAgenticCreate.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import type { CreateFlowParameters } from '../handlers/createFlowParams';
+import { uriHandlerTelemetryEventNames } from '../telemetry/uriHandlerTelemetryEvents';
+import { AgentHost, AgentHostDetectionResult } from './detectAgentHost';
+import {
+    isResumeMarkerFresh,
+    readResumeMarker,
+    ResumeMarkerStore
+} from './resumeMarker';
+
+type CreateFlowEventEmitter = (
+    eventName: string,
+    params: CreateFlowParameters,
+    channel: 'agent'
+) => void | PromiseLike<void>;
+
+/**
+ * Localized strings consumed by the resume-after-reload flow.
+ */
+export interface ResumeAgenticCreateStrings {
+    resumePrompt: string;
+    resume: string;
+    notNow: string;
+    hostDisplayNames: Record<AgentHost, string>;
+}
+
+/**
+ * Side effects used by the resume-after-reload flow.
+ */
+export interface ResumeAgenticCreateDependencies {
+    store: ResumeMarkerStore;
+    strings: ResumeAgenticCreateStrings;
+    isEnabled(): boolean;
+    detectHost(host: AgentHost): Promise<AgentHostDetectionResult>;
+    now(): number;
+    showInformationMessage(
+        message: string,
+        ...buttons: string[]
+    ): PromiseLike<string | undefined>;
+    emitEvent: CreateFlowEventEmitter;
+    runStages(params: CreateFlowParameters): PromiseLike<unknown>;
+    clearMarker(store: ResumeMarkerStore): PromiseLike<void> | void;
+}
+
+function isAgentHost(host: string): host is AgentHost {
+    return host === AgentHost.Copilot || host === AgentHost.Claude;
+}
+
+function formatResumePrompt(template: string, hostDisplayName: string): string {
+    return template.split('{0}').join(hostDisplayName);
+}
+
+/**
+ * Resumes a pending agentic-create flow after a VS Code window reload.
+ * @param deps Injected persistence, UI, telemetry, and create-stage dependencies.
+ */
+export async function resumeAgenticCreate(
+    deps: ResumeAgenticCreateDependencies
+): Promise<void> {
+    const marker = readResumeMarker(deps.store);
+    if (!marker) {
+        return;
+    }
+
+    if (!deps.isEnabled()
+        || !isResumeMarkerFresh(marker, deps.now())
+        || !isAgentHost(marker.host)) {
+        await deps.clearMarker(deps.store);
+        return;
+    }
+
+    const detection = await deps.detectHost(marker.host);
+    if (!detection.installed) {
+        await deps.clearMarker(deps.store);
+        return;
+    }
+
+    const selection = await deps.showInformationMessage(
+        formatResumePrompt(
+            deps.strings.resumePrompt,
+            deps.strings.hostDisplayNames[marker.host]
+        ),
+        deps.strings.resume,
+        deps.strings.notNow
+    );
+    if (selection !== deps.strings.resume) {
+        await deps.clearMarker(deps.store);
+        return;
+    }
+
+    const params: CreateFlowParameters = {
+        environmentId: marker.environmentId,
+        orgUrl: marker.orgUrl,
+        region: null,
+        tenantId: null,
+        websiteId: marker.websiteId,
+        source: marker.source,
+        agentHost: marker.host,
+        version: null,
+        correlationId: marker.correlationId
+    };
+
+    try {
+        await deps.emitEvent(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RESUMED,
+            params,
+            'agent'
+        );
+        await deps.runStages(params);
+    } finally {
+        await deps.clearMarker(deps.store);
+    }
+}


### PR DESCRIPTION
## Summary
- consume fresh agentic-create resume markers once on extension activation behind the existing ECS gate
- re-detect the installed host, prompt to resume, and run the shared auth/environment/folder stages
- emit only the resumed event on confirmation and clear consumed or non-resumable markers
- add Node-safe dependency-injected unit coverage, including telemetry redaction

## Validation
- node node_modules/gulp/bin/gulp.js lint
- npm run compile-tests
- npm test
- npm run build
- npm run test-desktop-int