### PR TITLE
Compose agent host resolution for agentic create

### DIFF
--- a/src/client/lib/PacTerminal.ts
+++ b/src/client/lib/PacTerminal.ts
@@ -63,7 +63,7 @@ export class PacTerminal implements vscode.Disposable {
             }
         }));
 
-        this._cmdDisposables.push(RegisterUriHandler(this._pacWrapper));
+        this._cmdDisposables.push(RegisterUriHandler(this._pacWrapper, this._context.globalState));
     }
 
     public openDocumentation(): void {

--- a/src/client/test/integration/agenticCreateHostResolve.test.ts
+++ b/src/client/test/integration/agenticCreateHostResolve.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { oneDSLoggerWrapper } from "../../../common/OneDSLoggerTelemetry/oneDSLoggerWrapper";
+import { PacWrapper } from "../../pac/PacWrapper";
+import { URI_CONSTANTS } from "../../uriHandler/constants/uriConstants";
+import {
+    AgenticCreateHandler,
+    AgenticCreateHandlerDependencies
+} from "../../uriHandler/handlers/agenticCreateHandler";
+import * as createFlowCommonStages from "../../uriHandler/handlers/createFlowCommonStages";
+import { emitCreateFlowEvent } from "../../uriHandler/telemetry/createFlowTelemetry";
+import { uriHandlerTelemetryEventNames } from "../../uriHandler/telemetry/uriHandlerTelemetryEvents";
+import { AgentHost, AgentHostDetectionResult } from "../../uriHandler/utils/detectAgentHost";
+import { AgentHostInstallResolution } from "../../uriHandler/utils/resolveAgentHostInstallation";
+import { ResumeMarkerStore } from "../../uriHandler/utils/resumeMarker";
+
+describe("Agentic create host resolution", () => {
+    let sandbox: sinon.SinonSandbox;
+    let runCreateFlowCommonStagesStub: sinon.SinonStub;
+    let detectAgentHostStub: sinon.SinonStub;
+    let selectAgentHostStub: sinon.SinonStub;
+    let resolveAgentHostInstallationStub: sinon.SinonStub;
+    let emitCreateFlowEventStub: sinon.SinonStub;
+    let traceInfoStub: sinon.SinonStub;
+    let traceErrorStub: sinon.SinonStub;
+    let storeUpdateStub: sinon.SinonStub;
+    let dependencies: AgenticCreateHandlerDependencies;
+    let store: ResumeMarkerStore;
+
+    const selectedFolder = vscode.Uri.file("C:\\private\\selected-site");
+    const rawOrgUrl = "https://private.crm.dynamics.com";
+    const rawTenantId = "private-tenant-id";
+    const uri = vscode.Uri.parse(
+        `vscode://${URI_CONSTANTS.EXTENSION_ID}${URI_CONSTANTS.PATHS.AGENTIC_CREATE}` +
+        `?${URI_CONSTANTS.PARAMETERS.SOURCE}=${URI_CONSTANTS.SOURCE_VALUES.POWER_PAGES_HOME}` +
+        `&${URI_CONSTANTS.PARAMETERS.ENV_ID}=environment-id` +
+        `&${URI_CONSTANTS.PARAMETERS.ORG_URL}=${encodeURIComponent(rawOrgUrl)}` +
+        `&${URI_CONSTANTS.PARAMETERS.TENANT_ID}=${rawTenantId}` +
+        `&${URI_CONSTANTS.PARAMETERS.WEBSITE_ID}=website-id` +
+        `&${URI_CONSTANTS.PARAMETERS.REFERRER_SESSION_ID}=correlation-id`
+    );
+
+    const detection: AgentHostDetectionResult[] = [
+        {
+            host: AgentHost.Copilot,
+            installed: true,
+            version: "1.0.0"
+        },
+        {
+            host: AgentHost.Claude,
+            installed: false
+        }
+    ];
+
+    const installEventNames = new Set<string>([
+        uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_PROMPTED,
+        uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_GUIDE_OPENED,
+        uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RECHECKED,
+        uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_RELOAD_REQUESTED,
+        uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_INSTALL_DISMISSED
+    ]);
+
+    const createHandler = (): AgenticCreateHandler =>
+        new AgenticCreateHandler({} as PacWrapper, store, dependencies);
+
+    const expectNoSensitiveTelemetry = (): void => {
+        for (const call of traceInfoStub.getCalls()) {
+            const properties = call.args[1] as Record<string, string>;
+            expect(properties).to.not.have.property("orgUrl");
+            expect(properties).to.not.have.property("tenantId");
+            expect(Object.values(properties)).to.not.include(rawOrgUrl);
+            expect(Object.values(properties)).to.not.include(rawTenantId);
+            expect(Object.values(properties)).to.not.include(selectedFolder.fsPath);
+        }
+    };
+
+    const expectNoInstallEventsFromHandler = (): void => {
+        const emittedNames = emitCreateFlowEventStub.getCalls().map(call => call.args[0] as string);
+        expect(emittedNames.some(eventName => installEventNames.has(eventName))).to.be.false;
+    };
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(AgenticCreateHandler, "isEnabled").returns(true);
+
+        traceInfoStub = sandbox.stub();
+        traceErrorStub = sandbox.stub();
+        sandbox.stub(oneDSLoggerWrapper, "getLogger").returns(
+            {
+                traceInfo: traceInfoStub,
+                traceError: traceErrorStub
+            } as unknown as ReturnType<typeof oneDSLoggerWrapper.getLogger>
+        );
+
+        runCreateFlowCommonStagesStub = sandbox.stub().resolves(selectedFolder);
+        sandbox.stub(
+            createFlowCommonStages,
+            "runCreateFlowCommonStages"
+        ).callsFake(runCreateFlowCommonStagesStub);
+        detectAgentHostStub = sandbox.stub();
+        detectAgentHostStub.withArgs(AgentHost.Copilot).resolves(detection[0]);
+        detectAgentHostStub.withArgs(AgentHost.Claude).resolves(detection[1]);
+        selectAgentHostStub = sandbox.stub().resolves({
+            host: AgentHost.Copilot,
+            installed: true
+        });
+        resolveAgentHostInstallationStub = sandbox.stub();
+        emitCreateFlowEventStub = sandbox.stub().callsFake(emitCreateFlowEvent);
+        storeUpdateStub = sandbox.stub().resolves();
+        store = {
+            get: () => undefined,
+            update: storeUpdateStub
+        };
+        dependencies = {
+            detectAgentHost: detectAgentHostStub,
+            selectAgentHost: selectAgentHostStub,
+            resolveAgentHostInstallation: resolveAgentHostInstallationStub,
+            emitCreateFlowEvent: emitCreateFlowEventStub
+        };
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("drops the flow when host selection is cancelled", async () => {
+        selectAgentHostStub.resolves(undefined);
+
+        await createHandler().handle(uri);
+
+        expect(detectAgentHostStub.callCount).to.equal(2);
+        expect(detectAgentHostStub.firstCall.calledWithExactly(AgentHost.Copilot)).to.be.true;
+        expect(detectAgentHostStub.secondCall.calledWithExactly(AgentHost.Claude)).to.be.true;
+        expect(selectAgentHostStub.calledOnceWithExactly(detection)).to.be.true;
+        expect(emitCreateFlowEventStub.calledOnce).to.be.true;
+        expect(emitCreateFlowEventStub.firstCall.args).to.include(
+            uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED
+        );
+        expect(emitCreateFlowEventStub.firstCall.args[3]).to.deep.equal({
+            reason: "hostSelectionCancelled"
+        });
+        expect(resolveAgentHostInstallationStub.notCalled).to.be.true;
+        expect(storeUpdateStub.notCalled).to.be.true;
+        expectNoInstallEventsFromHandler();
+        expectNoSensitiveTelemetry();
+    });
+
+    it("emits host selected once and stops at the G3 seam for an installed host", async () => {
+        await createHandler().handle(uri);
+
+        expect(emitCreateFlowEventStub.calledOnce).to.be.true;
+        expect(emitCreateFlowEventStub.firstCall.args[0]).to.equal(
+            uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_SELECTED
+        );
+        expect(emitCreateFlowEventStub.firstCall.args[3]).to.deep.equal({
+            host: AgentHost.Copilot,
+            installed: "true"
+        });
+        expect(resolveAgentHostInstallationStub.notCalled).to.be.true;
+        expect(storeUpdateStub.notCalled).to.be.true;
+        expectNoInstallEventsFromHandler();
+        expectNoSensitiveTelemetry();
+    });
+
+    const resolutions: AgentHostInstallResolution[] = [
+        {
+            status: "resolved",
+            host: AgentHost.Claude
+        },
+        {
+            status: "reloading"
+        },
+        {
+            status: "dismissed"
+        }
+    ];
+
+    for (const resolution of resolutions) {
+        it(`handles a not-installed host when installation resolution is ${resolution.status}`, async () => {
+            selectAgentHostStub.resolves({
+                host: AgentHost.Claude,
+                installed: false
+            });
+            resolveAgentHostInstallationStub.resolves(resolution);
+
+            await createHandler().handle(uri);
+
+            expect(emitCreateFlowEventStub.calledOnce).to.be.true;
+            expect(emitCreateFlowEventStub.firstCall.args[0]).to.equal(
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_SELECTED
+            );
+            expect(emitCreateFlowEventStub.firstCall.args[3]).to.deep.equal({
+                host: AgentHost.Claude,
+                installed: "false"
+            });
+            expect(resolveAgentHostInstallationStub.calledOnce).to.be.true;
+            expect(resolveAgentHostInstallationStub.firstCall.args[0]).to.equal(AgentHost.Claude);
+            expect(resolveAgentHostInstallationStub.firstCall.args[1]).to.equal("Claude Code");
+            expect(resolveAgentHostInstallationStub.firstCall.args[3]).to.include.keys(
+                "strings",
+                "showInformationMessage",
+                "showWarningMessage",
+                "openExternal",
+                "writeResumeMarker",
+                "reloadWindow"
+            );
+            expect(storeUpdateStub.notCalled).to.be.true;
+            expectNoInstallEventsFromHandler();
+            expectNoSensitiveTelemetry();
+            expect(traceErrorStub.notCalled).to.be.true;
+        });
+    }
+});

--- a/src/client/uriHandler/handlers/agenticCreateHandler.ts
+++ b/src/client/uriHandler/handlers/agenticCreateHandler.ts
@@ -13,6 +13,45 @@ import { buildCreateFlowTelemetry, parseCreateFlowParameters } from "./createFlo
 import { emitCreateFlowError, emitCreateFlowEvent } from "../telemetry/createFlowTelemetry";
 import { runCreateFlowCommonStages } from "./createFlowCommonStages";
 import { isSupportedContractVersion } from "./createFlowContractVersion";
+import { AgentHost, detectAgentHost } from "../utils/detectAgentHost";
+import { selectAgentHost } from "../utils/selectAgentHost";
+import {
+    AgentHostInstallationStrings,
+    resolveAgentHostInstallation
+} from "../utils/resolveAgentHostInstallation";
+import { ResumeMarkerStore, writeResumeMarker } from "../utils/resumeMarker";
+import { URI_HANDLER_STRINGS } from "../constants/uriStrings";
+
+/**
+ * Injectable dependencies used by the agent-specific create-flow tail.
+ */
+export interface AgenticCreateHandlerDependencies {
+    detectAgentHost: typeof detectAgentHost;
+    selectAgentHost: typeof selectAgentHost;
+    resolveAgentHostInstallation: typeof resolveAgentHostInstallation;
+    emitCreateFlowEvent: typeof emitCreateFlowEvent;
+}
+
+const DEFAULT_DEPENDENCIES: AgenticCreateHandlerDependencies = {
+    detectAgentHost,
+    selectAgentHost,
+    resolveAgentHostInstallation,
+    emitCreateFlowEvent
+};
+
+const AGENT_HOST_DISPLAY_NAMES: Record<AgentHost, string> = {
+    [AgentHost.Copilot]: URI_HANDLER_STRINGS.AGENT_HOSTS.COPILOT,
+    [AgentHost.Claude]: URI_HANDLER_STRINGS.AGENT_HOSTS.CLAUDE
+};
+
+const AGENT_HOST_INSTALLATION_STRINGS: AgentHostInstallationStrings = {
+    installGuidancePrompt: URI_HANDLER_STRINGS.PROMPTS.AGENT_HOST_INSTALL_GUIDANCE,
+    viewInstallationGuide: URI_HANDLER_STRINGS.BUTTONS.VIEW_INSTALLATION_GUIDE,
+    checkAgain: URI_HANDLER_STRINGS.BUTTONS.CHECK_AGAIN,
+    dismiss: URI_HANDLER_STRINGS.BUTTONS.DISMISS,
+    reloadWindow: URI_HANDLER_STRINGS.BUTTONS.RELOAD_WINDOW,
+    notNow: URI_HANDLER_STRINGS.BUTTONS.NOT_NOW
+};
 
 /**
  * Handles the `/agenticCreate` deep link launched from the Power Pages home page, which will
@@ -20,14 +59,22 @@ import { isSupportedContractVersion } from "./createFlowContractVersion";
  *
  * This is a dark, flag-gated scaffold. When {@link EnableAgenticCreateFromHome} is off (the
  * default) the handler is a no-op. When enabled it runs the shared authentication, environment,
- * and folder-selection stages. The actual agentic behavior (agent-host selection and Power Pages
- * plugin bootstrapping) is intentionally deferred to a follow-up change.
+ * and folder-selection stages, then resolves the selected agent host. Power Pages plugin
+ * bootstrapping is intentionally deferred to a follow-up change.
  */
 export class AgenticCreateHandler {
     private readonly pacWrapper: PacWrapper;
+    private readonly resumeMarkerStore?: ResumeMarkerStore;
+    private readonly dependencies: AgenticCreateHandlerDependencies;
 
-    constructor(pacWrapper: PacWrapper) {
+    constructor(
+        pacWrapper: PacWrapper,
+        resumeMarkerStore?: ResumeMarkerStore,
+        dependencies: AgenticCreateHandlerDependencies = DEFAULT_DEPENDENCIES
+    ) {
         this.pacWrapper = pacWrapper;
+        this.resumeMarkerStore = resumeMarkerStore;
+        this.dependencies = dependencies;
     }
 
     /**
@@ -85,7 +132,71 @@ export class AgenticCreateHandler {
                 return;
             }
 
-            // TODO (G2/G3 agent): Implement the channel-specific tail using folderUri.
+            // Legacy and isolated test callers can omit persistence; production registration supplies it.
+            const resumeMarkerStore = this.resumeMarkerStore;
+            if (!resumeMarkerStore) {
+                return;
+            }
+
+            const detection = await Promise.all([
+                this.dependencies.detectAgentHost(AgentHost.Copilot),
+                this.dependencies.detectAgentHost(AgentHost.Claude)
+            ]);
+            const selection = await this.dependencies.selectAgentHost(detection);
+            if (!selection) {
+                this.dependencies.emitCreateFlowEvent(
+                    uriHandlerTelemetryEventNames.URI_HANDLER_CREATE_FLOW_DROPPED,
+                    params,
+                    'agent',
+                    { reason: 'hostSelectionCancelled' }
+                );
+                return;
+            }
+
+            this.dependencies.emitCreateFlowEvent(
+                uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_HOST_SELECTED,
+                params,
+                'agent',
+                {
+                    host: selection.host,
+                    installed: String(selection.installed)
+                }
+            );
+
+            if (selection.installed) {
+                // TODO (G3 agent): plugin marketplace add -> install -> sample prompt for the selected host.
+                return;
+            }
+
+            const resolution = await this.dependencies.resolveAgentHostInstallation(
+                selection.host,
+                AGENT_HOST_DISPLAY_NAMES[selection.host],
+                params,
+                {
+                    strings: AGENT_HOST_INSTALLATION_STRINGS,
+                    showInformationMessage: (message, ...buttons) =>
+                        vscode.window.showInformationMessage(message, ...buttons),
+                    showWarningMessage: (message, ...buttons) =>
+                        vscode.window.showWarningMessage(message, ...buttons),
+                    openExternal: async (url) => {
+                        await vscode.env.openExternal(vscode.Uri.parse(url));
+                    },
+                    writeResumeMarker: (marker) =>
+                        writeResumeMarker(resumeMarkerStore, marker),
+                    reloadWindow: async () => {
+                        await vscode.commands.executeCommand('workbench.action.reloadWindow');
+                    }
+                }
+            );
+
+            switch (resolution.status) {
+                case 'resolved':
+                    // TODO (G3 agent): plugin marketplace add -> install -> sample prompt for the selected host.
+                    return;
+                case 'reloading':
+                case 'dismissed':
+                    return;
+            }
         } catch (error) {
             emitCreateFlowError(
                 uriHandlerTelemetryEventNames.URI_HANDLER_AGENTIC_CREATE_FAILED,

--- a/src/client/uriHandler/uriHandler.ts
+++ b/src/client/uriHandler/uriHandler.ts
@@ -13,14 +13,18 @@ import { UriHandlerUtils, UriParameters } from "./utils/uriHandlerUtils";
 import { AuthEnvironmentService } from "./utils/authEnvironment";
 import { AgenticCreateHandler } from "./handlers/agenticCreateHandler";
 import { PacCreateHandler } from "./handlers/pacCreateHandler";
+import { ResumeMarkerStore } from "./utils/resumeMarker";
 
 /**
  * Signature for a deep-link route handler. Each registered URI path maps to one handler.
  */
 type UriRouteHandler = (uri: vscode.Uri) => Promise<void>;
 
-export function RegisterUriHandler(pacWrapper: PacWrapper): vscode.Disposable {
-    const uriHandler = new UriHandler(pacWrapper);
+export function RegisterUriHandler(
+    pacWrapper: PacWrapper,
+    resumeMarkerStore?: ResumeMarkerStore
+): vscode.Disposable {
+    const uriHandler = new UriHandler(pacWrapper, resumeMarkerStore);
     return vscode.window.registerUriHandler(uriHandler);
 }
 
@@ -31,10 +35,10 @@ export class UriHandler implements vscode.UriHandler {
     private readonly agenticCreateHandler: AgenticCreateHandler;
     private readonly pacCreateHandler: PacCreateHandler;
 
-    constructor(pacWrapper: PacWrapper) {
+    constructor(pacWrapper: PacWrapper, resumeMarkerStore?: ResumeMarkerStore) {
         this.pacWrapper = pacWrapper;
         this.authEnvironmentService = new AuthEnvironmentService(pacWrapper);
-        this.agenticCreateHandler = new AgenticCreateHandler(pacWrapper);
+        this.agenticCreateHandler = new AgenticCreateHandler(pacWrapper, resumeMarkerStore);
         this.pacCreateHandler = new PacCreateHandler(pacWrapper);
         this.routes = this.buildRoutes();
     }


### PR DESCRIPTION
## Summary
- thread the resume-marker store from `PacTerminal` into `AgenticCreateHandler`
- resolve Copilot CLI / Claude Code after the shared auth, environment, and folder stages
- emit one host-selected event, reuse the existing drop event on picker cancellation, and delegate missing-host guidance to the merged utility
- stop installed/resolved paths at the G3 plugin bootstrap TODO

## Testing
- `node node_modules/gulp/bin/gulp.js lint`
- `npm run compile-tests`
- `npm test`
- `npm run build` (2 expected LiquidJS `module.createRequire` warnings)
- `npm run test-desktop-int` (934 passing)

## Dependency note
The not-installed -> reload path relies on GI-D's activation hook in #1665 to resume after VS Code reload. This slice is independently correct and testable, but #1665 should merge first.