### PR TITLE
Use title case for Power Pages Actions

### DIFF
--- a/loc/translations-export/vscode-powerplatform.xlf
+++ b/loc/translations-export/vscode-powerplatform.xlf
@@ -1876,10 +1876,10 @@ The second line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.
       <source xml:lang="en">Overview</source>
     </trans-unit>
     <trans-unit id="microsoft.powerplatform.pages.actionsHub.title">
-      <source xml:lang="en">POWER PAGES ACTIONS</source>
+      <source xml:lang="en">Power Pages Actions</source>
     </trans-unit>
     <trans-unit id="microsoft-powerplatform-portals.navigation-loop.powerPagesFileExplorer.title">
-      <source xml:lang="en">POWER PAGES ACTIONS</source>
+      <source xml:lang="en">Power Pages Actions</source>
     </trans-unit>
     <trans-unit id="power-platform-activitybar.title">
       <source xml:lang="en">Power Platform</source>

--- a/package.nls.json
+++ b/package.nls.json
@@ -90,9 +90,9 @@
       "The fifth line should be '[TRANSLATION HERE](command:powerplatform-walkthrough.saveConflict-learn-more).', keeping brackets and the text in the parentheses unmodified"
     ]
   },
-  "microsoft-powerplatform-portals.navigation-loop.powerPagesFileExplorer.title": "POWER PAGES ACTIONS",
+  "microsoft-powerplatform-portals.navigation-loop.powerPagesFileExplorer.title": "Power Pages Actions",
   "powerplatform.pages.previewSite.title": "Preview Site",
-  "microsoft.powerplatform.pages.actionsHub.title": "POWER PAGES ACTIONS",
+  "microsoft.powerplatform.pages.actionsHub.title": "Power Pages Actions",
   "microsoft.powerplatform.pages.actionsHub.refresh.title": "Refresh",
   "microsoft.powerplatform.pages.actionsHub.switchEnvironment.title": "Change Environment",
   "microsoft.powerplatform.pages.actionsHub.showEnvironmentDetails.title": "Show Environment Details",


### PR DESCRIPTION
Replace the all-uppercase `POWER PAGES ACTIONS` title with `Power Pages Actions` for both desktop and web views.
Regenerate the localization export to match the updated labels.

VS Code has launched a new Modern UI where by default the panel names are in Title case and our actions menu stands out in that case.